### PR TITLE
docs: add style guide and roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,21 @@
+# openDAW Roadmap
+
+## Near term
+
+- Publish core documentation set and initial diagrams.
+- Define documentation ownership and review process.
+- Run continuous integration for tests and linting.
+
+## Mid term
+
+- Launch internationalization workflow for community translations.
+- Integrate accessibility tooling and audits.
+- Version documentation alongside the first stable release.
+
+## Long term
+
+- Support additional languages and downloadable offline docs.
+- Provide real-time collaborative editing for documentation.
+- Evolve roadmap based on community feedback.
+
+Roadmap items are tentative and may change as the project evolves.

--- a/docs/i18n-accessibility.md
+++ b/docs/i18n-accessibility.md
@@ -1,0 +1,16 @@
+# Internationalization and Accessibility Plan
+
+## Internationalization
+
+- Use Docusaurus' i18n system with English as the source language.
+- Manage translations through a community platform such as Crowdin or Weblate.
+- Store translated Markdown and JSON files under `i18n/<locale>`.
+- Extract new strings at each release and notify translators.
+
+## Accessibility baseline
+
+- Target **WCAG 2.1 AA** compliance for all documentation pages.
+- Ensure keyboard navigation and focus visibility across interactive elements.
+- Provide descriptive alt text, ARIA labels, and semantic HTML.
+- Maintain sufficient color contrast and avoid conveying information by color alone.
+- Run automated accessibility checks (e.g., axe-core) as part of CI.

--- a/docs/ownership-map.md
+++ b/docs/ownership-map.md
@@ -1,0 +1,11 @@
+# Documentation Ownership Map
+
+Each page lists a primary maintainer responsible for reviews and updates.
+
+| Document                   | Maintainer     |
+| -------------------------- | -------------- |
+| README.md                  | @andremichelle |
+| ROADMAP.md                 | @andremichelle |
+| docs/documentation-plan.md | @polarity      |
+| docs/style-guide.md        | @docs-team     |
+| docs/i18n-accessibility.md | @docs-team     |

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,29 @@
+# Documentation Style Guide
+
+This guide establishes conventions for writing and maintaining openDAW documentation.
+
+## Voice and tone
+
+- Use friendly, inclusive language.
+- Write in present tense and active voice.
+- Prefer short sentences and simple words.
+
+## Formatting
+
+- Structure pages with incremental Markdown headings.
+- Use sentence case for headings.
+- Wrap code and commands in backticks.
+- Provide alt text for all images.
+- Link to other docs using relative paths.
+
+## Review cadence
+
+- Pages owned by active teams are reviewed **monthly**.
+- The entire documentation set is audited **quarterly** for accuracy and broken links.
+- Page owners listed in `ownership-map.md` drive reviews and updates.
+
+## Versioning strategy
+
+- Documentation follows the project’s release tags.
+- `main` reflects work for the next release; stable versions are tagged and stored under `versioned_docs/`.
+- Deprecated pages are archived rather than deleted to preserve history.


### PR DESCRIPTION
## Summary
- add documentation style guide with review cadence and versioning strategy
- document internationalization approach and accessibility baseline
- introduce project roadmap and ownership map for doc pages

## Testing
- `npm test`
- `npm run lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_68ae74d398cc83218e4fe184366e92b2