### PR TITLE
docs: expand runtime tsdoc and README examples

### DIFF
--- a/packages/lib/runtime/README.md
+++ b/packages/lib/runtime/README.md
@@ -4,20 +4,70 @@ _This package is part of the openDAW SDK_
 
 Runtime utilities and asynchronous operations for TypeScript projects.
 
-## Async & Promises
+## Usage
 
-* **promises.ts** - Promise utilities and async operation helpers
-* **wait.ts** - Waiting and delay utilities
-* **runtime.ts** - Runtime environment utilities
+```ts
+import { Wait, Promises, Runtime, network, Fetch } from "@opendaw/lib-runtime"
+```
 
-## Network & Communication
+### Async & Promises
 
-* **fetch.ts** - HTTP request utilities and fetch wrappers
-* **network.ts** - Network-related utilities
-* **messenger.ts** - Message passing utilities
-* **communicator.ts** - Inter-process communication helpers
+Use {@link Promises.retry} to automatically retry failing operations:
 
-## Time & Performance
+```ts
+const data = await Promises.retry(() => fetch("/data").then(r => r.json()))
+```
 
-* **timespan.ts** - Time span calculations and utilities
-* **stopwatch.ts** - Performance timing and measurement utilities
+Delay execution with {@link Wait.frames} or {@link Wait.timeSpan}:
+
+```ts
+await Wait.frames(2)
+await Wait.timeSpan(TimeSpan.seconds(1))
+```
+
+Debounce calls using {@link Runtime.debounce}:
+
+```ts
+const log = Runtime.debounce(console.log, 500)
+window.addEventListener("resize", () => log("resized"))
+```
+
+### Network & Communication
+
+Limit concurrent requests with {@link network.limitFetch}:
+
+```ts
+const response = await network.limitFetch("/api")
+```
+
+Track download progress using {@link Fetch.ProgressArrayBuffer}:
+
+```ts
+const load = Fetch.ProgressArrayBuffer(p => console.log(p))
+const buffer = await load(await fetch(url))
+```
+
+Create message channels via {@link Messenger} and build typed protocols with {@link Communicator.sender}:
+
+```ts
+const messenger = Messenger.for(new MessageChannel().port1)
+const protocol = Communicator.sender(messenger, d => ({
+  ping: () => d.dispatchAndForget(console.log, "pong")
+}))
+```
+
+### Time & Performance
+
+Estimate remaining time with {@link TimeSpanUtils.startEstimator}:
+
+```ts
+const estimate = TimeSpanUtils.startEstimator()
+console.log(estimate(0.5).toString())
+```
+
+Measure code execution using {@link stopwatch}:
+
+```ts
+const sw = stopwatch()
+sw.lab("step 1")
+```

--- a/packages/lib/runtime/src/fetch.ts
+++ b/packages/lib/runtime/src/fetch.ts
@@ -1,6 +1,20 @@
 import {asDefined, byte, ByteArrayOutput, Func, Procedure, unitValue} from "@opendaw/lib-std"
 
+/** Utilities for working with the Fetch API. */
 export namespace Fetch {
+    /**
+     * Creates a function that reads a {@link Response} into an `ArrayBuffer`
+     * while reporting download progress.
+     *
+     * @example
+     * ```ts
+     * const load = Fetch.ProgressArrayBuffer(p => console.log(p * 100))
+     * const buffer = await load(await fetch(url))
+     * ```
+     *
+     * @param progress - Callback receiving the progress as a value between `0` and `1`.
+     * @returns Function that consumes a {@link Response} and resolves with the body as `ArrayBuffer`.
+     */
     export const ProgressArrayBuffer = (progress: Procedure<unitValue>): Func<Response, Promise<ArrayBufferLike>> =>
         async (response: Response): Promise<ArrayBufferLike> => {
             if (!response.headers.has("Content-Length")) {

--- a/packages/lib/runtime/src/index.ts
+++ b/packages/lib/runtime/src/index.ts
@@ -1,3 +1,4 @@
+/** Entry point re-exporting all runtime utilities. */
 const key = Symbol.for("@openDAW/lib-runtime")
 
 if ((globalThis as any)[key]) {

--- a/packages/lib/runtime/src/messenger.ts
+++ b/packages/lib/runtime/src/messenger.ts
@@ -1,15 +1,56 @@
-import {isDefined, Notifier, Nullable, Observable, Observer, Procedure, Subscription, Terminable} from "@opendaw/lib-std"
+import { isDefined, Notifier, Nullable, Observable, Observer, Procedure, Subscription, Terminable } from "@opendaw/lib-std"
 
+/**
+ * Minimal subset of the {@link MessagePort} interface required by {@link Messenger}.
+ *
+ * @remarks
+ * The port may be a {@link Worker}, {@link MessagePort}, {@link BroadcastChannel},
+ * or any compatible object exposing `postMessage` and the event callbacks.
+ */
 export type Port = {
+    /** Sends a message through the underlying channel. */
     postMessage(message: any): void
+    /** Callback invoked when a message is received. */
     onmessage: Nullable<Procedure<MessageEvent>>
+    /** Callback invoked when an error occurs while sending a message. */
     onmessageerror: Nullable<Procedure<MessageEvent>>
 }
 
-export const Messenger = {for: (port: Port): Messenger => new NativeMessenger(port)}
+/**
+ * Factory for creating {@link Messenger} instances.
+ *
+ * @example
+ * ```ts
+ * const { port1 } = new MessageChannel()
+ * const messenger = Messenger.for(port1)
+ * messenger.send("ping")
+ * ```
+ *
+ * @param port - Communication endpoint used to exchange messages.
+ * @returns A messenger bound to the given port.
+ */
+export const Messenger = { for: (port: Port): Messenger => new NativeMessenger(port) }
 
+/**
+ * Observable wrapper around a {@link Port}.
+ *
+ * @remarks
+ * `Messenger` instances can create named sub channels using {@link Messenger.channel}
+ * to multiplex communication over the same port.
+ */
 export type Messenger = Observable<any> & Terminable & {
+    /**
+     * Sends a message through the underlying port.
+     *
+     * @param message - Arbitrary data to send.
+     */
     send(message: any): void
+    /**
+     * Creates a messenger that filters messages by channel name.
+     *
+     * @param name - Name of the sub channel.
+     * @returns New messenger bound to the given channel.
+     */
     channel(name: string): Messenger
 }
 
@@ -17,6 +58,12 @@ class NativeMessenger implements Messenger {
     readonly #port: Port
     readonly #notifier = new Notifier<any>()
 
+    /**
+     * Creates a new messenger around the provided {@link Port}.
+     * The constructor asserts that the port is not already in use.
+     *
+     * @param port - Port to wrap.
+     */
     constructor(port: Port) {
         this.#port = port
 
@@ -25,12 +72,24 @@ class NativeMessenger implements Messenger {
             throw new Error(`${port} is already wrapped.`)
         }
         port.onmessage = (event: MessageEvent) => this.#notifier.notify(event.data)
-        port.onmessageerror = (event: MessageEvent) => {throw new Error(event.type)}
+        port.onmessageerror = (event: MessageEvent) => {
+            throw new Error(event.type)
+        }
     }
 
-    send(message: any): void {this.#port.postMessage(message)}
-    channel(name: string): Messenger {return new Channel(this, name)}
-    subscribe(observer: Observer<MessageEvent>): Subscription {return this.#notifier.subscribe(observer)}
+    /** @inheritdoc */
+    send(message: any): void {
+        this.#port.postMessage(message)
+    }
+    /** @inheritdoc */
+    channel(name: string): Messenger {
+        return new Channel(this, name)
+    }
+    /** @inheritdoc */
+    subscribe(observer: Observer<MessageEvent>): Subscription {
+        return this.#notifier.subscribe(observer)
+    }
+    /** @inheritdoc */
     terminate(): void {
         this.#notifier.terminate()
         this.#port.onmessage = null
@@ -44,6 +103,10 @@ class Channel implements Messenger {
     readonly #notifier = new Notifier<any>()
     readonly #subscription: Subscription
 
+    /**
+     * @param messages - Parent messenger to forward messages through.
+     * @param name - Name of the logical sub channel.
+     */
     constructor(messages: Messenger, name: string) {
         this.#messages = messages
         this.#name = name
@@ -54,11 +117,22 @@ class Channel implements Messenger {
         })
     }
 
-    send(message: any): void {this.#messages.send({channel: this.#name, message})}
-    channel(name: string): Messenger {return new Channel(this, name)}
-    subscribe(observer: Observer<MessageEvent>): Subscription {return this.#notifier.subscribe(observer)}
+    /** @inheritdoc */
+    send(message: any): void {
+        this.#messages.send({ channel: this.#name, message })
+    }
+    /** @inheritdoc */
+    channel(name: string): Messenger {
+        return new Channel(this, name)
+    }
+    /** @inheritdoc */
+    subscribe(observer: Observer<MessageEvent>): Subscription {
+        return this.#notifier.subscribe(observer)
+    }
+    /** @inheritdoc */
     terminate(): void {
         this.#subscription.terminate()
         this.#notifier.terminate()
     }
 }
+

--- a/packages/lib/runtime/src/network.ts
+++ b/packages/lib/runtime/src/network.ts
@@ -1,8 +1,24 @@
-import {Promises} from "./promises"
+import { Promises } from "./promises"
 
+/**
+ * Network related helper functions.
+ */
 export namespace network {
     const limit = new Promises.Limit<Response>(4)
 
+    /**
+     * Fetches a resource but limits the amount of concurrent requests.
+     *
+     * @example
+     * ```ts
+     * const response = await network.limitFetch("/api/data")
+     * const json = await response.json()
+     * ```
+     *
+     * @param input - Request information passed to {@link fetch}.
+     * @param init - Optional fetch options.
+     * @returns A promise resolving to the {@link Response}.
+     */
     export const limitFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
         limit.add(() => fetch(input, init))
 }

--- a/packages/lib/runtime/src/runtime.ts
+++ b/packages/lib/runtime/src/runtime.ts
@@ -1,7 +1,23 @@
-import {Exec, Subscription} from "@opendaw/lib-std"
+import { Exec, Subscription } from "@opendaw/lib-std"
 
+/**
+ * Utilities for working with timers and the JavaScript runtime.
+ */
 export namespace Runtime {
-    // Debounces execution by delaying the call until after the timeout has passed without new invocations.
+    /**
+        * Creates a debounced function that delays invoking {@link Exec} until after
+        * `timeout` milliseconds have elapsed since the last time the debounced
+        * function was called.
+        *
+        * @param exec - Function to debounce.
+        * @param timeout - Delay in milliseconds, defaults to `1000`.
+        *
+        * @example
+        * ```ts
+        * const log = Runtime.debounce(console.log, 500)
+        * window.addEventListener("resize", () => log("resized"))
+        * ```
+        */
     export const debounce = (() => {
         let id: any = undefined
         return (exec: Exec, timeout: number = 1000) => {
@@ -10,11 +26,27 @@ export namespace Runtime {
         }
     })()
 
+    /**
+     * Executes a function repeatedly at the specified interval.
+     *
+     * @param exec - Function to invoke.
+     * @param time - Interval in milliseconds.
+     * @param args - Optional arguments passed to the function.
+     * @returns A {@link Subscription} used to cancel the interval.
+     */
     export const scheduleInterval = (exec: Exec, time: number, ...args: Array<any>): Subscription => {
         const id = setInterval(exec, time, ...args)
         return {terminate: () => clearInterval(id)}
     }
 
+    /**
+     * Executes a function once after a delay.
+     *
+     * @param exec - Function to invoke.
+     * @param time - Delay in milliseconds.
+     * @param args - Optional arguments passed to the function.
+     * @returns A {@link Subscription} used to cancel the timeout.
+     */
     export const scheduleTimeout = (exec: Exec, time: number, ...args: Array<any>): Subscription => {
         const id = setTimeout(exec, time, ...args)
         return {terminate: () => clearTimeout(id)}

--- a/packages/lib/runtime/src/stopwatch.ts
+++ b/packages/lib/runtime/src/stopwatch.ts
@@ -1,5 +1,19 @@
+/** Simple logging stopwatch. */
 interface Stopwatch {lab(label: string): void}
 
+/**
+ * Creates a {@link Stopwatch} that logs labelled laps to the console.
+ *
+ * @example
+ * ```ts
+ * const sw = stopwatch()
+ * // ...do work
+ * sw.lab("step 1")
+ * ```
+ *
+ * @param level - Console level used for logging, defaults to `"debug"`.
+ * @returns A stopwatch instance.
+ */
 export const stopwatch = (level: "debug" | "info" = "debug"): Stopwatch => {
     const startTime = performance.now()
     return {

--- a/packages/lib/runtime/src/timespan.ts
+++ b/packages/lib/runtime/src/timespan.ts
@@ -1,6 +1,20 @@
 import {Func, TimeSpan, unitValue} from "@opendaw/lib-std"
 
+/** Helpers for working with {@link TimeSpan}. */
 export namespace TimeSpanUtils {
+    /**
+     * Creates a function that estimates the remaining time of a process given
+     * the current progress.
+     *
+     * @example
+     * ```ts
+     * const estimate = TimeSpanUtils.startEstimator()
+     * // ...later
+     * console.log(estimate(0.5).toString())
+     * ```
+     *
+     * @returns Function accepting the current progress and returning the estimated {@link TimeSpan} left.
+     */
     export const startEstimator = (): Func<number, TimeSpan> => {
         const startTime: number = performance.now()
         return (progress: unitValue): TimeSpan => {

--- a/packages/lib/runtime/src/wait.ts
+++ b/packages/lib/runtime/src/wait.ts
@@ -1,22 +1,60 @@
 import {Exec, int, Observable, TimeSpan, tryCatch} from "@opendaw/lib-std"
 
+/** Utilities for waiting on various asynchronous events. */
 export namespace Wait {
+    /**
+     * Resolves on the next animation frame.
+     *
+     * @returns Promise that resolves after one frame.
+     */
     export const frame = (): Promise<void> => new Promise(resolve => requestAnimationFrame(() => resolve()))
+
+    /**
+     * Resolves after the given number of animation frames.
+     *
+     * @param numFrames - Number of frames to wait.
+     */
     export const frames = (numFrames: int): Promise<void> => new Promise(resolve => {
         let count = numFrames
         const callback = () => {if (--count <= 0) {resolve()} else {requestAnimationFrame(callback)}}
         requestAnimationFrame(callback)
     })
+
+    /**
+     * Waits for the specified {@link TimeSpan}.
+     *
+     * @param time - Duration to wait.
+     * @param args - Optional arguments forwarded to the timeout callback.
+     */
     export const timeSpan = <T>(time: TimeSpan, ...args: any[]): Promise<T> =>
         new Promise(resolve => setTimeout(resolve, time.millis(), ...args))
+
+    /**
+     * Resolves when an event is fired on the target.
+     *
+     * @param target - Event target to listen on.
+     * @param type - Event type to await.
+     */
     export const event = (target: EventTarget, type: string): Promise<void> =>
         new Promise<void>(resolve => target.addEventListener(type, resolve as Exec, {once: true}))
+
+    /**
+     * Resolves when the observable emits its next value.
+     *
+     * @param observable - Observable to subscribe to.
+     */
     export const observable = (observable: Observable<unknown>) => new Promise<void>(resolve => {
         const terminable = observable.subscribe(() => {
             terminable.terminate()
             resolve()
         })
     })
+
+    /**
+     * Runs a generator until completion, yielding control every event loop turn.
+     *
+     * @param generator - Generator to exhaust.
+     */
     export const complete = <R>(generator: Generator<unknown, R>): Promise<R> =>
         new Promise<R>((resolve, reject) => {
             const interval = setInterval(() => {


### PR DESCRIPTION
## Summary
- document runtime utilities with TSDoc comments and examples
- add README usage snippets linking to API

## Testing
- `npm test --workspace packages/lib/runtime` *(fails: vitest not found)*
- `npx -y typedoc packages/lib/runtime/src/index.ts` *(fails: missing @opendaw/lib-std and ES2015 libs)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a7c62208321bba3904dfc8eafd2