### PR TITLE
docs: add TSDoc and README for std utilities

### DIFF
--- a/packages/lib/std/README.md
+++ b/packages/lib/std/README.md
@@ -2,7 +2,9 @@ _This package is part of the openDAW SDK_
 
 # @opendaw/lib-std
 
-Standard library providing core utilities and data structures for TypeScript projects.
+A lightweight standard library offering foundational utilities, algorithms and
+data structures for TypeScript projects. Each file listed below can be imported
+individually.
 
 ## Core Utilities
 

--- a/packages/lib/std/src/arrays.ts
+++ b/packages/lib/std/src/arrays.ts
@@ -1,40 +1,92 @@
 import {asDefined, Func, int, Nullable, NumberArray, panic} from "./lang"
 
+/**
+ * Defines sort order helpers for {@link Arrays.isSorted} and other utilities.
+ */
 export enum Sorting {Ascending = 1, Descending = -1}
 
+/**
+ * Collection of helpers for working with {@link Array} instances.
+ * All functions are static and side–effect free unless otherwise stated.
+ */
 export class Arrays {
+    /** Internal empty array used by {@link Arrays.empty}. */
     static readonly #empty = Object.freeze(new Array<never>(0))
+
+    /**
+     * Returns a frozen empty array that can be reused without additional
+     * allocations.
+     */
     static readonly empty = <T>(): ReadonlyArray<T> => (() => this.#empty)()
+
+    /** Removes all elements from {@link array}. */
     static readonly clear = <T>(array: Array<T>): void => {array.length = 0}
+
+    /** Replaces the contents of {@link array} with {@link newValues}. */
     static readonly replace = <T>(array: Array<T>, newValues: Array<T>): void => {
         array.length = 0
         array.push(...newValues)
     }
+
+    /**
+     * Consumes the array by invoking {@link procedure} for each element and
+     * removing entries for which the procedure returns `true`.
+     */
     static readonly consume = <T>(array: Array<T>, procedure: Func<T, boolean>): void => {
         for (let index = 0; index < array.length;) {
             if (procedure(array[index])) {array.splice(index, 1)} else {index++}
         }
     }
+
+    /** Returns the first element or `null` if the array is empty. */
     static readonly peekFirst = <T>(array: ReadonlyArray<T>): Nullable<T> => array.at(0) ?? null
+
+    /** Returns the last element or `null` if the array is empty. */
     static readonly peekLast = <T>(array: ReadonlyArray<T>): Nullable<T> => array.at(-1) ?? null
+
+    /** Retrieves the first element and throws with {@link fail} if absent. */
     static readonly getFirst = <T>(array: ReadonlyArray<T>, fail: string): T => asDefined(array.at(0), fail)
+
+    /** Retrieves the last element and throws with {@link fail} if absent. */
     static readonly getLast = <T>(array: ReadonlyArray<T>, fail: string): T => asDefined(array.at(-1), fail)
+
+    /**
+     * Returns the element before {@link element} in {@link array}. Throws if the
+     * element cannot be found.
+     */
     static readonly getPrev = <T>(array: Array<T>, element: T): T => {
         const index: int = array.indexOf(element)
         if (index === -1) {return panic(`${element} not found in ${array}`)}
         return asDefined(array.at((index - 1) % array.length), "Internal Error")
     }
+
+    /**
+     * Returns the element after {@link element} in {@link array}. Throws if the
+     * element cannot be found.
+     */
     static readonly getNext = <T>(array: Array<T>, element: T): T => {
         const index: int = array.indexOf(element)
         if (index === -1) {return panic(`${element} not found in ${array}`)}
         return asDefined(array.at((index + 1) % array.length), "Internal Error")
     }
+
+    /** Removes and returns the last element of {@link array}. */
     static readonly removeLast = <T>(array: Array<T>, fail: string): T => asDefined(array.pop(), fail)
+
+    /**
+     * Creates a new array of length {@link n} by invoking {@link factory} for
+     * each index.
+     */
     static readonly create = <T>(factory: Func<int, T>, n: int): Array<T> => {
         const array: T[] = new Array<T>(n)
         for (let i: int = 0; i < n; i++) {array[i] = factory(i)}
         return array
     }
+
+    /**
+     * Compares two array-like objects for strict equality of all elements and
+     * length.
+     */
     static readonly equals = <T>(a: ArrayLike<T>, b: ArrayLike<T>) => {
         if (a.length !== b.length) {return false}
         for (let i = 0; i < a.length; i++) {
@@ -44,12 +96,8 @@ export class Arrays {
     }
 
     /**
-     * The satisfy method checks if all elements in a given array satisfy a provided predicate function
-     * when compared with the first element of the array. That essentially means that all tested properties
-     * in the predicate function are equal throughout the array.
-     * [1, 1, 1, 1, 1] > (a, b) => a === b returns true
-     * [1, 1, 1, 1, 2] > (a, b) => a === b returns false
-     * [1, 1, 3, 2, 1] > (a, b) => a === b returns false
+     * Checks whether all elements in {@link array} satisfy the provided
+     * {@link predicate} when compared to the first element.
      */
     static readonly satisfy = <T>(array: ReadonlyArray<T>, predicate: (a: T, b: T) => boolean): boolean => {
         if (array.length < 2) {return true}
@@ -59,18 +107,32 @@ export class Arrays {
         }
         return true
     }
+
+    /** Removes the first occurrence of {@link element} from {@link array}. */
     static readonly remove = <T>(array: Array<T>, element: T): void => {
         const index: int = array.indexOf(element)
         if (index === -1) {return panic(`${element} not found in ${array}`)}
         array.splice(index, 1)
     }
+
+    /**
+     * Removes {@link element} from {@link array} if present and returns whether
+     * a removal happened.
+     */
     static readonly removeOpt = <T>(array: Array<T>, element: T): boolean => {
         const index: int = array.indexOf(element)
         if (index === -1) {return false}
         array.splice(index, 1)
         return true
     }
+
+    /** Returns `true` if {@link array} contains duplicate values. */
     static readonly hasDuplicates = <T>(array: Array<T>): boolean => new Set<T>(array).size < array.length
+
+    /**
+     * Removes duplicate values from {@link array} in-place while preserving
+     * order.
+     */
     static readonly removeDuplicates = <T>(array: Array<T>): Array<T> => {
         let index = 0 | 0
         const result = new Set<T>()
@@ -83,6 +145,11 @@ export class Arrays {
         array.length = index
         return array
     }
+
+    /**
+     * Removes duplicates based on the value of {@link key} for each element in
+     * {@link array}.
+     */
     static readonly removeDuplicateKeys = <T, K extends keyof T>(array: Array<T>, key: K): Array<T> => {
         let index = 0 | 0
         const seen = new Set<T[K]>()
@@ -96,22 +163,36 @@ export class Arrays {
         array.length = index
         return array
     }
+
+    /** Iterates over the array yielding each element in order. */
     static* iterate<T>(array: ArrayLike<T>): Generator<T> {
         for (let i: int = 0; i < array.length; i++) {
             yield array[i]
         }
     }
+
+    /** Iterates over the array in reverse order. */
     static* iterateReverse<T>(array: ArrayLike<T>): Generator<T> {
         for (let i: int = array.length - 1; i >= 0; i--) {
             yield array[i]
         }
     }
+
+    /**
+     * Iterates over the array yielding objects that also indicate whether the
+     * current element is the first or last one.
+     */
     static* iterateStateFull<T>(array: ArrayLike<T>): Generator<{ value: T, isFirst: boolean, isLast: boolean }> {
         const maxIndex = array.length - 1
         for (let i: int = 0; i <= maxIndex; i++) {
             yield {value: array[i], isFirst: i === 0, isLast: i === maxIndex}
         }
     }
+
+    /**
+     * Determines whether the numeric {@link array} is sorted in the specified
+     * {@link sorting} order.
+     */
     static isSorted<ARRAY extends NumberArray>(array: ARRAY, sorting: Sorting = Sorting.Ascending): boolean {
         if (array.length < 2) {return true}
         let prev: number = array[0]

--- a/packages/lib/std/src/binary-search.ts
+++ b/packages/lib/std/src/binary-search.ts
@@ -1,8 +1,17 @@
 import {Comparator, Func, int} from "./lang"
 
-// https://en.wikipedia.org/wiki/Binary_search_algorithm
-//
+/**
+ * Implementation of the classic binary search algorithm operating on
+ * sorted arrays.  All comparison logic is delegated to a provided
+ * {@link Comparator} allowing use with arbitrary types.
+ *
+ * @see https://en.wikipedia.org/wiki/Binary_search_algorithm
+ */
 export namespace BinarySearch {
+    /**
+     * Searches for an exact match of {@link key} in {@link sorted} and returns
+     * its index or `-1` if the key is absent.
+     */
     export const exact = <T>(sorted: ReadonlyArray<T>, key: T, comparator: Comparator<T>): int => {
         let l: int = 0 | 0
         let r: int = sorted.length - 1
@@ -15,6 +24,10 @@ export namespace BinarySearch {
         return -1
     }
 
+    /**
+     * Variant of {@link exact} that first maps each element using
+     * {@link map} before comparison.
+     */
     export const exactMapped = <T, U>(sorted: ReadonlyArray<U>, key: T, comparator: Comparator<T>, map: Func<U, T>): int => {
         let l: int = 0 | 0
         let r: int = sorted.length - 1
@@ -27,6 +40,11 @@ export namespace BinarySearch {
         return -1
     }
 
+    /**
+     * Returns the left-most index at which {@link key} could be inserted while
+     * preserving order. When {@link key} exists, its first occurrence is
+     * returned.
+     */
     export const leftMost = <T>(sorted: ReadonlyArray<T>, key: T, comparator: Comparator<T>): int => {
         let l: int = 0 | 0
         let r: int = sorted.length
@@ -41,6 +59,10 @@ export namespace BinarySearch {
         return l
     }
 
+    /**
+     * Returns the right-most index of {@link key}. If the key does not exist the
+     * index of its floor value is returned.
+     */
     export const rightMost = <T>(sorted: ReadonlyArray<T>, key: T, comparator: Comparator<T>): int => {
         let l: int = 0 | 0
         let r: int = sorted.length
@@ -55,6 +77,9 @@ export namespace BinarySearch {
         return r - 1
     }
 
+    /**
+     * {@link leftMost} operating on mapped values.
+     */
     export const leftMostMapped =
         <T, U>(sorted: ReadonlyArray<U>, key: T, comparator: Comparator<T>, map: Func<U, T>): int => {
             let l: int = 0 | 0
@@ -70,6 +95,9 @@ export namespace BinarySearch {
             return l
         }
 
+    /**
+     * {@link rightMost} operating on mapped values.
+     */
     export const rightMostMapped =
         <T, U>(sorted: ReadonlyArray<U>, key: T, comparator: Comparator<T>, map: Func<U, T>): int => {
             let l: int = 0 | 0
@@ -85,6 +113,11 @@ export namespace BinarySearch {
             return r - 1
         }
 
+    /**
+     * Returns the range of indices `[left, right]` for all elements matching
+     * {@link key}. When the key is missing, the insertion point and floor index
+     * are returned instead.
+     */
     export const rangeMapped =
         <T, U>(sorted: ReadonlyArray<U>, key: T, comparator: Comparator<T>, map: Func<U, T>): [int, int] =>
             [leftMostMapped(sorted, key, comparator, map), rightMostMapped(sorted, key, comparator, map)]

--- a/packages/lib/std/src/cache.ts
+++ b/packages/lib/std/src/cache.ts
@@ -1,6 +1,7 @@
 import {Exec, Nullable, Provider} from "./lang"
 import {Terminable} from "./terminable"
 
+/** Simple lazy-initialising cache backed by a provider function. */
 export class Cache<T> implements Terminable {
     readonly #provider: Provider<T>
 
@@ -8,8 +9,10 @@ export class Cache<T> implements Terminable {
 
     constructor(provider: Provider<T>) {this.#provider = provider}
 
+    /** Clears the cached value. */
     readonly invalidate: Exec = () => this.#value = null
 
+    /** Returns the cached value, invoking the provider on first access. */
     get(): T {
         if (this.#value === null) {this.#value = this.#provider()}
         return this.#value

--- a/packages/lib/std/src/comparators.ts
+++ b/packages/lib/std/src/comparators.ts
@@ -1,9 +1,15 @@
 import {Comparator, int, NumberArray} from "./lang"
 
+/** Lexicographic comparator for strings. */
 export const StringComparator: Comparator<string> = (a: string, b: string): number => a > b ? 1 : b > a ? -1 : 0
 
+/** Numeric comparator returning the difference `a - b`. */
 export const NumberComparator: Comparator<number> = (a: number, b: number): number => a - b
 
+/**
+ * Compares two arrays element by element and falls back to length when all
+ * compared elements are equal.
+ */
 export const NumberArrayComparator: Comparator<NumberArray> = (a, b): number => {
     const n: int = Math.min(a.length, b.length)
     for (let i: int = 0; i < n; i++) {

--- a/packages/lib/std/src/hash.ts
+++ b/packages/lib/std/src/hash.ts
@@ -3,10 +3,14 @@ import {Crypto} from "./crypto"
 
 declare const crypto: Crypto
 
-//
-// SHA-256
-//
+/**
+ * Helper utilities around SHA‑256 hashing.  All functions operate on raw
+ * `ArrayBuffer` instances to remain platform agnostic.
+ */
 export namespace Hash {
+    /**
+     * Concatenates the given buffers and returns their SHA‑256 digest.
+     */
     export const fromBuffers = async (...buffers: ReadonlyArray<ArrayBufferLike>): Promise<ArrayBuffer> => {
         const totalLength = buffers.reduce((sum, buf) => sum + buf.byteLength, 0)
         const mergedArray = new Uint8Array(totalLength)
@@ -18,6 +22,9 @@ export namespace Hash {
         return await crypto.subtle.digest("SHA-256", mergedArray)
     }
 
+    /**
+     * Compares two SHA‑256 hashes for byte equality.
+     */
     export const equals = (a: ArrayBuffer, b: ArrayBuffer): boolean => {
         assert(a.byteLength === 32, "First hash has invalid length")
         assert(b.byteLength === 32, "Second hash has invalid length")
@@ -27,6 +34,10 @@ export namespace Hash {
         return true
     }
 
+    /**
+     * Returns a hexadecimal string representation of the hash contained in
+     * {@link buffer}.
+     */
     export const toString = (buffer: ArrayBuffer) =>
         Array.from(new Uint8Array(buffer)).map(b => b.toString(16).padStart(2, "0")).join("")
 }

--- a/packages/lib/std/src/math.ts
+++ b/packages/lib/std/src/math.ts
@@ -2,31 +2,51 @@
 
 import {int, unitValue} from "./lang"
 
+/** Two times π. */
 export const TAU = Math.PI * 2.0
+/** Half of π. */
 export const PI_HALF = Math.PI / 2.0
+/** Quarter of π. */
 export const PI_QUART = Math.PI / 4.0
+/** 1 / √2 constant. */
 export const INVERSE_SQRT_2 = 1.0 / Math.sqrt(2.0)
 
+/** Clamps {@link value} between {@link min} and {@link max}. */
 export const clamp = (value: number, min: number, max: number): number => Math.max(min, Math.min(value, max))
+/** Clamps {@link value} to the [0,1] range. */
 export const clampUnit = (value: number): unitValue => Math.max(0.0, Math.min(value, 1.0))
+/** Clamps {@link value} and adds a margin on both sides. */
 export const squashUnit = (value: unitValue, margin: unitValue): unitValue =>
     margin + (1.0 - 2.0 * margin) * Math.max(0.0, Math.min(value, 1.0))
+/** Quantizes {@link value} downwards to the nearest {@link interval}. */
 export const quantizeFloor = (value: number, interval: number): number => Math.floor(value / interval) * interval
+/** Quantizes {@link value} upwards to the nearest {@link interval}. */
 export const quantizeCeil = (value: number, interval: number): number => Math.ceil(value / interval) * interval
+/** Quantizes {@link value} to the nearest {@link interval}. */
 export const quantizeRound = (value: number, interval: number): number => Math.round(value / interval) * interval
+/** Linear interpolation. */
 export const linear = (y1: number, y2: number, mu: number): number => y1 + (y2 - y1) * mu
+/** Cosine interpolation between {@link y1} and {@link y2}. */
 export const cosine = (y1: number, y2: number, mu: number): number => {
     const mu2 = (1.0 - Math.cos(mu * Math.PI)) * 0.5
     return y1 * (1.0 - mu2) + y2 * mu2
 }
+/** Modulo that always yields a positive result. */
 export const mod = (value: number, range: number): number => fract(value / range) * range
+/** Fractional part of {@link value}. */
 export const fract = (value: number): number => value - Math.floor(value)
+/** Next power of two for {@link n}. */
 export const nextPowOf2 = (n: int): int => Math.pow(2, Math.ceil(Math.log(n) / Math.log(2)))
+/** Converts radians to degrees. */
 export const radToDeg = (rad: number): number => rad * 180.0 / Math.PI
+/** Converts degrees to radians. */
 export const degToRad = (deg: number): number => deg / 180.0 * Math.PI
 
 // Möbius-Ease Curve
 // Only produces valid values between 0 and 1 (unitValues)
 // https://www.desmos.com/calculator/ht8cytaxsz
 // The inverse is h`=1-h
+/**
+ * Möbius easing function parameterised by `h`.
+ */
 export const moebiusEase = (x: unitValue, h: unitValue): unitValue => (x * h) / ((2.0 * h - 1.0) * (x - 1.0) + h)

--- a/packages/lib/std/src/parameters.ts
+++ b/packages/lib/std/src/parameters.ts
@@ -7,6 +7,7 @@ import {clamp} from "./math"
 import {Notifier} from "./notifier"
 import {Observable, ObservableValue} from "./observables"
 
+/** Observable value that can also be represented in normalized [0,1] form. */
 export interface ObservableUnitValue extends Observable<ObservableUnitValue> {
     setUnitValue: (value: unitValue) => void
     getUnitValue: () => unitValue
@@ -14,24 +15,31 @@ export interface ObservableUnitValue extends Observable<ObservableUnitValue> {
 
 export type PrintValue = StringResult
 
+/** Observable value with a string representation. */
 export interface ObservablePrintValue extends Observable<ObservablePrintValue> {
     setPrintValue(text: string): void
     getPrintValue(): PrintValue
 }
 
+/** Sources that can influence a {@link Parameter}. */
 export type ControlSource = "automated" | "modulated" | "midi" | "external"
 
+/** Listener notified when control sources change. */
 export interface ControlSourceListener {
     onControlSourceAdd(source: ControlSource): void
     onControlSourceRemove(source: ControlSource): void
 }
 
+/** Interface describing a controllable parameter. */
 export interface Parameter<T extends Primitive = Primitive> extends ObservableValue<T>, ObservableUnitValue, ObservablePrintValue, Terminable {
     subscribe(observer: Observer<Parameter<T>>): Subscription
     catchupAndSubscribeControlSources(observer: ControlSourceListener): Subscription
 
+    /** Current value as set by control sources. */
     getControlledValue(): T
+    /** Controlled value in normalized form. */
     getControlledUnitValue(): unitValue
+    /** Controlled value as printable string. */
     getControlledPrintValue(): Readonly<StringResult>
 
     get valueMapping(): ValueMapping<T>
@@ -39,6 +47,7 @@ export interface Parameter<T extends Primitive = Primitive> extends ObservableVa
     get name(): string
 }
 
+/** Default {@link Parameter} implementation storing its value in memory. */
 export class DefaultParameter<T extends Primitive = Primitive> implements Parameter<T> {
     static percent(name: string, value: unitValue): Parameter<unitValue> {
         return new DefaultParameter<unitValue>(ValueMapping.unipolar(), StringMapping.percent(), name, value)
@@ -71,6 +80,7 @@ export class DefaultParameter<T extends Primitive = Primitive> implements Parame
     get name(): string {return this.#name}
     get resetValue(): T {return this.#resetValue}
 
+    /** Resets the parameter to its initial value. */
     reset(): void {this.setValue(this.#resetValue)}
 
     subscribe(observer: Observer<Parameter<T>>): Subscription {return this.#notifier.subscribe(observer)}
@@ -79,7 +89,9 @@ export class DefaultParameter<T extends Primitive = Primitive> implements Parame
         return this.subscribe(observer)
     }
 
+    /** Returns the raw value. */
     getValue(): T {return this.#value}
+    /** Sets the raw value, clamping via {@link valueMapping}. */
     setValue(value: T): void {
         value = this.#valueMapping.clamp(value)
         if (this.#value === value) {return}
@@ -87,10 +99,14 @@ export class DefaultParameter<T extends Primitive = Primitive> implements Parame
         this.#notifier.notify(this)
     }
 
+    /** Sets the value via normalized representation. */
     setUnitValue(value: unitValue): void {this.setValue(this.#valueMapping.y(clamp(value, 0.0, 1.0)))}
+    /** Returns the normalized value. */
     getUnitValue(): unitValue {return this.#valueMapping.x(this.#value)}
 
+    /** Printable representation of the current value. */
     getPrintValue(): Readonly<StringResult> {return this.#stringMapping.x(this.#value)}
+    /** Updates value from a string, if possible. */
     setPrintValue(text: string): void {
         const result = this.#stringMapping.y(text)
         if (result.type === "unitValue") {

--- a/packages/lib/std/src/strings.ts
+++ b/packages/lib/std/src/strings.ts
@@ -1,18 +1,25 @@
 import {isDefined, Nullish} from "./lang"
 
+/** String manipulation helpers. */
 export namespace Strings {
+    /** Converts hyphenated text to camelCase. */
     export const hyphenToCamelCase = (value: string) => value
         .replace(/-([a-z])/g, (g: string) => g[1].toUpperCase())
 
+    /** Returns {@link value} or {@link fallback} when the former is empty. */
     export const fallback = (value: Nullish<string>, fallback: string): string =>
         isDefined(value) && value.length > 0 ? value : fallback
 
+    /** Checks whether {@link str} ends with a numeric digit. */
     export const endsWithDigit = (str: string): boolean => /\d$/.test(str)
 
+    /** Ensures a trimmed, non-empty string by falling back if required. */
     export const nonEmpty = (str: Nullish<string>, fallback: string): string =>
         isDefined(str) && str.trim().length > 0 ? str : fallback
 
-    // UTF-8
+    /**
+     * Encodes {@link str} as a UTF-8 byte array wrapped in an ArrayBuffer.
+     */
     export const toArrayBuffer = (str: string): ArrayBuffer => {
         const buffer = new ArrayBuffer(str.length)
         const view = new Uint8Array(buffer)
@@ -22,6 +29,10 @@ export namespace Strings {
         return buffer
     }
 
+    /**
+     * Returns a unique name by appending a counter when {@link desiredName}
+     * already exists within {@link existingNames}.
+     */
     export const getUniqueName = (existingNames: ReadonlyArray<string>, desiredName: string): string => {
         const existingSet = new Set(existingNames)
         let test = desiredName

--- a/packages/lib/std/src/sync-stream.test.ts
+++ b/packages/lib/std/src/sync-stream.test.ts
@@ -3,10 +3,10 @@ import {ByteArrayInput, ByteArrayOutput} from "./data"
 import {SyncStream} from "./sync-stream"
 import {Schema} from "./schema"
 
-/* ------------------------------------------------------------------ *
- * Minimal stub that fulfils the Schema.IO<T> contract.
- * We serialise a single signed 32-bit integer (4 bytes).
- * ------------------------------------------------------------------ */
+/**
+ * Minimal stub that fulfils the {@link Schema.IO} contract by
+ * serialising a single signed 32-bit integer.
+ */
 type Sample = { n: number }
 
 const makeIO = (): Schema.IO<Sample> => ({


### PR DESCRIPTION
## Summary
- document core std helpers with TSDoc
- add README overview for standard library utilities

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a7e049083219bb3ba672a02884b