### PR TITLE
docs: add component diagram

### DIFF
--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -35,3 +35,23 @@ C4Container
     Rel(app, config, "Loads")
     Rel(studio, browser, "Audio output")
 ```
+
+## Components
+
+```mermaid
+C4Component
+    title openDAW Component Diagram
+    Component(app, "App", "Next.js/React", "User interface and orchestration")
+    Component(studio, "Studio", "Audio Engine", "Audio processing and scheduling")
+    Component(lib, "Lib", "Shared utilities", "Reusable logic")
+    Component(config, "Config", "Configuration", "Runtime and build settings")
+    Rel(app, studio, "Controls")
+    Rel(app, lib, "Uses")
+    Rel(app, config, "Loads")
+    Rel(studio, lib, "Uses")
+```
+
+- **App** – Provides the user interface and coordinates system interactions.
+- **Studio** – Handles audio processing, scheduling, and engine control.
+- **Lib** – Supplies shared utilities and reusable logic across modules.
+- **Config** – Delivers runtime and build settings consumed by other components.


### PR DESCRIPTION
## Summary
- document component-level interactions between app, studio, lib and config
- describe each component's role in architecture overview

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/lib-dawproject#lint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68ae85f7d6708321b31cb4d6f3ecc4e4