### PR TITLE
docs: expand user glossary

### DIFF
--- a/packages/docs/docs-user/glossary.md
+++ b/packages/docs/docs-user/glossary.md
@@ -1,1 +1,25 @@
 # Glossary
+
+## Automation
+
+Control parameters over time via curves or modulators. Learn how in the [Automation and Modulation Workflow](workflows/automation-modulation.md).
+
+## Clip
+
+A piece of recorded or arranged audio or MIDI placed on the timeline. Manage clips within [Tracks](features/tracks.md).
+
+## MIDI
+
+Musical Instrument Digital Interface data for notes, velocities, and control. Edit MIDI in the [Piano Roll](features/piano-roll.md).
+
+## Mixer
+
+Console for balancing levels and routing between tracks. See the [Mixer](features/mixer.md).
+
+## Plugin
+
+An instrument or effect unit inserted on a track. Read more in [Devices and Plugins](features/devices-and-plugins.md).
+
+## Track
+
+A lane in the arrangement that holds clips and devices. Learn more in [Tracks](features/tracks.md).


### PR DESCRIPTION
## Summary
- add alphabetical entries for Automation, Clip, MIDI, Mixer, Plugin and Track

## Testing
- `npx -y turbo run test --concurrency=1` *(fails: tsconfig.json not found for @opendaw/studio-enums)*
- `npx -y turbo run lint` *(fails: eslint config missing for @opendaw/studio-adapters)*

------
https://chatgpt.com/codex/tasks/task_b_68ae860762d883219a8a64f5a8f1c223