### PR TITLE
docs: add production lesson guides

### DIFF
--- a/docs-learn/lessons/arranging-and-song-structure.md
+++ b/docs-learn/lessons/arranging-and-song-structure.md
@@ -1,0 +1,15 @@
+# Arranging & Song Structure
+
+Arranging organizes musical ideas into a complete song. openDAW's timeline helps you build sections and move parts around.
+
+## Hands-on: Build an Arrangement
+
+1. **Sketch a loop** – Create a short loop for drums, bass or chords in the timeline.
+2. **Duplicate to extend** – Select the loop and use copy/paste or drag to duplicate it across the timeline.
+3. **Define sections** – Mark out intro, verse and chorus by arranging clips or adding empty space.
+4. **Add variation** – Modify MIDI notes, swap instrument presets or mute elements to create contrast between sections.
+5. **Use markers** – Place timeline markers to label each part of the song for easy navigation.
+6. **Create transitions** – Add fills, risers or automation to lead the listener between sections.
+7. **Finalize the structure** – Trim the project end point and export your song when satisfied.
+
+By iterating through these steps you can transform simple loops into a structured piece of music.

--- a/docs-learn/lessons/effects.md
+++ b/docs-learn/lessons/effects.md
@@ -1,0 +1,15 @@
+# Effects
+
+Effects process audio to shape tone and space. openDAW lets you stack effects or route tracks to shared processors.
+
+## Hands-on: Build an Effect Chain
+
+1. **Prepare a sound source** – Use an existing track or create a new instrument track with a simple pattern.
+2. **Open the Device Panel** – Select the track and open its Device Panel to manage processors.
+3. **Insert an effect** – Click _Add Device_ and choose an effect like _Delay_ or _Reverb_. The effect appears after the instrument.
+4. **Tweak parameters** – Adjust sliders or knobs on the effect to hear how the sound changes.
+5. **Add another effect** – Insert an _EQ_ or _Compressor_ after the first effect to build a chain.
+6. **Use send effects** – Create a new _Aux_ track with a _Reverb_ and use each track's _Send_ knob to route audio to it.
+7. **Save your chain** – Once you like the sound, save the track or effect chain as a preset for reuse.
+
+Experimenting with different effect orders and settings reveals how signal processing shapes a mix.

--- a/docs-learn/lessons/midi-and-synthesis.md
+++ b/docs-learn/lessons/midi-and-synthesis.md
@@ -1,0 +1,14 @@
+# MIDI & Synthesis
+
+MIDI describes musical events, while synthesis turns those events into sound. In openDAW you can explore both concepts interactively.
+
+## Hands-on: Program a Synth Melody
+
+1. **Create a MIDI track** – In the track list choose _Add Track → Instrument_. An empty instrument track appears.
+2. **Add a synthesizer** – Open the Device Panel for the new track and load a built‑in synth such as _Simple Synth_.
+3. **Draw a MIDI clip** – In the timeline drag to create a region, then double‑click it to open the piano roll.
+4. **Enter notes** – Click within the piano roll to place a few notes. Press _Space_ to hear them.
+5. **Shape the sound** – Adjust oscillator waveforms, filter cutoff and envelope controls in the synth UI. Listen to how the tone changes.
+6. **Experiment further** – Change note lengths, velocities or instrument presets to explore how MIDI data affects synthesis.
+
+By sending MIDI messages to a synth and tweaking its parameters you build an intuitive understanding of how electronic instruments create sound.

--- a/docs-learn/lessons/mixing-and-panning.md
+++ b/docs-learn/lessons/mixing-and-panning.md
@@ -1,0 +1,15 @@
+# Mixing & Panning
+
+Mixing balances levels and places sounds within the stereo field. openDAW's mixer provides straightforward controls for both.
+
+## Hands-on: Balance a Simple Mix
+
+1. **Load a multitrack project** – Open a project with at least a few tracks or duplicate an existing one.
+2. **Open the Mixer** – Use the mixer view to see faders and pan knobs for every track.
+3. **Set initial levels** – Play the song and move each track's fader so that no channel or the master meter clips.
+4. **Pan tracks** – Turn the pan knob left or right to give instruments their own space. Try panning drums slightly left and guitars right.
+5. **Create a sense of space** – Use send effects like reverb or delay to add depth while keeping levels under control.
+6. **Check the mix** – Toggle solo and mute buttons to focus on individual parts, ensuring each element is clear.
+7. **Compare on headphones and speakers** – Listening on different systems helps you judge balance and stereo placement.
+
+These basic steps demonstrate how thoughtful level and pan adjustments can create a cohesive stereo mix.


### PR DESCRIPTION
## Summary
- add MIDI & synthesis lesson with steps for programming a synth melody
- add effects lesson demonstrating building chains and sends
- add mixing & panning guide for balancing a simple mix
- add arranging & song structure lesson for building complete songs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae74d0f7048321805105b2cf59c2ba