### PR TITLE
docs: expand user workflows

### DIFF
--- a/packages/docs/docs-user/workflows/automation-modulation.md
+++ b/packages/docs/docs-user/workflows/automation-modulation.md
@@ -1,0 +1,13 @@
+# Automation and Modulation Workflow
+
+Control parameters over time for dynamic mixes and expressive sound design.
+
+1. **Choose a target.** Click a track or device parameter you want to change automatically.
+2. **Create an automation lane.** Press `A` or use the context menu to reveal automation for the track.
+3. **Draw automation points.** Click to add nodes and drag to shape the curve across the timeline.
+4. **Add a modulator (optional).** Insert an LFO or envelope in the device chain to modulate parameters continuously.
+5. **Map the modulator.** Use the device's mapping controls to connect the LFO/envelope to the desired knob or slider.
+6. **Adjust depth and rate.** Tune how strongly and how fast the modulation affects the parameter.
+7. **Playback and refine.** Hit play and tweak points or settings until the movement fits the track.
+
+Automation captures precise changes, while modulators add evolving motion—combine both for engaging mixes.

--- a/packages/docs/docs-user/workflows/beat.md
+++ b/packages/docs/docs-user/workflows/beat.md
@@ -1,1 +1,13 @@
 # Beat Workflow
+
+Follow these steps to lay down a simple drum beat.
+
+1. **Create a new project.** Open the studio and choose _New Project_ from the start screen.
+2. **Add a drum track.** Click the `+` button in the track header and pick the built‑in drum instrument.
+3. **Open the note editor.** Double‑click the empty clip on the drum track to show the piano roll.
+4. **Program a pattern.** Draw kicks on beat 1 and 3, snares on 2 and 4, and eighth‑note hi‑hats across the bar.
+5. **Loop and audition.** Set the loop markers around the bar and press play to hear the groove.
+6. **Tweak the tempo and swing.** Use the transport controls to adjust BPM or enable shuffle for feel.
+7. **Extend the arrangement.** Duplicate the clip or record more variations to build a longer beat.
+
+This workflow gets a basic rhythm going so you can start layering basslines, melodies, and effects.

--- a/packages/docs/docs-user/workflows/export-share.md
+++ b/packages/docs/docs-user/workflows/export-share.md
@@ -1,0 +1,13 @@
+# Export and Share Workflow
+
+Share your music outside of openDAW by rendering audio or packaging the project.
+
+1. **Finalize your mix.** Balance tracks and stop playback where you want the export to end.
+2. **Open the export dialog.** From the main menu choose _File → Export_.
+3. **Pick an option.** Select _Audio Mixdown_ to render a WAV/MP3 or _Project Bundle_ to create an `.odb` file.
+4. **Set the range.** Export the entire song or define start and end markers for a section.
+5. **Confirm quality settings.** Choose sample rate and format if exporting audio.
+6. **Start the export.** Click _Export_ and wait for processing to complete.
+7. **Download or share.** Save the resulting file to your computer or send the bundle to a collaborator.
+
+Use this workflow whenever you need to back up a project or deliver a finished track.

--- a/packages/docs/docs-user/workflows/record-and-fx.md
+++ b/packages/docs/docs-user/workflows/record-and-fx.md
@@ -1,1 +1,15 @@
 # Record and FX Workflow
+
+Capture audio and shape it with effects.
+
+1. **Set up your input.** Connect a microphone or instrument and allow browser audio permissions.
+2. **Create an audio track.** Use the `+` button to add a track configured for audio recording.
+3. **Arm the track.** Click the record icon on the track header so it lights up.
+4. **Check levels.** Speak or play to confirm the meter moves without clipping.
+5. **Start recording.** Press the main record button in the transport and perform your part.
+6. **Stop when finished.** Hit stop to place the recorded clip on the timeline.
+7. **Add an effect.** In the device panel for the track, choose an effect such as delay or reverb.
+8. **Tweak parameters.** Adjust knobs or sliders to taste while listening to playback.
+9. **Commit the take.** Rename the clip or consolidate it, then save the project.
+
+With these steps you can record vocals or instruments and immediately enhance them with built‑in effects.

--- a/packages/docs/sidebarsUser.js
+++ b/packages/docs/sidebarsUser.js
@@ -1,3 +1,15 @@
 module.exports = {
-  userSidebar: [{ type: 'doc', id: 'intro' }],
+  userSidebar: [
+    { type: "doc", id: "intro" },
+    {
+      type: "category",
+      label: "Workflows",
+      items: [
+        "workflows/beat",
+        "workflows/record-and-fx",
+        "workflows/export-share",
+        "workflows/automation-modulation",
+      ],
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- flesh out beat and record/FX workflow guides
- document export/share and automation/modulation workflows
- expose workflows in user docs sidebar

## Testing
- `npm test`
- `npm run lint` *(fails: Use "@ts-expect-error" instead of "@ts-ignore" in packages/app/headless/src/ExampleProject.ts and more)*

------
https://chatgpt.com/codex/tasks/task_b_68ae74ce894c83218606ce8c6bba3504