### PR TITLE
docs: add dsp tsdoc

### DIFF
--- a/packages/lib/dsp/README.md
+++ b/packages/lib/dsp/README.md
@@ -4,43 +4,54 @@ _This package is part of the openDAW SDK_
 
 Digital Signal Processing utilities and audio processing functions for TypeScript projects.
 
+## Signal Flow
+
+```mermaid
+graph LR
+    A[Input] --> B((Biquad))
+    B --> C{{Stereo}}
+    C --> D[Output]
+```
+
+See {@link BiquadProcessor} and {@link StereoMatrix} for the stages shown above.
+
 ## Core Audio Processing
 
 * **fft.ts** - Fast Fourier Transform implementations
 * **rms.ts** - Root Mean Square calculations
 * **delay.ts** - Audio delay effects and processing
-* **stereo.ts** - Stereo audio processing utilities
-* **window.ts** - Windowing functions for signal processing
+* **stereo.ts** - Stereo audio processing utilities ({@link StereoMatrix})
+* **window.ts** - Windowing functions for signal processing ({@link Window})
 
 ## Oscillators & Synthesis
 
 * **osc.ts** - Oscillator implementations and waveform generation
 * **value.ts** - Audio value processing and manipulation
-* **ramp.ts** - Smooth parameter transitions and ramping
+* **ramp.ts** - Smooth parameter transitions and ramping ({@link Ramp})
 
 ## Musical Theory & MIDI
 
 * **notes.ts** - Musical note utilities and conversions
-* **chords.ts** - Chord theory and generation
-* **midi-keys.ts** - MIDI key mapping and utilities
-* **fractions.ts** - Musical fraction calculations
+* **chords.ts** - Chord theory and generation ({@link Chord})
+* **midi-keys.ts** - MIDI key mapping and utilities ({@link MidiKeys})
+* **fractions.ts** - Musical fraction calculations ({@link Fraction})
 
 ## Timing & Rhythm
 
-* **ppqn.ts** - Pulses Per Quarter Note timing utilities
-* **bpm-tools.ts** - Beats Per Minute calculations and tools
+* **ppqn.ts** - Pulses Per Quarter Note timing utilities ({@link PPQN})
+* **bpm-tools.ts** - Beats Per Minute calculations and tools ({@link BPMTools})
 * **grooves.ts** - Rhythm and groove pattern utilities
 
 ## Audio Graph & Events
 
-* **graph.ts** - Audio processing graph utilities
-* **events.ts** - Audio event handling and scheduling
+* **graph.ts** - Audio processing graph utilities ({@link Graph})
+* **events.ts** - Audio event handling and scheduling ({@link EventCollection})
 * **fragmentor.ts** - Audio fragment processing
 
 ## Filters & Effects
 
-* **biquad-coeff.ts** - Biquad filter coefficient calculations
-* **biquad-processor.ts** - Biquad filter processing implementation
+* **biquad-coeff.ts** - Biquad filter coefficient calculations ({@link BiquadCoeff})
+* **biquad-processor.ts** - Biquad filter processing implementation ({@link BiquadProcessor})
 
 ## Utilities
 

--- a/packages/lib/dsp/src/biquad-coeff.ts
+++ b/packages/lib/dsp/src/biquad-coeff.ts
@@ -6,6 +6,12 @@ import {assert, clamp, TAU, unitValue} from "@opendaw/lib-std"
 // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/audio/biquad.cc
 // quickly tested all biquad modes
 
+/**
+ * Coefficients for a canonical biquad filter.
+ *
+ * The corresponding difference equation is
+ * \(y[n]=b_0x[n]+b_1x[n-1]+b_2x[n-2]-a_1y[n-1]-a_2y[n-2]\).
+ */
 export class BiquadCoeff {
     a1: number = 0.0
     a2: number = 0.0
@@ -15,8 +21,14 @@ export class BiquadCoeff {
 
     constructor() {this.identity()}
 
+    /** Resets coefficients to pass-through identity. */
     identity(): void {this.setNormalizedCoefficients(1, 0, 0, 1, 0, 0)}
 
+    /**
+     * Configures a low-pass filter.
+     * @param cutoff - Normalized cutoff frequency in `[0,1]`.
+     * @param resonance - Resonance in dB.
+     */
     setLowpassParams(cutoff: unitValue, resonance: number): this {
         cutoff = clamp(cutoff, 0.0, 1.0)
         if (cutoff === 1) {
@@ -40,6 +52,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a high-pass filter.
+     * @param cutoff - Normalized cutoff frequency.
+     * @param resonance - Resonance in dB.
+     */
     setHighpassParams(cutoff: unitValue, resonance: number): this {
         cutoff = clamp(cutoff, 0.0, 1.0)
         if (cutoff === 1) {
@@ -63,6 +80,9 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Stores unnormalized coefficients and normalizes by `a0`.
+     */
     setNormalizedCoefficients(b0: number, b1: number, b2: number, a0: number, a1: number, a2: number): this {
         const a0_inverse = 1.0 / a0
         this.b0 = b0 * a0_inverse
@@ -73,6 +93,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a low-shelf filter.
+     * @param frequency - Normalized corner frequency.
+     * @param db_gain - Shelf gain in dB.
+     */
     setLowShelfParams(frequency: unitValue, db_gain: number): this {
         frequency = clamp(frequency, 0.0, 1.0)
         const a = Math.pow(10.0, db_gain / 40)
@@ -99,6 +124,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a high-shelf filter.
+     * @param frequency - Normalized corner frequency.
+     * @param db_gain - Shelf gain in dB.
+     */
     setHighShelfParams(frequency: unitValue, db_gain: number): this {
         frequency = clamp(frequency, 0.0, 1.0)
         const a = Math.pow(10.0, db_gain / 40)
@@ -125,6 +155,12 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a peaking filter.
+     * @param frequency - Normalized center frequency.
+     * @param q - Quality factor.
+     * @param db_gain - Gain in dB.
+     */
     setPeakingParams(frequency: number, q: number, db_gain: number): this {
         frequency = clamp(frequency, 0.0, 1.0)
         q = Math.max(0.0, q)
@@ -150,6 +186,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures an all-pass filter.
+     * @param frequency - Normalized center frequency.
+     * @param q - Quality factor.
+     */
     setAllpassParams(frequency: unitValue, q: number): this {
         frequency = clamp(frequency, 0.0, 1.0)
         q = Math.max(0.0, q)
@@ -174,6 +215,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a notch filter.
+     * @param frequency - Normalized center frequency.
+     * @param q - Quality factor.
+     */
     setNotchParams(frequency: unitValue, q: number): this {
         frequency = clamp(frequency, 0.0, 1.0)
         q = Math.max(0.0, q)
@@ -198,6 +244,11 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Configures a band-pass filter.
+     * @param frequency - Normalized center frequency.
+     * @param q - Quality factor.
+     */
     setBandpassParams(frequency: unitValue, q: number): this {
         frequency = Math.max(0.0, frequency)
         q = Math.max(0.0, q)
@@ -222,6 +273,12 @@ export class BiquadCoeff {
         return this
     }
 
+    /**
+     * Calculates the complex frequency response of the configured filter.
+     * @param frequency - Normalized frequency values.
+     * @param magResponse - Output magnitude array.
+     * @param phaseResponse - Output phase array.
+     */
     getFrequencyResponse(frequency: Float32Array, magResponse: Float32Array, phaseResponse: Float32Array): void {
         assert(frequency.length === magResponse.length && frequency.length === phaseResponse.length,
             "Array lengths do not match")

--- a/packages/lib/dsp/src/biquad-processor.ts
+++ b/packages/lib/dsp/src/biquad-processor.ts
@@ -1,12 +1,19 @@
 import {BiquadCoeff} from "./biquad-coeff"
 import {Arrays, int} from "@opendaw/lib-std"
 
+/**
+ * Interface for processing samples with biquad filters.
+ */
 export interface BiquadProcessor {
+    /** Clears internal state. */
     reset(): void
+    /** Processes a block of samples. */
     process(coeff: BiquadCoeff, source: Float32Array, target: Float32Array, fromIndex: int, toIndex: int): void
+    /** Processes a single sample. */
     processFrame(coeff: BiquadCoeff, x: number): number
 }
 
+/** Single-channel biquad processor implementing the difference equation. */
 export class BiquadMono implements BiquadProcessor {
     #x1: number = 0.0
     #x2: number = 0.0
@@ -50,6 +57,9 @@ export class BiquadMono implements BiquadProcessor {
     }
 }
 
+/**
+ * Stack of cascaded biquad processors to create higher-order filters.
+ */
 export class BiquadStack implements BiquadProcessor {
     readonly #stack: ReadonlyArray<BiquadProcessor>
 

--- a/packages/lib/dsp/src/bpm-tools.ts
+++ b/packages/lib/dsp/src/bpm-tools.ts
@@ -13,6 +13,14 @@ export namespace BPMTools {
         maxBPM: number
     }>
 
+    /**
+     * Estimates the tempo of an audio buffer.
+     *
+     * @param buf - Mono input samples.
+     * @param sampleRate - Sampling rate of `buf`.
+     * @param options - Configuration such as search bounds.
+     * @returns Detected BPM.
+     */
     export function detect(buf: Float32Array, sampleRate: number, options: Options = {}): number {
         const {
             interval = 64,      // samples between energy taps

--- a/packages/lib/dsp/src/chords.ts
+++ b/packages/lib/dsp/src/chords.ts
@@ -1,10 +1,19 @@
 import {Arrays, int} from "@opendaw/lib-std"
 
+/** Helper functions for working with musical chords. */
 export namespace Chord {
     export const Major: ReadonlyArray<int> = [0, 2, 4, 5, 7, 9, 11]
     export const Minor: ReadonlyArray<int> = [0, 2, 3, 5, 7, 8, 10]
     export const NoteLabels = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]
 
+    /**
+     * Compiles a chord of `n` notes from a given scale.
+     *
+     * @param scale - Scale intervals.
+     * @param root - MIDI note of the root.
+     * @param variation - Starting degree within the scale.
+     * @param n - Number of notes to generate.
+     */
     export const compile = (scale: ReadonlyArray<int>, root: int, variation: int, n: int): ReadonlyArray<int> =>
         Arrays.create(index => {
             const step = variation + index * 2
@@ -12,5 +21,8 @@ export namespace Chord {
             return root + interval
         }, n)
 
+    /**
+     * Converts a MIDI note number into a human-readable note label.
+     */
     export const toString = (midiNote: int): string => NoteLabels[midiNote % 12] + (Math.floor(midiNote / 12) - 2)
 }

--- a/packages/lib/dsp/src/fractions.ts
+++ b/packages/lib/dsp/src/fractions.ts
@@ -1,11 +1,15 @@
 import {int} from "@opendaw/lib-std"
 import {PPQN, ppqn} from "./ppqn"
 
+/** Tuple representing a musical fraction `n/d`. */
 export type Fraction = Readonly<[int, int]>
 
 export namespace Fraction {
+    /** Creates a builder for accumulating fractions. */
     export const builder = () => new Builder()
+    /** Converts a fraction to a floating-point ratio. */
     export const toDouble = ([n, d]: Fraction): number => n / d
+    /** Converts a time fraction to {@link ppqn} pulses. */
     export const toPPQN = ([n, d]: Fraction): ppqn => PPQN.fromSignature(n, d)
 
     class Builder {

--- a/packages/lib/dsp/src/graph.ts
+++ b/packages/lib/dsp/src/graph.ts
@@ -1,7 +1,11 @@
 import {Arrays, asDefined, assert} from "@opendaw/lib-std"
 
+/** Directed edge between two vertices. */
 export type Edge<V> = [V, V]
 
+/**
+ * Minimal directed graph used for audio-processing graphs.
+ */
 export class Graph<V> {
     readonly #vertices: Array<V>
     readonly #predecessors: Map<V, Array<V>>
@@ -11,6 +15,7 @@ export class Graph<V> {
         this.#predecessors = new Map<V, Array<V>>()
     }
 
+    /** Registers a vertex. */
     addVertex(vertex: V): void {
         assert(!this.#vertices.includes(vertex), "Vertex already exists")
         this.#vertices.push(vertex)
@@ -18,22 +23,26 @@ export class Graph<V> {
         this.#predecessors.set(vertex, [])
     }
 
+    /** Removes a vertex and its edges. */
     removeVertex(vertex: V): void {
         Arrays.remove(this.#vertices, vertex)
         const found = this.#predecessors.delete(vertex)
         assert(found, "Predecessor does not exists")
     }
 
+    /** Returns the predecessors of a vertex. */
     getPredecessors(vertex: V): ReadonlyArray<V> {return this.#predecessors.get(vertex) ?? Arrays.empty()}
     predecessors(): Map<V, V[]> {return this.#predecessors}
     vertices(): ReadonlyArray<V> {return this.#vertices}
 
+    /** Adds a directed edge. */
     addEdge([source, target]: Edge<V>): void {
         const vertexPredecessors = asDefined(this.#predecessors.get(target), `[add] Edge has unannounced vertex. (${target})`)
         assert(!vertexPredecessors.includes(source), `${source} is already marked.`)
         vertexPredecessors.push(source)
     }
 
+    /** Removes a directed edge. */
     removeEdge([source, target]: Edge<V>): void {
         const vertexPredecessors = asDefined(this.#predecessors.get(target), `[remove] Edge has unannounced vertex. (${target})`)
         assert(vertexPredecessors.includes(source), `${source} is not marked.`)
@@ -43,6 +52,9 @@ export class Graph<V> {
     isEmpty(): boolean {return this.#vertices.length === 0}
 }
 
+/**
+ * Computes a topological order of a {@link Graph} and detects loops.
+ */
 export class TopologicalSort<V> {
     readonly #graph: Graph<V>
     readonly #sorted: Array<V>
@@ -59,12 +71,15 @@ export class TopologicalSort<V> {
         this.#successors = new Map<V, Set<V>>()
     }
 
+    /** Updates the internal order; call after mutating the graph. */
     update(): void {
         this.#prepare()
         this.#graph.vertices().forEach(vertex => this.#visit(vertex))
     }
 
+    /** Sorted vertices after {@link update}. */
     sorted(): ReadonlyArray<V> {return this.#sorted}
+    /** Indicates whether the graph contains cycles. */
     hasLoops(): boolean {return this.#withLoops.size !== 0}
 
     #prepare(): void {

--- a/packages/lib/dsp/src/index.ts
+++ b/packages/lib/dsp/src/index.ts
@@ -7,24 +7,45 @@ if ((globalThis as any)[key]) {
     console.debug(`%c${key.description}%c is now available in ${globalThis.constructor.name}.`, "color: hsl(200, 83%, 60%)", "color: inherit")
 }
 
+/** Biquad filter coefficient utilities. */
 export * from "./biquad-coeff"
+/** Biquad filter processors. */
 export * from "./biquad-processor"
+/** Tempo analysis helpers. */
 export * from "./bpm-tools"
+/** Chord theory helpers. */
 export * from "./chords"
+/** Delay line processing. */
 export * from "./delay"
+/** Time-based event collections. */
 export * from "./events"
+/** Fast Fourier transform utilities. */
 export * from "./fft"
+/** Musical fractions and conversions. */
 export * from "./fractions"
+/** Audio fragment processing. */
 export * from "./fragmentor"
+/** Directed graphs and topological sorting. */
 export * from "./graph"
+/** Groove pattern utilities. */
 export * from "./grooves"
+/** MIDI key naming and scales. */
 export * from "./midi-keys"
+/** Musical note utilities. */
 export * from "./notes"
+/** Oscillator implementations. */
 export * from "./osc"
+/** Pulses-per-quarter-note conversions. */
 export * from "./ppqn"
+/** Parameter ramping helpers. */
 export * from "./ramp"
+/** Root-mean-square calculations. */
 export * from "./rms"
+/** Stereo matrix processing. */
 export * from "./stereo"
+/** General DSP utilities. */
 export * from "./utils"
+/** Value manipulation helpers. */
 export * from "./value"
+/** Windowing functions. */
 export * from "./window"

--- a/packages/lib/dsp/src/midi-keys.ts
+++ b/packages/lib/dsp/src/midi-keys.ts
@@ -1,5 +1,8 @@
 import {byte, int} from "@opendaw/lib-std"
 
+/**
+ * Constants and helpers for dealing with MIDI key numbers.
+ */
 export namespace MidiKeys {
     export const BlackKeyIndices = [1, 3, 6, 8, 10]
     export const BlackKeyBits = BlackKeyIndices.reduce((bits: int, keyIndex: int) => (bits |= 1 << keyIndex), 0)
@@ -11,7 +14,9 @@ export namespace MidiKeys {
         Spanish: ["Do", "Do#", "Re", "Re#", "Mi", "Fa", "Fa#", "Sol", "Sol#", "La", "La#", "Si"],
         Japanese: ["ド", "ド♯", "レ", "レ♯", "ミ", "ファ", "ファ♯", "ソ", "ソ♯", "ラ", "ラ♯", "シ"]
     }
+    /** Determines if a MIDI note is a black key. */
     export const isBlackKey = (note: int) => (BlackKeyBits & (1 << (note % 12))) !== 0
+    /** Returns a human readable string such as `C4`. */
     export const toFullString = (note: int): string => `${Names.English[note % 12]}${(Math.floor(note / 12) - 2)}`
 
     export interface Scale {
@@ -38,6 +43,7 @@ export namespace MidiKeys {
         equals(other: Scale): boolean {return this.#bits === other.bits}
     }
 
+    /** Common musical scales represented as bit masks. */
     export const StockScales: ReadonlyArray<PredefinedScale> = [
         new PredefinedScaleImpl("Major", 0, 2, 4, 5, 7, 9, 11),
         new PredefinedScaleImpl("Natural Minor", 0, 2, 3, 5, 7, 8, 10),

--- a/packages/lib/dsp/src/ppqn.ts
+++ b/packages/lib/dsp/src/ppqn.ts
@@ -3,6 +3,7 @@
 
 import {int} from "@opendaw/lib-std"
 
+/** Musical position expressed in pulses per quarter note. */
 export type ppqn = number
 
 const Quarter = 960 as const
@@ -30,6 +31,7 @@ const pulsesToSeconds = (pulses: ppqn, bpm: number): number => (pulses * 60.0 / 
 const samplesToPulses = (samples: number, bpm: number, sampleRate: number): ppqn => secondsToPulses(samples / sampleRate, bpm)
 const pulsesToSamples = (pulses: ppqn, bpm: number, sampleRate: number): number => pulsesToSeconds(pulses, bpm) * sampleRate
 
+/** Utility conversions for {@link ppqn} timing. */
 export const PPQN = {
     Bar,
     Quarter,

--- a/packages/lib/dsp/src/window.ts
+++ b/packages/lib/dsp/src/window.ts
@@ -1,6 +1,15 @@
+/**
+ * Window functions used for spectral analysis and smoothing.
+ */
 export namespace Window {
     export enum Type {Bartlett, Blackman, BlackmanHarris, Hamming, Hanning}
 
+    /**
+     * Generates a window of the desired `type` and length `n`.
+     *
+     * @param type - Shape of the window.
+     * @param n - Number of samples.
+     */
     export const create = (type: Type, n: number): Float32Array => {
         const values = new Float32Array(n)
         const a = Math.PI / (n - 1)


### PR DESCRIPTION
## Summary
- document DSP modules with TSDoc, equations, and parameter tables
- describe each index export and add signal-flow README diagrams

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a7af4208321a053c6d61c6b7377