### PR TITLE
docs: expand latency info and document storage model

### DIFF
--- a/packages/docs/docs-learn/how-it-works/latency-and-buffers.md
+++ b/packages/docs/docs-learn/how-it-works/latency-and-buffers.md
@@ -1,1 +1,30 @@
 # Latency and Buffers
+
+Audio in the browser is processed in small chunks called buffers. Each buffer
+contains a fixed number of samples that the audio hardware consumes at regular
+intervals. The time between these hardware callbacks determines the base
+latency of the system.
+
+## Buffer size and latency
+
+Smaller buffers reduce latency because the audio thread delivers audio to the
+device more frequently. However, less time is available for the engine to fill
+each buffer. If the system cannot compute the next buffer in time the user hears
+drop-outs or glitches. Larger buffers provide more safety but increase the delay
+between user interaction and audible result.
+
+## Scheduling
+
+openDAW schedules audio work ahead of time to keep the audio thread supplied
+with buffers. When the buffer size is 128 samples at 48 kHz, for example, the
+engine has roughly 2.7 ms to render the next block of audio. Timers and events
+are aligned to this cadence so that sequencing remains tight across different
+devices.
+
+## Device round-trip
+
+Latency is cumulative. MIDI or user interface events travel through the audio
+graph, are queued into buffers, and finally emerge from the speakers after the
+hardware has processed them. Monitoring external signals adds another trip
+through the converters. Understanding this round-trip time is essential when
+recording or synchronising with other gear.

--- a/packages/docs/docs-learn/how-it-works/storage-model.md
+++ b/packages/docs/docs-learn/how-it-works/storage-model.md
@@ -1,0 +1,20 @@
+# Storage Model
+
+openDAW stores project data inside the browser using the [Origin Private File
+System (OPFS)](https://developer.mozilla.org/en-US/docs/Web/API/Origin_Private_File_System).
+OPFS provides a sandboxed, persistent file system that is not visible to the
+user's operating system. It allows the application to save audio files and
+project state without requiring a network connection.
+
+## Export
+
+Projects can be exported at any time. Exporting creates a portable archive that
+contains the project JSON along with referenced audio assets. The archive can be
+downloaded to the local disk or uploaded to another service for sharing.
+
+## Backup
+
+To avoid data loss, openDAW periodically creates a backup of the OPFS data. The
+backup can be written to IndexedDB or synchronised with a backend service when
+the user is online. Restoring from a backup repopulates the OPFS directory so
+that work can continue even after clearing browser storage.


### PR DESCRIPTION
## Summary
- expand latency and buffers guide with buffer size trade-offs and scheduling notes
- add storage model page covering OPFS, export, and backup

## Testing
- `npm test`
- `npm run lint` *(fails: command @opendaw/app-headless#lint exited with 1)*

------
https://chatgpt.com/codex/tasks/task_b_68ae74d0e62c83219ebebeddf0d8fc04