### PR TITLE
docs: describe scheduler states

### DIFF
--- a/packages/docs/docs-dev/architecture/audio-path.md
+++ b/packages/docs/docs-dev/architecture/audio-path.md
@@ -19,3 +19,18 @@ sequenceDiagram
         AudioEngine->>Output: Produce sound
     end
 ```
+
+## Scheduler States
+
+The scheduler manages the lifecycle of events as they move from being submitted to the moment they are processed.
+
+```mermaid
+stateDiagram-v2
+    [*] --> queued
+    queued --> running: dispatched to engine
+    running --> completed: finished playback
+    completed --> [*]
+```
+
+Events enter the **queued** state when the app submits them to the scheduler. At their scheduled time they move to the **running** state as the scheduler dispatches them to the audio engine. Once an event has been processed by the audio engine it reaches the **completed** state, leaving the scheduler's active set.
+


### PR DESCRIPTION
## Summary
- document scheduler lifecycle with mermaid state diagram

## Testing
- `npm test`
- `npm run lint` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_68ae85f912ec8321849bf5ade59d93ca