### PR TITLE
docs(midi): add TSDoc and usage examples

### DIFF
--- a/packages/lib/midi/README.md
+++ b/packages/lib/midi/README.md
@@ -2,4 +2,48 @@ _This package is part of the openDAW SDK_
 
 # @opendaw/lib-midi
 
-MIDI library
+Utilities for reading, writing and interpreting MIDI data.
+
+## Decoding a MIDI file
+
+```ts
+import { MidiFile } from "@opendaw/lib-midi";
+
+const response = await fetch("song.mid");
+const buffer = await response.arrayBuffer();
+const midi = MidiFile.decoder(buffer).decode();
+console.log(midi.tracks.length);
+```
+
+## Encoding a MIDI file
+
+```ts
+import {
+  MidiFile,
+  MidiTrack,
+  ControlEvent,
+  ControlType,
+} from "@opendaw/lib-midi";
+
+const track = MidiTrack.createEmpty();
+track.controlEvents.add(0, new ControlEvent(0, ControlType.NOTE_ON, 60, 127));
+track.controlEvents.add(0, new ControlEvent(480, ControlType.NOTE_OFF, 60, 0));
+
+const output = MidiFile.encoder().addTrack(track).encode();
+// write output.toUint8Array() to disk
+```
+
+## Integrating with DSP
+
+```ts
+import { MidiData } from "@opendaw/lib-midi";
+import { BandLimitedOscillator, Waveform } from "@opendaw/lib-dsp";
+
+const message = MidiData.noteOn(0, 69, 100);
+if (MidiData.isNoteOn(message)) {
+  const freq = 440 * Math.pow(2, (MidiData.readPitch(message) - 69) / 12);
+  const osc = new BandLimitedOscillator();
+  const buffer = new Float32Array(128);
+  osc.generate(buffer, freq / 44100, Waveform.sine, 0, buffer.length);
+}
+```

--- a/packages/lib/midi/src/Channel.ts
+++ b/packages/lib/midi/src/Channel.ts
@@ -1,3 +1,6 @@
-import {byte} from "@opendaw/lib-std"
+import { byte } from "@opendaw/lib-std";
 
-export type Channel = byte
+/**
+ * MIDI channel number in the range 0-15.
+ */
+export type Channel = byte;

--- a/packages/lib/midi/src/Chunk.ts
+++ b/packages/lib/midi/src/Chunk.ts
@@ -1,1 +1,7 @@
-export const enum Chunk {MTHD = 0x4d546864, MTRK = 0x4d54726b}
+/**
+ * MIDI chunk identifiers used in Standard MIDI Files.
+ */
+export const enum Chunk {
+  MTHD = 0x4d546864,
+  MTRK = 0x4d54726b,
+}

--- a/packages/lib/midi/src/ControlEvent.ts
+++ b/packages/lib/midi/src/ControlEvent.ts
@@ -1,67 +1,101 @@
-import {byte, Comparator, int, safeExecute} from "@opendaw/lib-std"
-import {Event} from "./Event"
-import {ControlType} from "./ControlType"
-import {ControlEventVisitor} from "./ControlEventVisitor"
-import {MidiFileDecoder} from "./MidiFileDecoder"
+import { byte, Comparator, int, safeExecute } from "@opendaw/lib-std";
+import { Event } from "./Event";
+import { ControlType } from "./ControlType";
+import { ControlEventVisitor } from "./ControlEventVisitor";
+import { MidiFileDecoder } from "./MidiFileDecoder";
 
+/**
+ * MIDI channel event such as note on/off, controllers or pitch bend.
+ */
 export class ControlEvent implements Event<ControlType> {
-    static readonly Comparator: Comparator<ControlEvent> = (a, b) => a.ticks - b.ticks
+  /** Comparator for sorting events by tick */
+  static readonly Comparator: Comparator<ControlEvent> = (a, b) =>
+    a.ticks - b.ticks;
 
-    constructor(readonly ticks: int, readonly type: ControlType, readonly param0: byte, readonly param1: byte) {}
+  constructor(
+    readonly ticks: int,
+    readonly type: ControlType,
+    readonly param0: byte,
+    readonly param1: byte,
+  ) {}
 
-    static decode(decoder: MidiFileDecoder, type: int, ticks: int): ControlEvent | null {
-        switch (type) {
-            case ControlType.NOTE_ON:
-            case ControlType.NOTE_OFF:
-            case ControlType.CONTROLLER:
-            case ControlType.PITCH_BEND:
-            case ControlType.NOTE_AFTER_TOUCH:
-                return new ControlEvent(ticks, type, decoder.readByte(), decoder.readByte())
-            case ControlType.PROGRAM_CHANGE:
-            case ControlType.CHANNEL_AFTER_TOUCH:
-                return new ControlEvent(ticks, type, decoder.readByte(), 0)
-        }
-        {
-            // else ignore the message
-            let c: int
-            do {
-                c = decoder.readByte() & 0xff
-            } while (c < 0x80)
-            decoder.skip(-1)
-        }
-        return null
+  /**
+   * Decode a control event from the stream if supported.
+   * @param decoder MIDI file decoder providing the bytes
+   * @param type status byte high nibble
+   * @param ticks absolute tick position
+   */
+  static decode(
+    decoder: MidiFileDecoder,
+    type: int,
+    ticks: int,
+  ): ControlEvent | null {
+    switch (type) {
+      case ControlType.NOTE_ON:
+      case ControlType.NOTE_OFF:
+      case ControlType.CONTROLLER:
+      case ControlType.PITCH_BEND:
+      case ControlType.NOTE_AFTER_TOUCH:
+        return new ControlEvent(
+          ticks,
+          type,
+          decoder.readByte(),
+          decoder.readByte(),
+        );
+      case ControlType.PROGRAM_CHANGE:
+      case ControlType.CHANNEL_AFTER_TOUCH:
+        return new ControlEvent(ticks, type, decoder.readByte(), 0);
     }
+    {
+      // else ignore the message
+      let c: int;
+      do {
+        c = decoder.readByte() & 0xff;
+      } while (c < 0x80);
+      decoder.skip(-1);
+    }
+    return null;
+  }
 
-    accept(visitor: ControlEventVisitor): void {
-        switch (this.type) {
-            case ControlType.NOTE_ON: {
-                if (0 === this.param1) {
-                    safeExecute(visitor.noteOff, this.param0)
-                } else {
-                    safeExecute(visitor.noteOn, this.param0, this.param1 / 127.0)
-                }
-                break
-            }
-            case ControlType.NOTE_OFF: {
-                safeExecute(visitor.noteOff, this.param0)
-                break
-            }
-            case ControlType.PITCH_BEND: {
-                const p1 = this.param0 & 0x7f
-                const p2 = this.param1 & 0x7f
-                const value = p1 | (p2 << 7)
-                safeExecute(visitor.pitchBend, 8192 >= value ? value / 8192.0 - 1.0 : (value - 8191) / 8192.0)
-                break
-            }
-            case ControlType.CONTROLLER: {
-                safeExecute(visitor.controller, this.param0, this.param1 / 127.0)
-                break
-            }
-            default: {break}
+  /**
+   * Apply the visitor callback for this event type.
+   */
+  accept(visitor: ControlEventVisitor): void {
+    switch (this.type) {
+      case ControlType.NOTE_ON: {
+        if (0 === this.param1) {
+          safeExecute(visitor.noteOff, this.param0);
+        } else {
+          safeExecute(visitor.noteOn, this.param0, this.param1 / 127.0);
         }
+        break;
+      }
+      case ControlType.NOTE_OFF: {
+        safeExecute(visitor.noteOff, this.param0);
+        break;
+      }
+      case ControlType.PITCH_BEND: {
+        const p1 = this.param0 & 0x7f;
+        const p2 = this.param1 & 0x7f;
+        const value = p1 | (p2 << 7);
+        safeExecute(
+          visitor.pitchBend,
+          8192 >= value ? value / 8192.0 - 1.0 : (value - 8191) / 8192.0,
+        );
+        break;
+      }
+      case ControlType.CONTROLLER: {
+        safeExecute(visitor.controller, this.param0, this.param1 / 127.0);
+        break;
+      }
+      default: {
+        break;
+      }
     }
+  }
 
-    toString(): string {
-        return `ControlEvent{ticks: ${this.ticks}, type: ${this.type}, param0: ${this.param0}, param1: ${this.param1}}`
-    }
+  /** String representation for debugging. */
+  toString(): string {
+    return `ControlEvent{ticks: ${this.ticks}, type: ${this.type}, param0: ${this.param0}, param1: ${this.param1}}`;
+  }
 }

--- a/packages/lib/midi/src/ControlEventVisitor.ts
+++ b/packages/lib/midi/src/ControlEventVisitor.ts
@@ -1,8 +1,15 @@
-import {byte} from "@opendaw/lib-std"
+import { byte } from "@opendaw/lib-std";
 
+/**
+ * Visitor interface for handling decoded {@link ControlEvent} instances.
+ */
 export interface ControlEventVisitor {
-    noteOn?(note: byte, velocity: number): void
-    noteOff?(note: byte): void
-    pitchBend?(delta: number): void
-    controller?(id: byte, value: number): void
+  /** Called for a note on message */
+  noteOn?(note: byte, velocity: number): void;
+  /** Called for a note off message */
+  noteOff?(note: byte): void;
+  /** Called for pitch bend messages with value in -1..1 */
+  pitchBend?(delta: number): void;
+  /** Called for controller changes with normalized value */
+  controller?(id: byte, value: number): void;
 }

--- a/packages/lib/midi/src/ControlType.ts
+++ b/packages/lib/midi/src/ControlType.ts
@@ -1,9 +1,20 @@
+/**
+ * Enumeration of MIDI channel voice message types.
+ * The values correspond to the high nibble of a MIDI status byte.
+ */
 export enum ControlType {
-    NOTE_ON = 0x90,
-    NOTE_OFF = 0x80,
-    NOTE_AFTER_TOUCH = 0xa0,
-    CONTROLLER = 0xb0,
-    PROGRAM_CHANGE = 0xc0,
-    CHANNEL_AFTER_TOUCH = 0xd0,
-    PITCH_BEND = 0xe0,
+  /** Note on message */
+  NOTE_ON = 0x90,
+  /** Note off message */
+  NOTE_OFF = 0x80,
+  /** Polyphonic after touch */
+  NOTE_AFTER_TOUCH = 0xa0,
+  /** Continuous controller change */
+  CONTROLLER = 0xb0,
+  /** Program change */
+  PROGRAM_CHANGE = 0xc0,
+  /** Channel after touch */
+  CHANNEL_AFTER_TOUCH = 0xd0,
+  /** Pitch bend */
+  PITCH_BEND = 0xe0,
 }

--- a/packages/lib/midi/src/Event.ts
+++ b/packages/lib/midi/src/Event.ts
@@ -1,6 +1,12 @@
-import {int} from "@opendaw/lib-std"
+import { int } from "@opendaw/lib-std";
 
+/**
+ * Generic timed MIDI event.
+ * @typeParam TYPE - specific event type identifier.
+ */
 export interface Event<TYPE> {
-    readonly ticks: int
-    readonly type: TYPE
+  /** Delta time in ticks from the start of the track */
+  readonly ticks: int;
+  /** Event type identifier */
+  readonly type: TYPE;
 }

--- a/packages/lib/midi/src/MetaType.ts
+++ b/packages/lib/midi/src/MetaType.ts
@@ -1,60 +1,70 @@
-import {Event} from "./Event"
-import {MidiFileDecoder} from "./MidiFileDecoder"
+import { Event } from "./Event";
+import { MidiFileDecoder } from "./MidiFileDecoder";
 
+/**
+ * MIDI meta-event type identifiers.
+ */
 export const enum MetaType {
-    SEQUENCE_NUMBER = 0x00,
-    TEXT_EVENT = 0x01,
-    COPYRIGHT_NOTICE = 0x02,
-    SEQUENCE_TRACK_NAME = 0x03,
-    INSTRUMENT_NAME = 0x04,
-    LYRICS = 0x05,
-    MARKER = 0x06,
-    CUE_POINT = 0x07,
-    CHANNEL_PREFIX = 0x20,
-    SET_TEMPO = 0x51,
-    SMPTE_OFFSET = 0x54,
-    TIME_SIGNATURE = 0x58,
-    KEY_SIGNATURE = 0x59,
-    SEQUENCER_SPECIFIC = 0x7f,
-    PREFIX_PORT = 0x21,
-    END_OF_TRACK = 0x2f,
+  SEQUENCE_NUMBER = 0x00,
+  TEXT_EVENT = 0x01,
+  COPYRIGHT_NOTICE = 0x02,
+  SEQUENCE_TRACK_NAME = 0x03,
+  INSTRUMENT_NAME = 0x04,
+  LYRICS = 0x05,
+  MARKER = 0x06,
+  CUE_POINT = 0x07,
+  CHANNEL_PREFIX = 0x20,
+  SET_TEMPO = 0x51,
+  SMPTE_OFFSET = 0x54,
+  TIME_SIGNATURE = 0x58,
+  KEY_SIGNATURE = 0x59,
+  SEQUENCER_SPECIFIC = 0x7f,
+  PREFIX_PORT = 0x21,
+  END_OF_TRACK = 0x2f,
 }
 
+/**
+ * Representation of a MIDI meta-event.
+ */
 export class MetaEvent implements Event<MetaType> {
-    private constructor(readonly ticks: number,
-                        readonly type: MetaType,
-                        readonly value: unknown) {}
+  private constructor(
+    readonly ticks: number,
+    readonly type: MetaType,
+    readonly value: unknown,
+  ) {}
 
-    static decode(decoder: MidiFileDecoder, ticks: number): MetaEvent | null {
-        const type = decoder.readByte() & 0xff
-        const length = decoder.readVarLen()
-        switch (type) {
-            case MetaType.SET_TEMPO:
-                return new MetaEvent(ticks, type, decoder.readTempo())
-            case MetaType.TIME_SIGNATURE:
-                return new MetaEvent(ticks, type, decoder.readSignature())
-            case MetaType.END_OF_TRACK:
-                return new MetaEvent(ticks, type, null)
-            case MetaType.TEXT_EVENT:
-            case MetaType.COPYRIGHT_NOTICE:
-            case MetaType.SEQUENCE_TRACK_NAME:
-            case MetaType.INSTRUMENT_NAME:
-            case MetaType.LYRICS:
-            case MetaType.MARKER:
-            case MetaType.CUE_POINT:
-            case MetaType.SEQUENCE_NUMBER:
-            case MetaType.CHANNEL_PREFIX:
-            case MetaType.KEY_SIGNATURE:
-            case MetaType.SEQUENCER_SPECIFIC:
-            case MetaType.PREFIX_PORT:
-            case MetaType.SMPTE_OFFSET:
-            default:
-                decoder.skip(length)
-        }
-        return null
+  /** Decode a meta-event from the stream. */
+  static decode(decoder: MidiFileDecoder, ticks: number): MetaEvent | null {
+    const type = decoder.readByte() & 0xff;
+    const length = decoder.readVarLen();
+    switch (type) {
+      case MetaType.SET_TEMPO:
+        return new MetaEvent(ticks, type, decoder.readTempo());
+      case MetaType.TIME_SIGNATURE:
+        return new MetaEvent(ticks, type, decoder.readSignature());
+      case MetaType.END_OF_TRACK:
+        return new MetaEvent(ticks, type, null);
+      case MetaType.TEXT_EVENT:
+      case MetaType.COPYRIGHT_NOTICE:
+      case MetaType.SEQUENCE_TRACK_NAME:
+      case MetaType.INSTRUMENT_NAME:
+      case MetaType.LYRICS:
+      case MetaType.MARKER:
+      case MetaType.CUE_POINT:
+      case MetaType.SEQUENCE_NUMBER:
+      case MetaType.CHANNEL_PREFIX:
+      case MetaType.KEY_SIGNATURE:
+      case MetaType.SEQUENCER_SPECIFIC:
+      case MetaType.PREFIX_PORT:
+      case MetaType.SMPTE_OFFSET:
+      default:
+        decoder.skip(length);
     }
+    return null;
+  }
 
-    toString(): string {
-        return `MetaEvent{ticks: ${this.ticks}, type: ${this.type}, value: ${this.value}}`
-    }
+  /** String representation for debugging. */
+  toString(): string {
+    return `MetaEvent{ticks: ${this.ticks}, type: ${this.type}, value: ${this.value}}`;
+  }
 }

--- a/packages/lib/midi/src/MidiData.ts
+++ b/packages/lib/midi/src/MidiData.ts
@@ -1,60 +1,94 @@
-import {byte, Nullable} from "@opendaw/lib-std"
+import { byte, Nullable } from "@opendaw/lib-std";
 
+/**
+ * Helper functions for working with raw MIDI message bytes.
+ */
 export namespace MidiData {
-    export const enum Command {NoteOn = 0x90, NoteOff = 0x80, PitchBend = 0xE0, Controller = 0xB0}
+  /**
+   * High-nibble command values for MIDI status bytes.
+   */
+  export const enum Command {
+    NoteOn = 0x90,
+    NoteOff = 0x80,
+    PitchBend = 0xe0,
+    Controller = 0xb0,
+  }
 
-    export const readCommand = (data: Uint8Array) => data[0] & 0xF0
-    export const readChannel = (data: Uint8Array) => data[0] & 0x0F
-    export const readParam1 = (data: Uint8Array) => 1 < data.length ? data[1] & 0xFF : 0
-    export const readParam2 = (data: Uint8Array) => 2 < data.length ? data[2] & 0xFF : 0
-    export const isNoteOn = (data: Uint8Array) => MidiData.readCommand(data) === Command.NoteOn
-    export const readPitch = (data: Uint8Array) => data[1]
-    export const readVelocity = (data: Uint8Array) => data[2] / 127.0
-    export const isNoteOff = (data: Uint8Array) => MidiData.readCommand(data) === Command.NoteOff
-    export const isPitchWheel = (data: Uint8Array) => MidiData.readCommand(data) === Command.PitchBend
-    export const asPitchBend = (data: Uint8Array) => {
-        const p1 = MidiData.readParam1(data) & 0x7F
-        const p2 = MidiData.readParam2(data) & 0x7F
-        const value = p1 | p2 << 7
-        return 8192 >= value ? value / 8192.0 - 1.0 : (value - 8191) / 8192.0
+  /** Extract the command nibble from a MIDI message. */
+  export const readCommand = (data: Uint8Array) => data[0] & 0xf0;
+  /** Extract the channel nibble from a MIDI message. */
+  export const readChannel = (data: Uint8Array) => data[0] & 0x0f;
+  /** Read first parameter byte if present. */
+  export const readParam1 = (data: Uint8Array) =>
+    1 < data.length ? data[1] & 0xff : 0;
+  /** Read second parameter byte if present. */
+  export const readParam2 = (data: Uint8Array) =>
+    2 < data.length ? data[2] & 0xff : 0;
+  /** Determine whether the message is a note on event. */
+  export const isNoteOn = (data: Uint8Array) =>
+    MidiData.readCommand(data) === Command.NoteOn;
+  /** Read the pitch from a note event. */
+  export const readPitch = (data: Uint8Array) => data[1];
+  /** Read the velocity from a note-on event and normalize to 0..1. */
+  export const readVelocity = (data: Uint8Array) => data[2] / 127.0;
+  /** Determine whether the message is a note off event. */
+  export const isNoteOff = (data: Uint8Array) =>
+    MidiData.readCommand(data) === Command.NoteOff;
+  /** Determine whether the message is a pitch bend. */
+  export const isPitchWheel = (data: Uint8Array) =>
+    MidiData.readCommand(data) === Command.PitchBend;
+  /** Convert pitch wheel data to a normalized value in -1..1. */
+  export const asPitchBend = (data: Uint8Array) => {
+    const p1 = MidiData.readParam1(data) & 0x7f;
+    const p2 = MidiData.readParam2(data) & 0x7f;
+    const value = p1 | (p2 << 7);
+    return 8192 >= value ? value / 8192.0 - 1.0 : (value - 8191) / 8192.0;
+  };
+  /** Determine whether the message is a controller change. */
+  export const isController = (data: Uint8Array): boolean =>
+    MidiData.readCommand(data) === Command.Controller;
+  /** Convert controller data to a normalized value. */
+  export const asValue = (data: Uint8Array) => {
+    const value = MidiData.readParam2(data);
+    if (64 < value) {
+      return 0.5 + (value - 63) / 128;
+    } else if (64 > value) {
+      return value / 128;
+    } else {
+      return 0.5;
     }
-    export const isController = (data: Uint8Array): boolean => MidiData.readCommand(data) === Command.Controller
-    export const asValue = (data: Uint8Array) => {
-        const value = MidiData.readParam2(data)
-        if (64 < value) {
-            return 0.5 + (value - 63) / 128
-        } else if (64 > value) {
-            return value / 128
-        } else {
-            return 0.5
-        }
-    }
-    export const noteOn = (channel: byte, note: byte, velocity: byte) => {
-        const bytes = new Uint8Array(3)
-        bytes[0] = channel | Command.NoteOn
-        bytes[1] = note | 0
-        bytes[2] = velocity | 0
-        return bytes
-    }
-    export const noteOff = (channel: byte, note: byte) => {
-        const bytes = new Uint8Array(3)
-        bytes[0] = channel | Command.NoteOff
-        bytes[1] = note
-        return bytes
-    }
+  };
+  /** Create a note on message */
+  export const noteOn = (channel: byte, note: byte, velocity: byte) => {
+    const bytes = new Uint8Array(3);
+    bytes[0] = channel | Command.NoteOn;
+    bytes[1] = note | 0;
+    bytes[2] = velocity | 0;
+    return bytes;
+  };
+  /** Create a note off message */
+  export const noteOff = (channel: byte, note: byte) => {
+    const bytes = new Uint8Array(3);
+    bytes[0] = channel | Command.NoteOff;
+    bytes[1] = note;
+    return bytes;
+  };
 
-    export const debug = (data: Nullable<Uint8Array>): string => {
-        if (data === null) {return "null"}
-        if (isNoteOn(data)) {
-            return `NoteOn #${readChannel(data)} ${readPitch(data)} : ${readVelocity(data).toFixed(2)}`
-        } else if (isNoteOff(data)) {
-            return `NoteOff #${readChannel(data)} ${readPitch(data)}`
-        } else if (isPitchWheel(data)) {
-            return `PitchWheel #${readChannel(data)} ${asPitchBend(data)}`
-        } else if (isController(data)) {
-            return `Control #${readChannel(data)} ${asValue(data)}`
-        } else {
-            return "Unknown"
-        }
+  /** Render a MIDI message as a human readable string. */
+  export const debug = (data: Nullable<Uint8Array>): string => {
+    if (data === null) {
+      return "null";
     }
+    if (isNoteOn(data)) {
+      return `NoteOn #${readChannel(data)} ${readPitch(data)} : ${readVelocity(data).toFixed(2)}`;
+    } else if (isNoteOff(data)) {
+      return `NoteOff #${readChannel(data)} ${readPitch(data)}`;
+    } else if (isPitchWheel(data)) {
+      return `PitchWheel #${readChannel(data)} ${asPitchBend(data)}`;
+    } else if (isController(data)) {
+      return `Control #${readChannel(data)} ${asValue(data)}`;
+    } else {
+      return "Unknown";
+    }
+  };
 }

--- a/packages/lib/midi/src/MidiFile.ts
+++ b/packages/lib/midi/src/MidiFile.ts
@@ -1,48 +1,70 @@
-import {byte, ByteArrayInput, ByteArrayOutput} from "@opendaw/lib-std"
-import {MidiTrack} from "./MidiTrack"
-import {Chunk} from "./Chunk"
-import {MidiFileDecoder} from "./MidiFileDecoder"
+import { byte, ByteArrayInput, ByteArrayOutput } from "@opendaw/lib-std";
+import { MidiTrack } from "./MidiTrack";
+import { Chunk } from "./Chunk";
+import { MidiFileDecoder } from "./MidiFileDecoder";
 
+/**
+ * Utilities for decoding and encoding Standard MIDI Files.
+ */
 export namespace MidiFile {
-    export const decoder = (buffer: ArrayBuffer): MidiFileDecoder => new MidiFileDecoder(new ByteArrayInput(buffer))
-    export const encoder = (): MidiFileEncoder => new MidiFileEncoder()
+  /**
+   * Create a decoder for the provided MIDI file buffer.
+   */
+  export const decoder = (buffer: ArrayBuffer): MidiFileDecoder =>
+    new MidiFileDecoder(new ByteArrayInput(buffer));
 
-    class MidiFileEncoder {
-        static writeVarLen(output: ByteArrayOutput, value: number): void {
-            let bytes: Array<byte> = []
-            while (value > 0x7F) {
-                bytes.push((value & 0x7F) | 0x80)
-                value >>= 7
-            }
-            bytes.push(value & 0x7F)
-            for (let i = bytes.length - 1; i >= 0; i--) {
-                output.writeByte(bytes[i])
-            }
-        }
+  /**
+   * Create a new encoder for generating MIDI files.
+   */
+  export const encoder = (): MidiFileEncoder => new MidiFileEncoder();
 
-        readonly #tracks: Array<MidiTrack> = []
-
-        addTrack(track: MidiTrack): this {
-            this.#tracks.push(track)
-            return this
-        }
-
-        encode(): ByteArrayOutput {
-            const output = ByteArrayOutput.create()
-            output.littleEndian = false
-            output.writeInt(Chunk.MTHD)
-            output.writeInt(6)
-            output.writeShort(0) // formatType
-            output.writeShort(this.#tracks.length)
-            output.writeShort(96) // timeDivision
-            this.#tracks.forEach(track => {
-                output.writeInt(Chunk.MTRK)
-                const buffer = track.encode()
-                output.writeInt(buffer.byteLength)
-                output.writeBytes(new Int8Array(buffer))
-            })
-            return output
-        }
+  /**
+   * Helper class used to incrementally build a MIDI file from tracks.
+   */
+  class MidiFileEncoder {
+    /**
+     * Write a variable-length integer to the output.
+     */
+    static writeVarLen(output: ByteArrayOutput, value: number): void {
+      let bytes: Array<byte> = [];
+      while (value > 0x7f) {
+        bytes.push((value & 0x7f) | 0x80);
+        value >>= 7;
+      }
+      bytes.push(value & 0x7f);
+      for (let i = bytes.length - 1; i >= 0; i--) {
+        output.writeByte(bytes[i]);
+      }
     }
 
+    readonly #tracks: Array<MidiTrack> = [];
+
+    /**
+     * Add a track to the encoder.
+     */
+    addTrack(track: MidiTrack): this {
+      this.#tracks.push(track);
+      return this;
+    }
+
+    /**
+     * Encode the added tracks into a MIDI file.
+     */
+    encode(): ByteArrayOutput {
+      const output = ByteArrayOutput.create();
+      output.littleEndian = false;
+      output.writeInt(Chunk.MTHD);
+      output.writeInt(6);
+      output.writeShort(0); // formatType
+      output.writeShort(this.#tracks.length);
+      output.writeShort(96); // timeDivision
+      this.#tracks.forEach((track) => {
+        output.writeInt(Chunk.MTRK);
+        const buffer = track.encode();
+        output.writeInt(buffer.byteLength);
+        output.writeBytes(new Int8Array(buffer));
+      });
+      return output;
+    }
+  }
 }

--- a/packages/lib/midi/src/MidiFileFormat.ts
+++ b/packages/lib/midi/src/MidiFileFormat.ts
@@ -1,6 +1,13 @@
-import {int} from "@opendaw/lib-std"
-import {MidiTrack} from "./MidiTrack"
+import { int } from "@opendaw/lib-std";
+import { MidiTrack } from "./MidiTrack";
 
+/**
+ * Description of a decoded MIDI file including its tracks and timing.
+ */
 export class MidiFileFormat {
-    constructor(readonly tracks: ReadonlyArray<MidiTrack>, readonly formatType: int, readonly timeDivision: int) {}
+  constructor(
+    readonly tracks: ReadonlyArray<MidiTrack>,
+    readonly formatType: int,
+    readonly timeDivision: int,
+  ) {}
 }

--- a/packages/lib/midi/src/MidiTrack.ts
+++ b/packages/lib/midi/src/MidiTrack.ts
@@ -1,101 +1,121 @@
-import {ArrayMultimap, ByteArrayOutput, int, isDefined} from "@opendaw/lib-std"
-import {Channel} from "./Channel"
-import {ControlEvent} from "./ControlEvent"
-import {MetaEvent, MetaType} from "./MetaType"
-import {MidiFileDecoder} from "./MidiFileDecoder"
-import {ControlType} from "./ControlType"
+import {
+  ArrayMultimap,
+  ByteArrayOutput,
+  int,
+  isDefined,
+} from "@opendaw/lib-std";
+import { Channel } from "./Channel";
+import { ControlEvent } from "./ControlEvent";
+import { MetaEvent, MetaType } from "./MetaType";
+import { MidiFileDecoder } from "./MidiFileDecoder";
+import { ControlType } from "./ControlType";
 
+/**
+ * Collection of MIDI control and meta events representing a single track.
+ */
 export class MidiTrack {
-    static decode(decoder: MidiFileDecoder): MidiTrack {
-        const controlEvents: ArrayMultimap<Channel, ControlEvent> = new ArrayMultimap<Channel, ControlEvent>()
-        const metaEvents: Array<MetaEvent> = []
-        let ticks: int = 0
-        let eventType: int = 0
-        let channel: Channel = 0
-        while (true) {
-            const varLen = decoder.readVarLen()
-            const b = decoder.readByte() & 0xff
-            if (b < 0xf0) {
-                // 0x00....0xEF (MidiControl)
-                ticks += varLen
-                if (b < 0x80) {
-                    // running mode, use the last eventType/channel!
-                    decoder.skip(-1)
-                } else {
-                    eventType = b & 0xf0
-                    channel = b & 0x0f
-                }
-                const event = ControlEvent.decode(decoder, eventType, ticks)
-                if (isDefined(event)) {
-                    controlEvents.add(channel, event)
-                }
-            } else if (b < 0xf8) {
-                decoder.skipSysEx(b) // 0xF0....0xF7
-            } else {
-                // 0xF8....0xFF
-                ticks += varLen
-                const event: MetaEvent | null = MetaEvent.decode(decoder, ticks)
-                if (event !== null) {
-                    metaEvents.push(event)
-                    if (event.type === MetaType.END_OF_TRACK) {
-                        break
-                    }
-                }
-            }
+  /**
+   * Decode a track from the given decoder.
+   */
+  static decode(decoder: MidiFileDecoder): MidiTrack {
+    const controlEvents: ArrayMultimap<Channel, ControlEvent> =
+      new ArrayMultimap<Channel, ControlEvent>();
+    const metaEvents: Array<MetaEvent> = [];
+    let ticks: int = 0;
+    let eventType: int = 0;
+    let channel: Channel = 0;
+    while (true) {
+      const varLen = decoder.readVarLen();
+      const b = decoder.readByte() & 0xff;
+      if (b < 0xf0) {
+        // 0x00....0xEF (MidiControl)
+        ticks += varLen;
+        if (b < 0x80) {
+          // running mode, use the last eventType/channel!
+          decoder.skip(-1);
+        } else {
+          eventType = b & 0xf0;
+          channel = b & 0x0f;
         }
-        return new MidiTrack(controlEvents, metaEvents)
-    }
-
-    static createEmpty(): MidiTrack {return new MidiTrack(new ArrayMultimap<Channel, ControlEvent>(), [])}
-
-    constructor(readonly controlEvents: ArrayMultimap<Channel, ControlEvent>,
-                readonly metaEvents: Array<MetaEvent>) {}
-
-    encode(): ArrayBufferLike {
-        const output = ByteArrayOutput.create()
-        const writeVarInt = (value: int): void => {
-            if (value <= 0x7F) {
-                output.writeByte(value)
-            } else {
-                let i = value
-                const bytes: Array<int> = []
-                bytes.push(i & 0x7F)
-                i >>= 7
-                while (i) {
-                    let b = i & 0x7F | 0x80
-                    bytes.push(b)
-                    i >>= 7
-                }
-                bytes.reverse().forEach(byte => output.writeByte(byte))
-            }
+        const event = ControlEvent.decode(decoder, eventType, ticks);
+        if (isDefined(event)) {
+          controlEvents.add(channel, event);
         }
-        this.controlEvents.forEach((channel, events) => {
-            let ticks = 0
-            let lastEventTypeByte = -1
-            events.forEach((event: ControlEvent) => {
-                const deltaTime = event.ticks - ticks
-                writeVarInt(deltaTime)
-                if (event.type === ControlType.NOTE_ON) {
-                    const eventTypeByte = 0x90 | channel
-                    if (eventTypeByte !== lastEventTypeByte) {
-                        output.writeByte(eventTypeByte)
-                    }
-                    output.writeByte(event.param0)
-                    output.writeByte(event.param1)
-                } else if (event.type === ControlType.NOTE_OFF) {
-                    const eventTypeByte = 0x90 | channel
-                    if (eventTypeByte !== lastEventTypeByte) {
-                        output.writeByte(eventTypeByte)
-                    }
-                    output.writeByte(event.param0)
-                    output.writeByte(event.param1)
-                } else {
-                    console.warn("Unknown ControlType")
-                }
-                ticks = event.ticks
-            })
-        })
-
-        return output.toArrayBuffer()
+      } else if (b < 0xf8) {
+        decoder.skipSysEx(b); // 0xF0....0xF7
+      } else {
+        // 0xF8....0xFF
+        ticks += varLen;
+        const event: MetaEvent | null = MetaEvent.decode(decoder, ticks);
+        if (event !== null) {
+          metaEvents.push(event);
+          if (event.type === MetaType.END_OF_TRACK) {
+            break;
+          }
+        }
+      }
     }
+    return new MidiTrack(controlEvents, metaEvents);
+  }
+
+  /** Create an empty track with no events. */
+  static createEmpty(): MidiTrack {
+    return new MidiTrack(new ArrayMultimap<Channel, ControlEvent>(), []);
+  }
+
+  constructor(
+    readonly controlEvents: ArrayMultimap<Channel, ControlEvent>,
+    readonly metaEvents: Array<MetaEvent>,
+  ) {}
+
+  /**
+   * Encode the track into a MIDI track chunk.
+   */
+  encode(): ArrayBufferLike {
+    const output = ByteArrayOutput.create();
+    const writeVarInt = (value: int): void => {
+      if (value <= 0x7f) {
+        output.writeByte(value);
+      } else {
+        let i = value;
+        const bytes: Array<int> = [];
+        bytes.push(i & 0x7f);
+        i >>= 7;
+        while (i) {
+          let b = (i & 0x7f) | 0x80;
+          bytes.push(b);
+          i >>= 7;
+        }
+        bytes.reverse().forEach((byte) => output.writeByte(byte));
+      }
+    };
+    this.controlEvents.forEach((channel, events) => {
+      let ticks = 0;
+      let lastEventTypeByte = -1;
+      events.forEach((event: ControlEvent) => {
+        const deltaTime = event.ticks - ticks;
+        writeVarInt(deltaTime);
+        if (event.type === ControlType.NOTE_ON) {
+          const eventTypeByte = 0x90 | channel;
+          if (eventTypeByte !== lastEventTypeByte) {
+            output.writeByte(eventTypeByte);
+          }
+          output.writeByte(event.param0);
+          output.writeByte(event.param1);
+        } else if (event.type === ControlType.NOTE_OFF) {
+          const eventTypeByte = 0x90 | channel;
+          if (eventTypeByte !== lastEventTypeByte) {
+            output.writeByte(eventTypeByte);
+          }
+          output.writeByte(event.param0);
+          output.writeByte(event.param1);
+        } else {
+          console.warn("Unknown ControlType");
+        }
+        ticks = event.ticks;
+      });
+    });
+
+    return output.toArrayBuffer();
+  }
 }

--- a/packages/lib/midi/src/index.ts
+++ b/packages/lib/midi/src/index.ts
@@ -1,21 +1,33 @@
-const key = Symbol.for("@openDAW/lib-midi")
+/**
+ * Entry point re-exporting all MIDI utilities.
+ * Registers a symbol on the global object for debugging purposes.
+ */
+const key = Symbol.for("@openDAW/lib-midi");
 
 if ((globalThis as any)[key]) {
-    console.debug(`%c${key.description}%c is already available in ${globalThis.constructor.name}.`, "color: hsl(10, 83%, 60%)", "color: inherit")
+  console.debug(
+    `%c${key.description}%c is already available in ${globalThis.constructor.name}.`,
+    "color: hsl(10, 83%, 60%)",
+    "color: inherit",
+  );
 } else {
-    (globalThis as any)[key] = true
-    console.debug(`%c${key.description}%c is now available in ${globalThis.constructor.name}.`, "color: hsl(200, 83%, 60%)", "color: inherit")
+  (globalThis as any)[key] = true;
+  console.debug(
+    `%c${key.description}%c is now available in ${globalThis.constructor.name}.`,
+    "color: hsl(200, 83%, 60%)",
+    "color: inherit",
+  );
 }
 
-export * from "./Channel"
-export * from "./Chunk"
-export * from "./ControlEvent"
-export * from "./ControlEventVisitor"
-export * from "./ControlType"
-export * from "./Event"
-export * from "./MetaType"
-export * from "./MidiData"
-export * from "./MidiFile"
-export * from "./MidiFileDecoder"
-export * from "./MidiFileFormat"
-export * from "./MidiTrack"
+export * from "./Channel";
+export * from "./Chunk";
+export * from "./ControlEvent";
+export * from "./ControlEventVisitor";
+export * from "./ControlType";
+export * from "./Event";
+export * from "./MetaType";
+export * from "./MidiData";
+export * from "./MidiFile";
+export * from "./MidiFileDecoder";
+export * from "./MidiFileFormat";
+export * from "./MidiTrack";


### PR DESCRIPTION
## Summary
- add TSDoc comments across MIDI library modules
- document decoding/encoding and DSP integration in README

## Testing
- `npm test --workspace=@opendaw/lib-midi`
- `npm run lint --workspace=@opendaw/lib-midi` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm run build --workspace=@opendaw/lib-midi` *(fails: missing @opendaw/lib-std and tsconfig)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a7ba0348321816a5c57b58eb473