### PR TITLE
docs: add architecture diagrams and package inventory

### DIFF
--- a/packages/docs/docs-dev/architecture/audio-path.md
+++ b/packages/docs/docs-dev/architecture/audio-path.md
@@ -1,0 +1,21 @@
+# Audio Path and Scheduler
+
+The sequence below shows how audio events travel through the system.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant App
+    participant Scheduler
+    participant AudioEngine
+    participant Output
+
+    User->>App: Start playback
+    App->>Scheduler: Submit audio events
+    Scheduler->>AudioEngine: Dispatch events at precise times
+    AudioEngine->>Output: Render audio
+    loop Each audio frame
+        Scheduler->>AudioEngine: Provide next events
+        AudioEngine->>Output: Produce sound
+    end
+```

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -1,1 +1,37 @@
 # Architecture Overview
+
+The architecture of openDAW is described using the C4 model.
+
+## Context
+
+```mermaid
+C4Context
+    title openDAW Context Diagram
+    Person(user, "Musician", "Creates and edits audio projects")
+    System(system, "openDAW", "Web‑based digital audio workstation")
+    System_Ext(browser, "Web Browser", "Hosts the application")
+    System_Ext(files, "File System", "Stores project data")
+    Rel(user, system, "Uses")
+    Rel(system, browser, "Runs inside")
+    Rel(system, files, "Reads and writes projects")
+```
+
+## Containers
+
+```mermaid
+C4Container
+    title openDAW Container Diagram
+    Person(user, "Musician")
+    System_Boundary(opendaw, "openDAW") {
+        Container(app, "App", "Next.js/React", "User interface and orchestration")
+        Container(studio, "Studio", "Audio Engine", "Audio processing and scheduling")
+        Container(lib, "Lib", "Shared utilities", "Reusable logic")
+        Container(config, "Config", "Configuration", "Runtime and build settings")
+    }
+    System_Ext(browser, "Web Browser")
+    Rel(user, app, "Interacts with")
+    Rel(app, studio, "Controls")
+    Rel(app, lib, "Uses")
+    Rel(app, config, "Loads")
+    Rel(studio, browser, "Audio output")
+```

--- a/packages/docs/docs-dev/package-inventory.md
+++ b/packages/docs/docs-dev/package-inventory.md
@@ -1,0 +1,11 @@
+# Package Inventory
+
+A high level overview of the packages in this repository.
+
+| Package  | Responsibility                                                        |
+| -------- | --------------------------------------------------------------------- |
+| `app`    | User-facing applications. Includes the Studio and Headless apps.      |
+| `config` | Shared configuration such as ESLint and TypeScript settings.          |
+| `docs`   | Documentation site and developer guides.                              |
+| `lib`    | Reusable libraries for DSP, DOM helpers, runtime utilities, and more. |
+| `studio` | Core audio engine components, adapters, and scheduling modules.       |


### PR DESCRIPTION
## Summary
- expand architecture overview with C4 context and container diagrams
- document package responsibilities in a new package inventory page
- add audio path and scheduler sequence diagram

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/lib-jsx#lint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68ae74c9c3d48321a39cc00c55b5a4e8