### PR TITLE
docs: add box forge documentation and tests

### DIFF
--- a/packages/docs/docs-dev/box-forge/examples.md
+++ b/packages/docs/docs-dev/box-forge/examples.md
@@ -1,0 +1,12 @@
+# Examples
+
+Running the forge writes TypeScript files into a target directory:
+
+```ts
+import { BoxForge } from "@opendaw/lib-box-forge";
+import schema from "./schema";
+
+await BoxForge.gen(schema);
+```
+
+See the test suite for more comprehensive scenarios.

--- a/packages/docs/docs-dev/box-forge/integration.md
+++ b/packages/docs/docs-dev/box-forge/integration.md
@@ -1,0 +1,13 @@
+# Integration
+
+Generated boxes behave like any other `@opendaw/lib-box` class. After forging, import
+them and interact with a `BoxGraph`:
+
+```ts
+import { BoxGraph } from "@opendaw/lib-box";
+import { DrumBox } from "./gen";
+
+const graph = new BoxGraph();
+const drum = DrumBox.create(graph, UUID.generate());
+drum.gain.setValue(0.5);
+```

--- a/packages/docs/docs-dev/box-forge/overview.md
+++ b/packages/docs/docs-dev/box-forge/overview.md
@@ -1,0 +1,5 @@
+# Box Forge Overview
+
+`@opendaw/lib-box-forge` compiles declarative schemas into ready-to-use Box classes.
+It automates creation of field accessors, visitors, and serialization helpers so
+that application code can focus on behaviour instead of boilerplate.

--- a/packages/docs/docs-dev/box-forge/schema-format.md
+++ b/packages/docs/docs-dev/box-forge/schema-format.md
@@ -1,0 +1,24 @@
+# Schema Format
+
+Schemas describe boxes using plain objects. Each box lists its fields and optional
+pointer rules:
+
+```ts
+import { BoxSchema } from "@opendaw/lib-box-forge";
+
+const DrumBox: BoxSchema<PointerType> = {
+  type: "box",
+  class: {
+    name: "DrumBox",
+    fields: {
+      1: { type: "float32", name: "gain" },
+      2: {
+        type: "pointer",
+        name: "output",
+        pointerType: PointerType.AudioOutput,
+        mandatory: true,
+      },
+    },
+  },
+};
+```

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -7,5 +7,15 @@ module.exports = {
     { type: "doc", id: "security-privacy" },
     { type: "doc", id: "browser-support" },
     { type: "doc", id: "licensing" },
+    {
+      type: "category",
+      label: "Box Forge",
+      items: [
+        { type: "doc", id: "box-forge/overview" },
+        { type: "doc", id: "box-forge/schema-format" },
+        { type: "doc", id: "box-forge/examples" },
+        { type: "doc", id: "box-forge/integration" },
+      ],
+    },
   ],
 };

--- a/packages/lib/box-forge/README.md
+++ b/packages/lib/box-forge/README.md
@@ -1,0 +1,28 @@
+# @opendaw/lib-box-forge
+
+Utility for generating strongly typed [Box](../box/README.md) classes from a declarative schema.
+
+## Features
+
+- Describe boxes, fields and pointer relationships in plain TypeScript objects.
+- Compile schemas into TypeScript source files with visitors and I/O helpers.
+- Ensures consistent field keys and pointer rules across boxes.
+
+## Basic Usage
+
+```ts
+import { BoxForge } from "@opendaw/lib-box-forge";
+import { PointerType } from "./Pointers";
+
+BoxForge.gen({
+  path: "./gen",
+  pointers: {
+    from: "./Pointers",
+    enum: "PointerType",
+    print: (p) => `PointerType.${PointerType[p]}`,
+  },
+  boxes: [],
+});
+```
+
+See the developer documentation under `packages/docs/docs-dev/box-forge` for more details.

--- a/packages/lib/box-forge/src/forge.ts
+++ b/packages/lib/box-forge/src/forge.ts
@@ -1,498 +1,662 @@
+/**
+ * Compiler that turns schema descriptions into concrete TypeScript box classes.
+ */
 import {
-    Arrays,
-    asDefined,
-    assert,
-    asValidIdentifier,
-    isDefined,
-    isValidIdentifier,
-    Nullable,
-    Nullish,
-    panic,
-    SetMultimap,
-    Strings,
-    Unhandled
-} from "@opendaw/lib-std"
-import {FieldKey, NoPointers, PointerRules, PointerTypes} from "@opendaw/lib-box"
-import {ModuleDeclarationKind, Project, Scope, SourceFile, VariableDeclarationKind} from "ts-morph"
-import {AnyField, BoxSchema, ClassSchema, FieldName, Referencable, Schema} from "./schema"
-import {header} from "./header"
+  Arrays,
+  asDefined,
+  assert,
+  asValidIdentifier,
+  isDefined,
+  isValidIdentifier,
+  Nullable,
+  Nullish,
+  panic,
+  SetMultimap,
+  Strings,
+  Unhandled,
+} from "@opendaw/lib-std";
+import {
+  FieldKey,
+  NoPointers,
+  PointerRules,
+  PointerTypes,
+} from "@opendaw/lib-box";
+import {
+  ModuleDeclarationKind,
+  Project,
+  Scope,
+  SourceFile,
+  VariableDeclarationKind,
+} from "ts-morph";
+import {
+  AnyField,
+  BoxSchema,
+  ClassSchema,
+  FieldName,
+  Referencable,
+  Schema,
+} from "./schema";
+import { header } from "./header";
 
-const reversed_field_names = new Set(["constructor", "pointers", "name", "address"])
+const reversed_field_names = new Set([
+  "constructor",
+  "pointers",
+  "name",
+  "address",
+]);
 
+/**
+ * Generates TypeScript source files for a given schema.
+ *
+ * @typeParam E - Pointer type enumeration used in the schema.
+ */
 export class BoxForge<E extends PointerTypes> {
-    static gen<E extends PointerTypes>(schema: Schema<E>): Promise<void> {
-        const time = Date.now()
-        console.debug(`start forging schema into ${schema.path}`)
-        const project = new Project()
-        const forge = new BoxForge<E>(project, schema, schema.path)
-        forge.#writeBoxVisitor()
-        forge.#writeBoxClasses()
-        forge.#writeBoxIndex()
-        forge.#writeBoxIO()
-        console.debug(`compiled in ${(Date.now() - time).toFixed(1)}ms`)
-        return project.save()
+  /**
+   * Compile the provided schema and write files to disk.
+   */
+  static gen<E extends PointerTypes>(schema: Schema<E>): Promise<void> {
+    const time = Date.now();
+    console.debug(`start forging schema into ${schema.path}`);
+    const project = new Project();
+    const forge = new BoxForge<E>(project, schema, schema.path);
+    forge.#writeBoxVisitor();
+    forge.#writeBoxClasses();
+    forge.#writeBoxIndex();
+    forge.#writeBoxIO();
+    console.debug(`compiled in ${(Date.now() - time).toFixed(1)}ms`);
+    return project.save();
+  }
+
+  readonly #project: Project;
+  readonly #schema: Schema<E>;
+  readonly #path: string;
+
+  readonly #written = new Map<string, ClassSchema<E>>();
+
+  private constructor(project: Project, schema: Schema<E>, path: string) {
+    this.#project = project;
+    this.#schema = schema;
+    this.#path = path;
+  }
+
+  /**
+   * Write a single class file based on the provided schema.
+   */
+  writeClass(
+    schema: ClassSchema<E>,
+    option: ClassOptions,
+    pointerRules: PointerRules<E>,
+  ): void {
+    const written: Nullish<ClassSchema<E>> = this.#written.get(schema.name);
+    if (isDefined(written)) {
+      if (written === schema) {
+        return;
+      }
+      if (JSON.stringify(written) === JSON.stringify(schema)) {
+        console.warn(
+          `we already wrote ${schema.name} with the very same properties. Consider merging.`,
+        );
+        return;
+      }
     }
+    const file: SourceFile = this.#project.createSourceFile(
+      `${this.#path}/${schema.name}.ts`,
+      header,
+    );
+    ClassWriter.write(this, file, schema, option, pointerRules);
+    this.#written.set(schema.name, schema);
+  }
 
-    readonly #project: Project
-    readonly #schema: Schema<E>
-    readonly #path: string
+  /** Access to pointer enumeration configuration. */
+  pointers(): Schema<E>["pointers"] {
+    return this.#schema.pointers;
+  }
 
-    readonly #written = new Map<string, ClassSchema<E>>()
+  #writeBoxVisitor(): void {
+    const file: SourceFile = this.#project.createSourceFile(
+      `${this.#path}/visitor.ts`,
+      header,
+    );
+    file.addImportDeclarations([
+      { moduleSpecifier: "@opendaw/lib-box", namedImports: ["VertexVisitor"] },
+      {
+        moduleSpecifier: ".",
+        namedImports: this.#schema.boxes.map(({ class: { name } }) => name),
+      },
+    ]);
+    file.addInterface({
+      name: "BoxVisitor",
+      typeParameters: ["R = void"],
+      extends: ["VertexVisitor<R>"],
+      isExported: true,
+      methods: this.#schema.boxes.map(({ class: { name } }) => ({
+        name: `visit${name}`,
+        hasQuestionToken: true,
+        parameters: [{ name: "box", type: name }],
+        returnType: "R",
+      })),
+    });
+  }
 
-    private constructor(project: Project, schema: Schema<E>, path: string) {
-        this.#project = project
-        this.#schema = schema
-        this.#path = path
-    }
+  #writeBoxClasses(): void {
+    this.#schema.boxes.forEach((box: BoxSchema<E>) =>
+      this.writeClass(
+        box.class,
+        BoxClassOption,
+        box.pointerRules ?? NoPointers,
+      ),
+    );
+  }
 
-    writeClass(schema: ClassSchema<E>, option: ClassOptions, pointerRules: PointerRules<E>): void {
-        const written: Nullish<ClassSchema<E>> = this.#written.get(schema.name)
-        if (isDefined(written)) {
-            if (written === schema) {
-                return
-            }
-            if (JSON.stringify(written) === JSON.stringify(schema)) {
-                console.warn(`we already wrote ${schema.name} with the very same properties. Consider merging.`)
-                return
-            }
-        }
-        const file: SourceFile = this.#project.createSourceFile(`${this.#path}/${schema.name}.ts`, header)
-        ClassWriter.write(this, file, schema, option, pointerRules)
-        this.#written.set(schema.name, schema)
-    }
+  #writeBoxIndex(): void {
+    const file: SourceFile = this.#project.createSourceFile(
+      `${this.#path}/index.ts`,
+      header,
+    );
+    file.addStatements(`export * from "./io"`);
+    file.addStatements(`export * from "./visitor"`);
+    this.#schema.boxes.forEach((box) =>
+      file.addStatements(`export * from "./${box.class.name}"`),
+    );
+    this.#written.forEach((_, name) =>
+      file.addStatements(`export * from "./${name}"`),
+    );
+  }
 
-    pointers(): Schema<E>["pointers"] {return this.#schema.pointers}
+  #writeBoxIO(): void {
+    const file: SourceFile = this.#project.createSourceFile(
+      `${this.#path}/io.ts`,
+      header,
+    );
+    const boxes = this.#schema.boxes;
+    file.addImportDeclarations([
+      {
+        moduleSpecifier: ".",
+        namedImports: boxes.map(({ class: { name } }) => name),
+      },
+      {
+        moduleSpecifier: STD_LIBRARY,
+        namedImports: ["ByteArrayInput", "panic", "Procedure", "UUID"],
+      },
+      { moduleSpecifier: BOX_LIBRARY, namedImports: ["BoxGraph", "Box"] },
+    ]);
+    const module = file.addModule({
+      name: "BoxIO",
+      isExported: true,
+      declarationKind: ModuleDeclarationKind.Namespace,
+    });
+    module.addInterface({
+      isExported: true,
+      name: "TypeMap",
+      properties: boxes.map(({ class: { name } }) => ({
+        name: `'${name}'`,
+        type: name,
+      })),
+    });
 
-    #writeBoxVisitor(): void {
-        const file: SourceFile = this.#project.createSourceFile(`${this.#path}/visitor.ts`, header)
-        file.addImportDeclarations([
-            {moduleSpecifier: "@opendaw/lib-box", namedImports: ["VertexVisitor"]},
-            {moduleSpecifier: ".", namedImports: this.#schema.boxes.map(({class: {name}}) => name)}
-        ])
-        file.addInterface({
-            name: "BoxVisitor",
-            typeParameters: ["R = void"],
-            extends: ["VertexVisitor<R>"],
-            isExported: true,
-            methods: this.#schema.boxes.map(({class: {name}}) => ({
-                name: `visit${name}`,
-                hasQuestionToken: true,
-                parameters: [{name: "box", type: name}],
-                returnType: "R"
-            }))
-        })
-    }
-
-    #writeBoxClasses(): void {
-        this.#schema.boxes.forEach((box: BoxSchema<E>) =>
-            this.writeClass(box.class, BoxClassOption, box.pointerRules ?? NoPointers))
-    }
-
-    #writeBoxIndex(): void {
-        const file: SourceFile = this.#project.createSourceFile(`${this.#path}/index.ts`, header)
-        file.addStatements(`export * from "./io"`)
-        file.addStatements(`export * from "./visitor"`)
-        this.#schema.boxes.forEach(box => file.addStatements(`export * from "./${box.class.name}"`))
-        this.#written.forEach((_, name) => file.addStatements(`export * from "./${name}"`))
-    }
-
-    #writeBoxIO(): void {
-        const file: SourceFile = this.#project.createSourceFile(`${this.#path}/io.ts`, header)
-        const boxes = this.#schema.boxes
-        file.addImportDeclarations([
-            {moduleSpecifier: ".", namedImports: boxes.map(({class: {name}}) => name)},
-            {moduleSpecifier: STD_LIBRARY, namedImports: ["ByteArrayInput", "panic", "Procedure", "UUID"]},
-            {moduleSpecifier: BOX_LIBRARY, namedImports: ["BoxGraph", "Box"]}
-        ])
-        const module = file.addModule({
-            name: "BoxIO",
-            isExported: true,
-            declarationKind: ModuleDeclarationKind.Namespace
-        })
-        module.addInterface({
-            isExported: true,
-            name: "TypeMap",
-            properties: boxes.map(({class: {name}}) => ({name: `'${name}'`, type: name}))
-        })
-
-        module.addVariableStatement({
-            isExported: true,
-            declarationKind: VariableDeclarationKind.Const,
-            declarations: [{
-                name: "create",
-                initializer: `<K extends keyof TypeMap, V extends TypeMap[K]>(
+    module.addVariableStatement({
+      isExported: true,
+      declarationKind: VariableDeclarationKind.Const,
+      declarations: [
+        {
+          name: "create",
+          initializer: `<K extends keyof TypeMap, V extends TypeMap[K]>(
 					name: K, graph: BoxGraph<TypeMap>, uuid: UUID.Format, constructor?: Procedure<V>): V => {
-      				switch (name) {${boxes.map(({class: {name}}) =>
-                    `case "${name}": return ${name}.create(graph, uuid, constructor as Procedure<${name}>) as V`).join("\n")}
+      				switch (name) {${boxes
+                .map(
+                  ({ class: { name } }) =>
+                    `case "${name}": return ${name}.create(graph, uuid, constructor as Procedure<${name}>) as V`,
+                )
+                .join("\n")}
 				default: return panic(\`Unknown box class '\${name}'\`)
-				}}`
-            }]
-        })
-        module.addVariableStatement({
-            isExported: true,
-            declarationKind: VariableDeclarationKind.Const,
-            declarations: [{
-                name: "deserialize",
-                initializer: `(graph: BoxGraph, buffer: ArrayBuffer): Box => {
+				}}`,
+        },
+      ],
+    });
+    module.addVariableStatement({
+      isExported: true,
+      declarationKind: VariableDeclarationKind.Const,
+      declarations: [
+        {
+          name: "deserialize",
+          initializer: `(graph: BoxGraph, buffer: ArrayBuffer): Box => {
 								const stream = new ByteArrayInput(buffer)
 								const className = stream.readString() as keyof TypeMap
 								const uuidBytes = UUID.fromDataInput(stream)
 								const box = create(className, graph, uuidBytes)
 								box.read(stream)
 								return box
-							}`
-            }]
-        })
-    }
+							}`,
+        },
+      ],
+    });
+  }
 }
 
-const STD_LIBRARY = "@opendaw/lib-std" as const
-const BOX_LIBRARY = "@opendaw/lib-box" as const
+const STD_LIBRARY = "@opendaw/lib-std" as const;
+const BOX_LIBRARY = "@opendaw/lib-box" as const;
 
+/** Options describing how to emit a generated class. */
 type ClassOptions = Readonly<{
-    import_std_lib: string[]
-    import_box_lib: string[]
-    extends: "Box" | "ObjectField"
-    construct: "BoxConstruct" | "FieldConstruct"
-    isBox: boolean
-}>
+  import_std_lib: string[];
+  import_box_lib: string[];
+  extends: "Box" | "ObjectField";
+  construct: "BoxConstruct" | "FieldConstruct";
+  isBox: boolean;
+}>;
 
+/** Default options used when generating Box subclasses. */
 export const BoxClassOption: ClassOptions = {
-    import_std_lib: ["Nullish", "safeExecute", "UUID"],
-    import_box_lib: ["Box", "BoxConstruct", "BoxGraph"],
-    extends: "Box",
-    construct: "BoxConstruct",
-    isBox: true
-}
+  import_std_lib: ["Nullish", "safeExecute", "UUID"],
+  import_box_lib: ["Box", "BoxConstruct", "BoxGraph"],
+  extends: "Box",
+  construct: "BoxConstruct",
+  isBox: true,
+};
 
+/** Options for generating ObjectField subclasses. */
 export const FieldClassOption: ClassOptions = {
-    import_std_lib: [],
-    import_box_lib: ["ObjectField", "FieldConstruct"],
-    extends: "ObjectField",
-    construct: "FieldConstruct",
-    isBox: false
-}
+  import_std_lib: [],
+  import_box_lib: ["ObjectField", "FieldConstruct"],
+  extends: "ObjectField",
+  construct: "FieldConstruct",
+  isBox: false,
+};
 
 type FieldPrinter = Readonly<{
-    fieldKey: FieldKey
-    fieldName: string
-    fieldValue?: string | number | boolean | Int8Array
-    importPath: string
-    className: string
-    new: string
-    type: string
-    ctorParams: ReadonlyArray<string | number | boolean | Int8Array | undefined>
-}>
+  fieldKey: FieldKey;
+  fieldName: string;
+  fieldValue?: string | number | boolean | Int8Array;
+  importPath: string;
+  className: string;
+  new: string;
+  type: string;
+  ctorParams: ReadonlyArray<string | number | boolean | Int8Array | undefined>;
+}>;
 
 type PointerRulesPrinter = Readonly<{
-    isEmpty: boolean
-    union: string
-    array: string
-    mandatory: boolean
-}>
+  isEmpty: boolean;
+  union: string;
+  array: string;
+  mandatory: boolean;
+}>;
 
+/** Mapping of primitive schema identifiers to field class names. */
 export const PrimitiveFields = Object.freeze({
-    int32: "Int32Field",
-    float32: "Float32Field",
-    boolean: "BooleanField",
-    string: "StringField",
-    bytes: "ByteArrayField"
-})
+  int32: "Int32Field",
+  float32: "Float32Field",
+  boolean: "BooleanField",
+  string: "StringField",
+  bytes: "ByteArrayField",
+});
 
 class ClassWriter<E extends PointerTypes> {
-    static write<E extends PointerTypes>(
-        generator: BoxForge<E>,
-        file: SourceFile,
-        schema: ClassSchema<E>,
-        option: ClassOptions,
-        edges: PointerRules<E>): void {
-        const writer = new ClassWriter<E>(generator, file, schema, option, edges)
-        writer.#writeFieldsType()
-        writer.#writeClass()
-        writer.#writeImports()
+  static write<E extends PointerTypes>(
+    generator: BoxForge<E>,
+    file: SourceFile,
+    schema: ClassSchema<E>,
+    option: ClassOptions,
+    edges: PointerRules<E>,
+  ): void {
+    const writer = new ClassWriter<E>(generator, file, schema, option, edges);
+    writer.#writeFieldsType();
+    writer.#writeClass();
+    writer.#writeImports();
+  }
+
+  readonly #generator: BoxForge<E>;
+  readonly #file: SourceFile;
+  readonly #schema: ClassSchema<E>;
+  readonly #option: ClassOptions;
+  readonly #pointerRules: PointerRules<E>;
+
+  readonly #imports: SetMultimap<string, string>;
+  readonly #fieldPrinter: ReadonlyArray<FieldPrinter>;
+
+  #usesPointerType: boolean = false;
+
+  private constructor(
+    generator: BoxForge<E>,
+    file: SourceFile,
+    schema: ClassSchema<E>,
+    option: ClassOptions,
+    pointerRules: PointerRules<E>,
+  ) {
+    this.#generator = generator;
+    this.#file = file;
+    this.#schema = schema;
+    this.#option = option;
+    this.#pointerRules = pointerRules;
+
+    this.#imports = new SetMultimap<string, string>([
+      [STD_LIBRARY, option.import_std_lib],
+      [BOX_LIBRARY, option.import_box_lib],
+    ]);
+    assert(
+      !Arrays.hasDuplicates(Object.keys(schema.fields)),
+      `${schema.name} has duplicate field keys.`,
+    );
+    assert(
+      !Arrays.hasDuplicates(
+        Object.values(schema.fields).map((field) => field.name),
+      ),
+      `${schema.name} has duplicate field names.`,
+    );
+    this.#fieldPrinter = Object.entries(schema.fields)
+      .map(([key, value]) => this.#printField(Number(key), value)!)
+      .filter((field) => isDefined(field));
+    this.#fieldPrinter.forEach((fields) =>
+      this.#imports.add(fields.importPath, fields.className),
+    );
+  }
+
+  #writeFieldsType(): void {
+    this.#file.addTypeAlias({
+      isExported: true,
+      name: this.#fieldsTypeName(),
+      type: `{${this.#fieldPrinter
+        .map((print) =>
+          isDefined(print.fieldValue)
+            ? `${print.fieldKey}: /* ${print.fieldName}: ${print.fieldValue} */ ${print.type}`
+            : `${print.fieldKey}: /* ${print.fieldName} */ ${print.type}`,
+        )
+        .join("\n")}
+				}`,
+    });
+  }
+
+  #writeClass(): void {
+    const {
+      union: edgesUnion,
+      array: edgesArray,
+      isEmpty: noEdgeConstrains,
+      mandatory: edgeMandatory,
+    } = this.#printPointerTypes(this.#pointerRules);
+    const className = this.#schema.name;
+    const fieldsType = this.#fieldsTypeName();
+    const declaration = this.#file.addClass({
+      isExported: true,
+      name: className,
+      extends: this.#option.isBox
+        ? `${this.#option.extends}<${edgesUnion}, ${fieldsType}>`
+        : `${this.#option.extends}<${fieldsType}>`,
+    });
+    if (noEdgeConstrains) {
+      this.#imports.add("@opendaw/lib-box", "UnreferenceableType");
     }
-
-    readonly #generator: BoxForge<E>
-    readonly #file: SourceFile
-    readonly #schema: ClassSchema<E>
-    readonly #option: ClassOptions
-    readonly #pointerRules: PointerRules<E>
-
-    readonly #imports: SetMultimap<string, string>
-    readonly #fieldPrinter: ReadonlyArray<FieldPrinter>
-
-    #usesPointerType: boolean = false
-
-    private constructor(
-        generator: BoxForge<E>,
-        file: SourceFile,
-        schema: ClassSchema<E>,
-        option: ClassOptions,
-        pointerRules: PointerRules<E>) {
-        this.#generator = generator
-        this.#file = file
-        this.#schema = schema
-        this.#option = option
-        this.#pointerRules = pointerRules
-
-        this.#imports = new SetMultimap<string, string>([
-            [STD_LIBRARY, option.import_std_lib],
-            [BOX_LIBRARY, option.import_box_lib]
-        ])
-        assert(!Arrays.hasDuplicates(Object.keys(schema.fields)),
-            `${schema.name} has duplicate field keys.`)
-        assert(!Arrays.hasDuplicates(Object.values(schema.fields).map(field => field.name)),
-            `${schema.name} has duplicate field names.`)
-        this.#fieldPrinter = Object.entries(schema.fields)
-            .map(([key, value]) => this.#printField(Number(key), value)!)
-            .filter(field => isDefined(field))
-        this.#fieldPrinter.forEach(fields => this.#imports.add(fields.importPath, fields.className))
+    if (this.#option.isBox) {
+      let pointerRules;
+      if (noEdgeConstrains) {
+        this.#imports.add(BOX_LIBRARY, "NoPointers");
+        pointerRules = "NoPointers";
+      } else {
+        pointerRules = `{accepts: [${edgesArray}], mandatory: ${edgeMandatory}}`;
+      }
+      this.#imports.addAll(STD_LIBRARY, ["Procedure", "safeExecute"]);
+      declaration.addMethod({
+        name: "create",
+        isStatic: true,
+        parameters: [
+          { name: "graph", type: "BoxGraph" },
+          { name: "uuid", type: "UUID.Format" },
+          {
+            name: "constructor",
+            type: `Procedure<${className}>`,
+            hasQuestionToken: true,
+          },
+        ],
+        statements: `return graph.stageBox(new ${className}({uuid, graph, name: "${className}", pointerRules: ${pointerRules}}), constructor)`,
+        returnType: className,
+      });
+    } else {
+      declaration.addMethod({
+        name: "create",
+        isStatic: true,
+        parameters: [
+          { name: "construct", type: "FieldConstruct<UnreferenceableType>" },
+        ],
+        statements: `return new ${className}(construct)`,
+        returnType: className,
+      });
     }
-
-    #writeFieldsType(): void {
-        this.#file.addTypeAlias({
-            isExported: true,
-            name: this.#fieldsTypeName(),
-            type: `{${this.#fieldPrinter.map(print =>
-                isDefined(print.fieldValue)
-                    ? `${print.fieldKey}: /* ${print.fieldName}: ${print.fieldValue} */ ${print.type}`
-                    : `${print.fieldKey}: /* ${print.fieldName} */ ${print.type}`).join("\n")}
-				}`
-        })
+    declaration.addConstructor({
+      scope: Scope.Private,
+      parameters: [
+        {
+          name: "construct",
+          type: `${this.#option.construct}<${edgesUnion}>`,
+        },
+      ],
+      statements: "super(construct)",
+    });
+    if (this.#option.isBox) {
+      this.#imports.add(".", "BoxVisitor");
+      declaration.addMethod({
+        name: "accept",
+        typeParameters: ["R"],
+        parameters: [{ name: "visitor", type: "BoxVisitor<R>" }],
+        returnType: "Nullish<R>",
+        statements: `return safeExecute(visitor.visit${className}, this)`,
+      });
     }
+    declaration.addGetAccessors(
+      this.#fieldPrinter.map((printer) => ({
+        name: asDefined(
+          printer.fieldName,
+          "accessible fields must have a name",
+        ),
+        returnType: printer.type,
+        statements: `return this.getField(${printer.fieldKey})`,
+      })),
+    );
+    declaration.addMethod({
+      name: "initializeFields",
+      statements: `return {${this.#fieldPrinter.map(
+        (printer) =>
+          `${printer.fieldKey}: ${printer.new}(${printer.ctorParams.join(",")})`,
+      )}}`,
+      returnType: fieldsType,
+    });
+  }
 
-    #writeClass(): void {
-        const {
-            union: edgesUnion,
-            array: edgesArray,
-            isEmpty: noEdgeConstrains,
-            mandatory: edgeMandatory
-        } = this.#printPointerTypes(this.#pointerRules)
-        const className = this.#schema.name
-        const fieldsType = this.#fieldsTypeName()
-        const declaration = this.#file.addClass({
-            isExported: true,
-            name: className,
-            extends: this.#option.isBox
-                ? `${this.#option.extends}<${edgesUnion}, ${fieldsType}>`
-                : `${this.#option.extends}<${fieldsType}>`
-        })
-        if (noEdgeConstrains) {
-            this.#imports.add("@opendaw/lib-box", "UnreferenceableType")
+  #fieldsTypeName(): string {
+    return `${this.#schema.name}Fields`;
+  }
+
+  #toValidIdentifier(identifier: string): string {
+    return isValidIdentifier(identifier)
+      ? identifier
+      : asValidIdentifier(Strings.hyphenToCamelCase(identifier));
+  }
+
+  #printField(
+    fieldKey: FieldKey,
+    field: AnyField<E> | (AnyField<E> & FieldName),
+  ): Nullable<FieldPrinter> {
+    const fieldName =
+      "name" in field ? this.#toValidIdentifier(field.name) : String(fieldKey);
+    if (reversed_field_names.has(fieldName)) {
+      return panic(`${fieldName} is a reserved keyword`);
+    }
+    const pointerRules = this.#printReferencablePointerRules(field);
+    const type = field.type;
+    switch (type) {
+      case "field":
+        assert(!pointerRules.isEmpty, "A field must have pointers");
+        return {
+          fieldKey,
+          fieldName,
+          importPath: BOX_LIBRARY,
+          className: "Field",
+          ctorParams: [
+            this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
+          ],
+          new: "Field.hook",
+          type: `Field<${pointerRules.union}>`,
+        };
+      case "int32":
+      case "float32":
+      case "boolean":
+      case "string":
+      case "bytes":
+        const className = asDefined(
+          PrimitiveFields[type],
+          `Unknown type: ${type}`,
+        );
+        return {
+          fieldKey,
+          fieldName,
+          fieldValue: field.value,
+          importPath: BOX_LIBRARY,
+          className,
+          new: `${className}.create`,
+          type: pointerRules.isEmpty
+            ? `${className}`
+            : `${className}<${pointerRules.union}>`,
+          ctorParams: [
+            this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
+            type === "string"
+              ? field.value === undefined
+                ? ""
+                : `"${field.value}"`
+              : field.value,
+          ],
+        };
+      case "pointer":
+        this.#usesPointerType = true;
+        return {
+          fieldKey,
+          fieldName,
+          importPath: BOX_LIBRARY,
+          className: "PointerField",
+          new: "PointerField.create",
+          type: `PointerField<${this.#generator.pointers().print(field.pointerType)}>`,
+          ctorParams: [
+            this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
+            this.#generator.pointers().print(field.pointerType),
+            String(field.mandatory),
+          ],
+        };
+      case "array":
+        const element = this.#printField(fieldKey, field.element);
+        if (!isDefined(element)) {
+          return null;
         }
-        if (this.#option.isBox) {
-            let pointerRules
-            if (noEdgeConstrains) {
-                this.#imports.add(BOX_LIBRARY, "NoPointers")
-                pointerRules = "NoPointers"
-            } else {
-                pointerRules = `{accepts: [${edgesArray}], mandatory: ${edgeMandatory}}`
-            }
-            this.#imports.addAll(STD_LIBRARY, ["Procedure", "safeExecute"])
-            declaration.addMethod({
-                name: "create",
-                isStatic: true,
-                parameters: [
-                    {name: "graph", type: "BoxGraph"},
-                    {name: "uuid", type: "UUID.Format"},
-                    {name: "constructor", type: `Procedure<${className}>`, hasQuestionToken: true}
-                ],
-                statements: `return graph.stageBox(new ${className}({uuid, graph, name: "${className}", pointerRules: ${pointerRules}}), constructor)`,
-                returnType: className
-            })
-        } else {
-            declaration.addMethod({
-                name: "create",
-                isStatic: true,
-                parameters: [{name: "construct", type: "FieldConstruct<UnreferenceableType>"}],
-                statements: `return new ${className}(construct)`,
-                returnType: className
-            })
-        }
-        declaration.addConstructor({
-            scope: Scope.Private,
-            parameters: [{
-                name: "construct",
-                type: `${this.#option.construct}<${edgesUnion}>`
-            }],
-            statements: "super(construct)"
-        })
-        if (this.#option.isBox) {
-            this.#imports.add(".", "BoxVisitor")
-            declaration.addMethod({
-                name: "accept",
-                typeParameters: ["R"],
-                parameters: [{name: "visitor", type: "BoxVisitor<R>"}],
-                returnType: "Nullish<R>",
-                statements: `return safeExecute(visitor.visit${className}, this)`
-            })
-        }
-        declaration.addGetAccessors(this.#fieldPrinter.map(printer => ({
-            name: asDefined(printer.fieldName, "accessible fields must have a name"),
-            returnType: printer.type,
-            statements: `return this.getField(${printer.fieldKey})`
-        })))
-        declaration.addMethod({
-            name: "initializeFields",
-            statements: `return {${this.#fieldPrinter.map(printer =>
-                `${printer.fieldKey}: ${printer.new}(${printer.ctorParams.join(",")})`)}}`,
-            returnType: fieldsType
-        })
+        this.#imports.add(element.importPath, element.className);
+        const elementEdgeConstrainsPrinter =
+          this.#printReferencablePointerRules(field.element);
+        return {
+          fieldKey,
+          fieldName,
+          importPath: BOX_LIBRARY,
+          className: "ArrayField",
+          new: "ArrayField.create",
+          type: `ArrayField<${element.type}>`,
+          ctorParams: [
+            this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
+            elementEdgeConstrainsPrinter.isEmpty
+              ? `construct => ${element.new}(${[
+                  "construct",
+                  ...element.ctorParams.slice(1),
+                ]})`
+              : `construct => ${element.new}(${[
+                  `{...construct, ${this.#writeEdgeProperty(elementEdgeConstrainsPrinter)}}`,
+                  ...element.ctorParams.slice(1),
+                ]})`,
+            field.length,
+          ],
+        };
+      case "object": {
+        this.#generator.writeClass(field.class, FieldClassOption, NoPointers);
+        const className = field.class.name;
+        return {
+          fieldKey,
+          fieldName,
+          importPath: `./${className}`,
+          className,
+          new: `${className}.create`,
+          type: className,
+          ctorParams: [
+            this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
+          ],
+        };
+      }
+      case "reserved":
+        return null;
+      default:
+        return Unhandled(type);
     }
+  }
 
-    #fieldsTypeName(): string {return `${this.#schema.name}Fields`}
-
-    #toValidIdentifier(identifier: string): string {
-        return isValidIdentifier(identifier) ? identifier : asValidIdentifier(Strings.hyphenToCamelCase(identifier))
+  #writeFieldConstruct(
+    fieldKey: FieldKey,
+    fieldName: string,
+    { array, mandatory, isEmpty }: PointerRulesPrinter,
+  ): string {
+    let pointerRules: string;
+    if (isEmpty) {
+      this.#imports.add(BOX_LIBRARY, "NoPointers");
+      pointerRules = "pointerRules: NoPointers";
+    } else {
+      pointerRules = `pointerRules: {accepts: [${array}], mandatory: ${mandatory}}`;
     }
+    return `{${[`parent: this`, `fieldKey: ${fieldKey}`, `fieldName: "${fieldName}"`, pointerRules].join(",")}}`;
+  }
 
-    #printField(fieldKey: FieldKey, field: AnyField<E> | (AnyField<E> & FieldName)): Nullable<FieldPrinter> {
-        const fieldName = "name" in field ? this.#toValidIdentifier(field.name) : String(fieldKey)
-        if (reversed_field_names.has(fieldName)) {
-            return panic(`${fieldName} is a reserved keyword`)
-        }
-        const pointerRules = this.#printReferencablePointerRules(field)
-        const type = field.type
-        switch (type) {
-            case "field":
-                assert(!pointerRules.isEmpty, "A field must have pointers")
-                return {
-                    fieldKey,
-                    fieldName,
-                    importPath: BOX_LIBRARY,
-                    className: "Field",
-                    ctorParams: [this.#writeFieldConstruct(fieldKey, fieldName, pointerRules)],
-                    new: "Field.hook",
-                    type: `Field<${pointerRules.union}>`
-                }
-            case "int32":
-            case "float32":
-            case "boolean":
-            case "string":
-            case "bytes":
-                const className = asDefined(PrimitiveFields[type], `Unknown type: ${type}`)
-                return {
-                    fieldKey,
-                    fieldName,
-                    fieldValue: field.value,
-                    importPath: BOX_LIBRARY,
-                    className,
-                    new: `${className}.create`,
-                    type: pointerRules.isEmpty ? `${className}` : `${className}<${pointerRules.union}>`,
-                    ctorParams: [this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
-                        type === "string" ? field.value === undefined ? "" : `"${field.value}"` : field.value]
-                }
-            case "pointer":
-                this.#usesPointerType = true
-                return {
-                    fieldKey,
-                    fieldName,
-                    importPath: BOX_LIBRARY,
-                    className: "PointerField",
-                    new: "PointerField.create",
-                    type: `PointerField<${(this.#generator.pointers().print(field.pointerType))}>`,
-                    ctorParams: [
-                        this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
-                        this.#generator.pointers().print(field.pointerType),
-                        String(field.mandatory)
-                    ]
-                }
-            case "array":
-                const element = this.#printField(fieldKey, field.element)
-                if (!isDefined(element)) {return null}
-                this.#imports.add(element.importPath, element.className)
-                const elementEdgeConstrainsPrinter = this.#printReferencablePointerRules(field.element)
-                return {
-                    fieldKey,
-                    fieldName,
-                    importPath: BOX_LIBRARY,
-                    className: "ArrayField",
-                    new: "ArrayField.create",
-                    type: `ArrayField<${element.type}>`,
-                    ctorParams: [
-                        this.#writeFieldConstruct(fieldKey, fieldName, pointerRules),
-                        elementEdgeConstrainsPrinter.isEmpty
-                            ? `construct => ${element.new}(${["construct",
-                                ...element.ctorParams.slice(1)]})`
-                            : `construct => ${element.new}(${[
-                                `{...construct, ${this.#writeEdgeProperty(elementEdgeConstrainsPrinter)}}`,
-                                ...element.ctorParams.slice(1)
-                            ]})`,
-                        field.length
-                    ]
-                }
-            case "object": {
-                this.#generator.writeClass(field.class, FieldClassOption, NoPointers)
-                const className = field.class.name
-                return {
-                    fieldKey,
-                    fieldName,
-                    importPath: `./${className}`,
-                    className,
-                    new: `${className}.create`,
-                    type: className,
-                    ctorParams: [this.#writeFieldConstruct(fieldKey, fieldName, pointerRules)]
-                }
-            }
-            case "reserved":
-                return null
-            default:
-                return Unhandled(type)
-        }
+  #writeEdgeProperty({
+    array,
+    mandatory,
+    isEmpty,
+  }: PointerRulesPrinter): string {
+    if (isEmpty) {
+      this.#imports.add(BOX_LIBRARY, "NoPointers");
+      return "pointerRules: NoPointers";
+    } else {
+      return `pointerRules: {accepts: [${array}], mandatory: ${mandatory}}`;
     }
+  }
 
-    #writeFieldConstruct(fieldKey: FieldKey, fieldName: string, {
-        array,
-        mandatory,
-        isEmpty
-    }: PointerRulesPrinter): string {
-        let pointerRules: string
-        if (isEmpty) {
-            this.#imports.add(BOX_LIBRARY, "NoPointers")
-            pointerRules = "pointerRules: NoPointers"
-        } else {
-            pointerRules = `pointerRules: {accepts: [${array}], mandatory: ${mandatory}}`
-        }
-        return `{${[`parent: this`, `fieldKey: ${fieldKey}`, `fieldName: "${fieldName}"`, pointerRules].join(",")}}`
-    }
+  #printReferencablePointerRules(
+    maybeReferencable: Referencable<E> | AnyField<E>,
+  ): PointerRulesPrinter {
+    return this.#printPointerTypes(
+      "pointerRules" in maybeReferencable
+        ? maybeReferencable.pointerRules
+        : undefined,
+    );
+  }
 
-    #writeEdgeProperty({array, mandatory, isEmpty}: PointerRulesPrinter): string {
-        if (isEmpty) {
-            this.#imports.add(BOX_LIBRARY, "NoPointers")
-            return "pointerRules: NoPointers"
-        } else {
-            return `pointerRules: {accepts: [${array}], mandatory: ${mandatory}}`
-        }
+  #printPointerTypes(rules?: PointerRules<E>): PointerRulesPrinter {
+    if (isDefined(rules) && rules.accepts.length > 0) {
+      const types = rules.accepts.map((edge) =>
+        this.#generator.pointers().print(edge),
+      );
+      this.#usesPointerType = true;
+      return {
+        isEmpty: false,
+        union: types.join("|"),
+        array: types.join(","),
+        mandatory: rules.mandatory,
+      };
     }
+    return {
+      isEmpty: true,
+      union: "UnreferenceableType",
+      array: "",
+      mandatory: false,
+    };
+  }
 
-    #printReferencablePointerRules(maybeReferencable: Referencable<E> | AnyField<E>): PointerRulesPrinter {
-        return this.#printPointerTypes("pointerRules" in maybeReferencable
-            ? maybeReferencable.pointerRules
-            : undefined)
+  #writeImports(): void {
+    if (this.#usesPointerType) {
+      const pointers = this.#generator.pointers();
+      this.#imports.add(pointers.from, pointers.enum);
     }
-
-    #printPointerTypes(rules?: PointerRules<E>): PointerRulesPrinter {
-        if (isDefined(rules) && rules.accepts.length > 0) {
-            const types = rules.accepts.map(edge => this.#generator.pointers().print(edge))
-            this.#usesPointerType = true
-            return {
-                isEmpty: false,
-                union: types.join("|"),
-                array: types.join(","),
-                mandatory: rules.mandatory
-            }
-        }
-        return {isEmpty: true, union: "UnreferenceableType", array: "", mandatory: false}
-    }
-
-    #writeImports(): void {
-        if (this.#usesPointerType) {
-            const pointers = this.#generator.pointers()
-            this.#imports.add(pointers.from, pointers.enum)
-        }
-        this.#imports.forEach((moduleSpecifier, namedImports) =>
-            this.#file.addImportDeclaration({
-                moduleSpecifier, namedImports: Array.from(namedImports)
-            }))
-    }
+    this.#imports.forEach((moduleSpecifier, namedImports) =>
+      this.#file.addImportDeclaration({
+        moduleSpecifier,
+        namedImports: Array.from(namedImports),
+      }),
+    );
+  }
 }

--- a/packages/lib/box-forge/src/header.ts
+++ b/packages/lib/box-forge/src/header.ts
@@ -1,3 +1,7 @@
+/**
+ * Header banner inserted at the top of each generated file. Includes project
+ * branding and a note that the source is auto-generated.
+ */
 export const header = `
 //
 //   ___          ___                 
@@ -8,4 +12,4 @@ export const header = `
 //
 //  auto-generated | do not edit | blame andre.michelle@opendaw.org
 //
-` as const
+` as const;

--- a/packages/lib/box-forge/src/index.ts
+++ b/packages/lib/box-forge/src/index.ts
@@ -1,2 +1,7 @@
-export * from "./schema"
-export * from "./forge"
+/**
+ * @packageDocumentation
+ * Entry point for Box Forge utilities. Re-exports schema helpers and the
+ * {@link BoxForge} compiler.
+ */
+export * from "./schema";
+export * from "./forge";

--- a/packages/lib/box-forge/src/schema.ts
+++ b/packages/lib/box-forge/src/schema.ts
@@ -1,78 +1,129 @@
-import {float, Func, int, Objects} from "@opendaw/lib-std"
-import {FieldKey, PointerRules, PointerTypes} from "@opendaw/lib-box"
+/**
+ * Schema definitions used by {@link BoxForge} to generate strongly-typed box
+ * classes. These types describe the shape of boxes, fields and pointer
+ * relations in a declarative manner.
+ */
+import { float, Func, int, Objects } from "@opendaw/lib-std";
+import { FieldKey, PointerRules, PointerTypes } from "@opendaw/lib-box";
 
+/**
+ * Primitive field types supported by the forge.
+ */
 export interface PrimitiveTypes {
-    int32: int,
-    float32: float
-    boolean: boolean
-    string: string
-    bytes: Int8Array
+  int32: int;
+  float32: float;
+  boolean: boolean;
+  string: string;
+  bytes: Int8Array;
 }
 
-export const reserved = Object.freeze({type: "reserved", name: ""} as const)
+/**
+ * Placeholder value used to reserve numeric field keys for future extension.
+ */
+export const reserved = Object.freeze({ type: "reserved", name: "" } as const);
 
-type ReservedType = typeof reserved
+type ReservedType = typeof reserved;
 
-export const reserveMany = <Keys extends int[]>(..._keys: Keys): Record<Keys[int], ReservedType> =>
-    ({} as Record<Keys[int], ReservedType>)
+/**
+ * Creates an object that reserves multiple field keys at once.
+ *
+ * @param _keys - Field keys to mark as {@link reserved}.
+ */
+export const reserveMany = <Keys extends int[]>(
+  ..._keys: Keys
+): Record<Keys[int], ReservedType> => ({}) as Record<Keys[int], ReservedType>;
 
+/**
+ * Common property carried by every field: its display name.
+ */
 export type FieldName = {
-    name: string
-}
+  name: string;
+};
+/**
+ * Adds optional pointer rules to schema types that can reference other boxes.
+ */
 export type Referencable<E extends PointerTypes> = {
-    pointerRules?: PointerRules<E>
-}
+  pointerRules?: PointerRules<E>;
+};
+/**
+ * Root forge schema supplied to {@link BoxForge.gen}. Describes output paths,
+ * pointer enumeration details and the list of boxes to generate.
+ */
 export type Schema<E extends PointerTypes> = {
-    path: string // the path to the folder to output the TypeScript files
-    pointers: {
-        from: string // the path to the pointer-type enum
-        enum: string // the name of the exported pointer-type enum
-        print: Func<E, string> // a function that turns the enum value into source code (Ptr.A > "Ptr.A")
-    }
-    boxes: ReadonlyArray<BoxSchema<E>>
-}
-export type FieldRecord<E extends PointerTypes> = Record<FieldKey, AnyField<E> & FieldName>
+  /** Path where generated TypeScript files will be written. */
+  path: string;
+  /** Pointer enum information used by the generator. */
+  pointers: {
+    from: string;
+    enum: string;
+    /** Converts an enum value into TypeScript source. */
+    print: Func<E, string>;
+  };
+  /** Collection of box schemas to forge. */
+  boxes: ReadonlyArray<BoxSchema<E>>;
+};
+/** Mapping of numeric field keys to their corresponding schema definitions. */
+export type FieldRecord<E extends PointerTypes> = Record<
+  FieldKey,
+  AnyField<E> & FieldName
+>;
+/** Describes a class to be generated, including its name and fields. */
 export type ClassSchema<E extends PointerTypes> = {
-    name: string
-    fields: FieldRecord<E>
-}
+  name: string;
+  fields: FieldRecord<E>;
+};
+/** Schema wrapper for a top-level box that becomes a generated class. */
 export type BoxSchema<E extends PointerTypes> = Referencable<E> & {
-    type: "box"
-    class: ClassSchema<E>
-}
+  type: "box";
+  class: ClassSchema<E>;
+};
+/** Schema for an object field containing its own class schema. */
 export type ObjectSchema<E extends PointerTypes> = {
-    type: "object"
-    class: ClassSchema<E>
-}
+  type: "object";
+  class: ClassSchema<E>;
+};
+/** Schema for a fixed-length array field. */
 export type ArrayFieldSchema<E extends PointerTypes> = {
-    type: "array",
-    element: AnyField<E>
-    length: int
-}
+  type: "array";
+  element: AnyField<E>;
+  length: int;
+};
+/** Schema describing a pointer to another box. */
 export type PointerFieldSchema<E extends PointerTypes> = {
-    type: "pointer"
-    pointerType: E
-    mandatory: boolean
-}
+  type: "pointer";
+  pointerType: E;
+  mandatory: boolean;
+};
 
-export type PrimitiveFieldSchema<E extends PointerTypes> = Referencable<E> & {
-    [K in keyof PrimitiveTypes]: { type: K, value?: PrimitiveTypes[K] }
-}[keyof PrimitiveTypes]
+/** Schema describing primitive field values such as numbers or strings. */
+export type PrimitiveFieldSchema<E extends PointerTypes> = Referencable<E> &
+  {
+    [K in keyof PrimitiveTypes]: { type: K; value?: PrimitiveTypes[K] };
+  }[keyof PrimitiveTypes];
 
+/** Base schema for plain fields with no additional structure. */
 export type FieldSchema<E extends PointerTypes> = Required<Referencable<E>> & {
-    type: "field"
-}
+  type: "field";
+};
+/** Union of every supported field schema type. */
 export type AnyField<E extends PointerTypes> =
-    | FieldSchema<E>
-    | PointerFieldSchema<E>
-    | PrimitiveFieldSchema<E>
-    | ArrayFieldSchema<E>
-    | ObjectSchema<E>
-    | typeof reserved
+  | FieldSchema<E>
+  | PointerFieldSchema<E>
+  | PrimitiveFieldSchema<E>
+  | ArrayFieldSchema<E>
+  | ObjectSchema<E>
+  | typeof reserved;
 
 // utility methods to build schema
 //
+/**
+ * Merge two field records ensuring no key overlap at compile time.
+ */
 export const mergeFields = <
-    E extends PointerTypes,
-    U extends FieldRecord<E>,
-    V extends FieldRecord<E>>(u: U, v: Objects.Disjoint<U, V>): U & V => Objects.mergeNoOverlap(u, v)
+  E extends PointerTypes,
+  U extends FieldRecord<E>,
+  V extends FieldRecord<E>,
+>(
+  u: U,
+  v: Objects.Disjoint<U, V>,
+): U & V => Objects.mergeNoOverlap(u, v);

--- a/packages/lib/box-forge/test/Pointers.ts
+++ b/packages/lib/box-forge/test/Pointers.ts
@@ -1,12 +1,16 @@
+/**
+ * Pointer categories referenced by the test schemas. When forging, these map
+ * pointer fields to the corresponding connection types.
+ */
 export enum PointerType {
-    NetworkModule,
-    AudioConnection,
-    AudioInput,
-    AudioOutput,
-    NoteConnection,
-    NoteInput,
-    NoteOutput,
-    ParameterAutomation,
-    ParameterModulation,
-    Groove
+  NetworkModule,
+  AudioConnection,
+  AudioInput,
+  AudioOutput,
+  NoteConnection,
+  NoteInput,
+  NoteOutput,
+  ParameterAutomation,
+  ParameterModulation,
+  Groove,
 }

--- a/packages/lib/box-forge/test/forge.test.ts
+++ b/packages/lib/box-forge/test/forge.test.ts
@@ -1,192 +1,245 @@
-import {beforeEach, describe, expect, it, vi} from "vitest"
-import {ByteArrayInput, ByteArrayOutput, Float, Option, UUID} from "@opendaw/lib-std"
-import {Compression} from "@opendaw/lib-dom"
-import {BoxGraph, Editing, PointerField} from "@opendaw/lib-box"
-import {PointerType} from "./Pointers"
-import {AudioConnectionBox, BoxIO, DelayBox, DrumBox, NetworkBox} from "./gen"
+/**
+ * Vitest suite demonstrating typical usage of forged box classes. The tests
+ * serve as executable documentation for the generated API.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ByteArrayInput,
+  ByteArrayOutput,
+  Float,
+  Option,
+  UUID,
+} from "@opendaw/lib-std";
+import { Compression } from "@opendaw/lib-dom";
+import { BoxGraph, Editing, PointerField } from "@opendaw/lib-box";
+import { PointerType } from "./Pointers";
+import {
+  AudioConnectionBox,
+  BoxIO,
+  DelayBox,
+  DrumBox,
+  NetworkBox,
+} from "./gen";
 
 interface TestScene {
-    delay: DelayBox
-    drum: DrumBox
-    graph: BoxGraph
-    network: NetworkBox
+  delay: DelayBox;
+  drum: DrumBox;
+  graph: BoxGraph;
+  network: NetworkBox;
 }
 
 describe("running tests on forged source code", () => {
-    beforeEach<TestScene>((scene: TestScene) => {
-        const graph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create))
-        scene.graph = graph
-        graph.beginTransaction()
-        scene.network = NetworkBox.create(graph, UUID.generate())
-        scene.drum = DrumBox.create(graph, UUID.generate())
-        scene.delay = DelayBox.create(graph, UUID.generate())
-        graph.endTransaction()
-    })
-    it("random access", () => {
-        const id = UUID.generate()
-        const graph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create))
-        graph.beginTransaction()
-        const box = DrumBox.create(graph, id)
-        graph.endTransaction()
-        expect(box.address.uuid).toBe(id)
-        expect(box.cutoff.getValue()).toBe(18000.0) // init
-        expect(box.patterns.getField(3).steps.getField(9).mode.getValue()).toBe(true) // init
-        graph.beginTransaction()
-        box.cutoff.setValue(Float.toFloat32(Math.PI))
-        graph.endTransaction()
-        expect(box.cutoff.getValue()).toBe(Float.toFloat32(Math.PI))
-        expect(box.patterns.getField(3).steps.getField(9).key.getValue()).toBe(0)
-        graph.beginTransaction()
-        box.patterns.getField(3).steps.getField(9).key.setValue(7)
-        graph.endTransaction()
-        expect(box.patterns.getField(3).steps.getField(9).key.getValue()).toBe(7)
-    })
-    it("connect & delete delay", (scene: TestScene) => {
-        const module_added = vi.fn()
-        const module_removed = vi.fn()
-        const subscription = scene.network.modules.pointerHub.subscribeImmediate({
-            onAdd: (_pointer: PointerField) => module_added(),
-            onRemove: (_pointer: PointerField) => module_removed()
-        }, PointerType.NetworkModule)
-        expect(() => scene.graph.edges().validateRequirements()).toThrow()
-        scene.graph.beginTransaction()
-        scene.drum.network.refer(scene.network.modules)
-        scene.delay.network.refer(scene.network.modules)
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).not.toThrow()
-        scene.graph.beginTransaction()
-        const audioConnection = AudioConnectionBox.create(scene.graph, UUID.generate())
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).toThrow()
-        scene.graph.beginTransaction()
-        audioConnection.network.refer(scene.network.connections)
-        audioConnection.output.refer(scene.drum.audioOutput)
-        audioConnection.input.refer(scene.delay.audioInput)
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).not.toThrow()
-        expect(Array.from(scene.graph.dependenciesOf(scene.drum).boxes)).toStrictEqual([audioConnection])
-        expect(Array.from(scene.graph.dependenciesOf(scene.delay).boxes)).toStrictEqual([audioConnection])
-        expect(Array.from(scene.graph.dependenciesOf(scene.network).boxes)).toStrictEqual([scene.drum, audioConnection, scene.delay])
-        expect(Array.from(scene.graph.dependenciesOf(audioConnection).boxes)).toStrictEqual([])
-        scene.graph.beginTransaction()
-        scene.delay.delete()
-        scene.graph.endTransaction()
-        expect(scene.delay.isAttached()).false
-        expect(audioConnection.isAttached()).false
-        expect(scene.drum.isAttached()).true
-        expect(scene.network.isAttached()).true
-        expect(module_added).toBeCalledTimes(2)
-        expect(module_removed).toBeCalledTimes(1)
-        subscription.terminate()
-    })
-    it("connect & delete connection", (scene: TestScene) => {
-        expect(() => scene.graph.edges().validateRequirements()).toThrow()
-        scene.graph.beginTransaction()
-        scene.drum.network.refer(scene.network.modules)
-        scene.delay.network.refer(scene.network.modules)
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).not.toThrow()
-        scene.graph.beginTransaction()
-        const audioConnection = AudioConnectionBox.create(scene.graph, UUID.generate())
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).toThrow()
-        scene.graph.beginTransaction()
-        audioConnection.network.refer(scene.network.connections)
-        audioConnection.output.refer(scene.drum.audioOutput)
-        audioConnection.input.refer(scene.delay.audioInput)
-        scene.graph.endTransaction()
-        expect(() => scene.graph.edges().validateRequirements()).not.toThrow()
-        scene.graph.beginTransaction()
-        audioConnection.delete()
-        scene.graph.endTransaction()
-        expect(audioConnection.isAttached()).false
-        expect(scene.delay.isAttached()).true
-        expect(scene.drum.isAttached()).true
-        expect(scene.network.isAttached()).true
-    })
-    it("editing", (scene: TestScene) => {
-        // init
-        scene.graph.beginTransaction()
-        scene.drum.network.refer(scene.network.modules)
-        scene.delay.network.refer(scene.network.modules)
-        scene.graph.endTransaction()
+  beforeEach<TestScene>((scene: TestScene) => {
+    const graph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create));
+    scene.graph = graph;
+    graph.beginTransaction();
+    scene.network = NetworkBox.create(graph, UUID.generate());
+    scene.drum = DrumBox.create(graph, UUID.generate());
+    scene.delay = DelayBox.create(graph, UUID.generate());
+    graph.endTransaction();
+  });
+  it("random access", () => {
+    const id = UUID.generate();
+    const graph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create));
+    graph.beginTransaction();
+    const box = DrumBox.create(graph, id);
+    graph.endTransaction();
+    expect(box.address.uuid).toBe(id);
+    expect(box.cutoff.getValue()).toBe(18000.0); // init
+    expect(box.patterns.getField(3).steps.getField(9).mode.getValue()).toBe(
+      true,
+    ); // init
+    graph.beginTransaction();
+    box.cutoff.setValue(Float.toFloat32(Math.PI));
+    graph.endTransaction();
+    expect(box.cutoff.getValue()).toBe(Float.toFloat32(Math.PI));
+    expect(box.patterns.getField(3).steps.getField(9).key.getValue()).toBe(0);
+    graph.beginTransaction();
+    box.patterns.getField(3).steps.getField(9).key.setValue(7);
+    graph.endTransaction();
+    expect(box.patterns.getField(3).steps.getField(9).key.getValue()).toBe(7);
+  });
+  it("connect & delete delay", (scene: TestScene) => {
+    const module_added = vi.fn();
+    const module_removed = vi.fn();
+    const subscription = scene.network.modules.pointerHub.subscribeImmediate(
+      {
+        onAdd: (_pointer: PointerField) => module_added(),
+        onRemove: (_pointer: PointerField) => module_removed(),
+      },
+      PointerType.NetworkModule,
+    );
+    expect(() => scene.graph.edges().validateRequirements()).toThrow();
+    scene.graph.beginTransaction();
+    scene.drum.network.refer(scene.network.modules);
+    scene.delay.network.refer(scene.network.modules);
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).not.toThrow();
+    scene.graph.beginTransaction();
+    const audioConnection = AudioConnectionBox.create(
+      scene.graph,
+      UUID.generate(),
+    );
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).toThrow();
+    scene.graph.beginTransaction();
+    audioConnection.network.refer(scene.network.connections);
+    audioConnection.output.refer(scene.drum.audioOutput);
+    audioConnection.input.refer(scene.delay.audioInput);
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).not.toThrow();
+    expect(
+      Array.from(scene.graph.dependenciesOf(scene.drum).boxes),
+    ).toStrictEqual([audioConnection]);
+    expect(
+      Array.from(scene.graph.dependenciesOf(scene.delay).boxes),
+    ).toStrictEqual([audioConnection]);
+    expect(
+      Array.from(scene.graph.dependenciesOf(scene.network).boxes),
+    ).toStrictEqual([scene.drum, audioConnection, scene.delay]);
+    expect(
+      Array.from(scene.graph.dependenciesOf(audioConnection).boxes),
+    ).toStrictEqual([]);
+    scene.graph.beginTransaction();
+    scene.delay.delete();
+    scene.graph.endTransaction();
+    expect(scene.delay.isAttached()).false;
+    expect(audioConnection.isAttached()).false;
+    expect(scene.drum.isAttached()).true;
+    expect(scene.network.isAttached()).true;
+    expect(module_added).toBeCalledTimes(2);
+    expect(module_removed).toBeCalledTimes(1);
+    subscription.terminate();
+  });
+  it("connect & delete connection", (scene: TestScene) => {
+    expect(() => scene.graph.edges().validateRequirements()).toThrow();
+    scene.graph.beginTransaction();
+    scene.drum.network.refer(scene.network.modules);
+    scene.delay.network.refer(scene.network.modules);
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).not.toThrow();
+    scene.graph.beginTransaction();
+    const audioConnection = AudioConnectionBox.create(
+      scene.graph,
+      UUID.generate(),
+    );
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).toThrow();
+    scene.graph.beginTransaction();
+    audioConnection.network.refer(scene.network.connections);
+    audioConnection.output.refer(scene.drum.audioOutput);
+    audioConnection.input.refer(scene.delay.audioInput);
+    scene.graph.endTransaction();
+    expect(() => scene.graph.edges().validateRequirements()).not.toThrow();
+    scene.graph.beginTransaction();
+    audioConnection.delete();
+    scene.graph.endTransaction();
+    expect(audioConnection.isAttached()).false;
+    expect(scene.delay.isAttached()).true;
+    expect(scene.drum.isAttached()).true;
+    expect(scene.network.isAttached()).true;
+  });
+  it("editing", (scene: TestScene) => {
+    // init
+    scene.graph.beginTransaction();
+    scene.drum.network.refer(scene.network.modules);
+    scene.delay.network.refer(scene.network.modules);
+    scene.graph.endTransaction();
 
-        // runtime
-        const editing = new Editing(scene.graph)
-        const connectionFinder = editing.modify(() => {
-            const connectionBox = AudioConnectionBox.create(scene.graph, UUID.generate())
-            connectionBox.output.refer(scene.drum.audioOutput)
-            connectionBox.input.refer(scene.delay.audioInput)
-            connectionBox.network.refer(scene.network.connections)
-            return () => scene.graph.findVertex(connectionBox.address).unwrap() as AudioConnectionBox
-        }).unwrap()
-        expect(connectionFinder().isAttached()).true
-        expect(connectionFinder().output.nonEmpty()).true
-        expect(connectionFinder().input.nonEmpty()).true
+    // runtime
+    const editing = new Editing(scene.graph);
+    const connectionFinder = editing
+      .modify(() => {
+        const connectionBox = AudioConnectionBox.create(
+          scene.graph,
+          UUID.generate(),
+        );
+        connectionBox.output.refer(scene.drum.audioOutput);
+        connectionBox.input.refer(scene.delay.audioInput);
+        connectionBox.network.refer(scene.network.connections);
+        return () =>
+          scene.graph
+            .findVertex(connectionBox.address)
+            .unwrap() as AudioConnectionBox;
+      })
+      .unwrap();
+    expect(connectionFinder().isAttached()).true;
+    expect(connectionFinder().output.nonEmpty()).true;
+    expect(connectionFinder().input.nonEmpty()).true;
 
-        editing.modify(() => connectionFinder().delete())
-        editing.undo()
-        expect(connectionFinder().isAttached()).true
-        expect(connectionFinder().output.nonEmpty()).true
-        expect(connectionFinder().input.nonEmpty()).true
-        editing.undo()
-        editing.redo()
-        expect(connectionFinder().isAttached()).true
-        expect(connectionFinder().output.nonEmpty()).true
-        expect(connectionFinder().input.nonEmpty()).true
-        editing.redo()
-        expect(() => connectionFinder()).toThrow()
+    editing.modify(() => connectionFinder().delete());
+    editing.undo();
+    expect(connectionFinder().isAttached()).true;
+    expect(connectionFinder().output.nonEmpty()).true;
+    expect(connectionFinder().input.nonEmpty()).true;
+    editing.undo();
+    editing.redo();
+    expect(connectionFinder().isAttached()).true;
+    expect(connectionFinder().output.nonEmpty()).true;
+    expect(connectionFinder().input.nonEmpty()).true;
+    editing.redo();
+    expect(() => connectionFinder()).toThrow();
 
-        editing.modify(() => {
-            const connectionBox = AudioConnectionBox.create(scene.graph, UUID.generate())
-            connectionBox.output.refer(scene.drum.audioOutput)
-            connectionBox.input.refer(scene.delay.audioInput)
-            connectionBox.network.refer(scene.network.connections)
-            scene.delay.delete()
-        })
-        editing.undo()
-        editing.redo()
-    })
-})
+    editing.modify(() => {
+      const connectionBox = AudioConnectionBox.create(
+        scene.graph,
+        UUID.generate(),
+      );
+      connectionBox.output.refer(scene.drum.audioOutput);
+      connectionBox.input.refer(scene.delay.audioInput);
+      connectionBox.network.refer(scene.network.connections);
+      scene.delay.delete();
+    });
+    editing.undo();
+    editing.redo();
+  });
+});
 
 describe("running tests on forged source code", () => {
-    it("serialization", () => {
-        const graph = new BoxGraph()
-        graph.beginTransaction()
-        const template = DrumBox.create(graph, UUID.generate())
-        graph.endTransaction()
-        const output = ByteArrayOutput.create()
-        graph.beginTransaction()
-        template.compressor.setValue(true)
-        template.patterns.getField(3).steps.getField(7).key.setValue(42)
-        graph.endTransaction()
-        template.write(output)
+  it("serialization", () => {
+    const graph = new BoxGraph();
+    graph.beginTransaction();
+    const template = DrumBox.create(graph, UUID.generate());
+    graph.endTransaction();
+    const output = ByteArrayOutput.create();
+    graph.beginTransaction();
+    template.compressor.setValue(true);
+    template.patterns.getField(3).steps.getField(7).key.setValue(42);
+    graph.endTransaction();
+    template.write(output);
 
-        graph.beginTransaction()
-        const recreation = DrumBox.create(graph, UUID.generate())
-        recreation.read(new ByteArrayInput(output.toArrayBuffer()))
-        graph.endTransaction()
-        expect(template.compressor.getValue()).toBe(true)
-        expect(template.patterns.getField(3).steps.getField(7).key.getValue()).toBe(42)
-    })
-    it.skip("serialization compressed", async () => {
-        const graph = new BoxGraph()
-        graph.beginTransaction()
-        const template = DrumBox.create(graph, UUID.generate())
-        template.compressor.setValue(true)
-        template.patterns.getField(3).steps.getField(7).key.setValue(42)
-        graph.endTransaction()
-        const output = ByteArrayOutput.create()
-        template.write(output)
-        const outputBuffer = output.toArrayBuffer() as ArrayBuffer
-        const buffer = await Compression.encode(outputBuffer)
-        console.debug("compression ratio", `${(buffer.byteLength / outputBuffer.byteLength * 100).toFixed(1)}%`)
-        const input = new ByteArrayInput(await Compression.decode(buffer)) // this times out
-        graph.beginTransaction()
-        const recreation = DrumBox.create(graph, UUID.generate())
-        recreation.read(input)
-        graph.endTransaction()
-        expect(template.compressor.getValue()).toBe(true)
-        expect(template.patterns.getField(3).steps.getField(7).key.getValue()).toBe(42)
-    })
-})
+    graph.beginTransaction();
+    const recreation = DrumBox.create(graph, UUID.generate());
+    recreation.read(new ByteArrayInput(output.toArrayBuffer()));
+    graph.endTransaction();
+    expect(template.compressor.getValue()).toBe(true);
+    expect(template.patterns.getField(3).steps.getField(7).key.getValue()).toBe(
+      42,
+    );
+  });
+  it.skip("serialization compressed", async () => {
+    const graph = new BoxGraph();
+    graph.beginTransaction();
+    const template = DrumBox.create(graph, UUID.generate());
+    template.compressor.setValue(true);
+    template.patterns.getField(3).steps.getField(7).key.setValue(42);
+    graph.endTransaction();
+    const output = ByteArrayOutput.create();
+    template.write(output);
+    const outputBuffer = output.toArrayBuffer() as ArrayBuffer;
+    const buffer = await Compression.encode(outputBuffer);
+    console.debug(
+      "compression ratio",
+      `${((buffer.byteLength / outputBuffer.byteLength) * 100).toFixed(1)}%`,
+    );
+    const input = new ByteArrayInput(await Compression.decode(buffer)); // this times out
+    graph.beginTransaction();
+    const recreation = DrumBox.create(graph, UUID.generate());
+    recreation.read(input);
+    graph.endTransaction();
+    expect(template.compressor.getValue()).toBe(true);
+    expect(template.patterns.getField(3).steps.getField(7).key.getValue()).toBe(
+      42,
+    );
+  });
+});

--- a/packages/lib/box-forge/test/schema.ts
+++ b/packages/lib/box-forge/test/schema.ts
@@ -1,108 +1,197 @@
-import {PointerRules} from "@opendaw/lib-box"
-import {BoxForge, ClassSchema, FieldName, FieldRecord, FieldSchema, mergeFields} from "../src"
-import {PointerType} from "./Pointers"
+/**
+ * Example schema used in tests to exercise the forge. Executing this file
+ * writes generated classes into `./test/gen`.
+ */
+import { PointerRules } from "@opendaw/lib-box";
+import {
+  BoxForge,
+  ClassSchema,
+  FieldName,
+  FieldRecord,
+  FieldSchema,
+  mergeFields,
+} from "../src";
+import { PointerType } from "./Pointers";
 
 const Module = {
-    1: {type: "pointer", name: "network", pointerType: PointerType.NetworkModule, mandatory: true},
-    2: {type: "int32", name: "x"},
-    3: {type: "int32", name: "y"},
-    4: {type: "string", name: "label"}
-} satisfies FieldRecord<PointerType>
+  1: {
+    type: "pointer",
+    name: "network",
+    pointerType: PointerType.NetworkModule,
+    mandatory: true,
+  },
+  2: { type: "int32", name: "x" },
+  3: { type: "int32", name: "y" },
+  4: { type: "string", name: "label" },
+} satisfies FieldRecord<PointerType>;
 
 const DefaultParameterPointerRules = {
-    accepts: [PointerType.ParameterModulation, PointerType.ParameterAutomation],
-    mandatory: false
-} satisfies PointerRules<PointerType>
+  accepts: [PointerType.ParameterModulation, PointerType.ParameterAutomation],
+  mandatory: false,
+} satisfies PointerRules<PointerType>;
 const DefaultAudioInput = {
-    type: "field", name: "audioInput", pointerRules: {mandatory: false, accepts: [PointerType.AudioInput]}
-} satisfies FieldSchema<PointerType.AudioInput> & FieldName
+  type: "field",
+  name: "audioInput",
+  pointerRules: { mandatory: false, accepts: [PointerType.AudioInput] },
+} satisfies FieldSchema<PointerType.AudioInput> & FieldName;
 const DefaultAudioOutput = {
-    type: "field", name: "audioOutput", pointerRules: {mandatory: false, accepts: [PointerType.AudioOutput]}
-} satisfies FieldSchema<PointerType.AudioOutput> & FieldName
+  type: "field",
+  name: "audioOutput",
+  pointerRules: { mandatory: false, accepts: [PointerType.AudioOutput] },
+} satisfies FieldSchema<PointerType.AudioOutput> & FieldName;
 
 const NetworkBox: ClassSchema<PointerType> = {
-    name: "NetworkBox",
-    fields: {
-        10: {
-            type: "field",
-            name: "modules",
-            pointerRules: {mandatory: false, accepts: [PointerType.NetworkModule]}
-        },
-        11: {
-            type: "field",
-            name: "connections",
-            pointerRules: {mandatory: false, accepts: [PointerType.AudioConnection]}
-        }
-    }
-}
+  name: "NetworkBox",
+  fields: {
+    10: {
+      type: "field",
+      name: "modules",
+      pointerRules: { mandatory: false, accepts: [PointerType.NetworkModule] },
+    },
+    11: {
+      type: "field",
+      name: "connections",
+      pointerRules: {
+        mandatory: false,
+        accepts: [PointerType.AudioConnection],
+      },
+    },
+  },
+};
 
 const AudioConnectionBox: ClassSchema<PointerType> = {
-    name: "AudioConnectionBox",
-    fields: {
-        10: {type: "pointer", name: "network", pointerType: PointerType.AudioConnection, mandatory: true},
-        11: {type: "pointer", name: "output", pointerType: PointerType.AudioOutput, mandatory: true},
-        12: {type: "pointer", name: "input", pointerType: PointerType.AudioInput, mandatory: true}
-    }
-}
+  name: "AudioConnectionBox",
+  fields: {
+    10: {
+      type: "pointer",
+      name: "network",
+      pointerType: PointerType.AudioConnection,
+      mandatory: true,
+    },
+    11: {
+      type: "pointer",
+      name: "output",
+      pointerType: PointerType.AudioOutput,
+      mandatory: true,
+    },
+    12: {
+      type: "pointer",
+      name: "input",
+      pointerType: PointerType.AudioInput,
+      mandatory: true,
+    },
+  },
+};
 
 const DrumBox: ClassSchema<PointerType> = {
-    name: "DrumBox",
-    fields: mergeFields({
-        10: {type: "float32", name: "gain", value: 0.0, pointerRules: DefaultParameterPointerRules},
-        11: {type: "float32", name: "cutoff", value: 18000.0, pointerRules: DefaultParameterPointerRules},
-        12: {type: "float32", name: "resonance", pointerRules: DefaultParameterPointerRules},
-        13: {type: "boolean", name: "compressor", pointerRules: DefaultParameterPointerRules},
-        20: {type: "int32", name: "patternIndex"},
-        21: {
-            type: "array", name: "patterns", length: 28, element: {
-                type: "object",
-                class: {
-                    name: "DrumPattern",
+  name: "DrumBox",
+  fields: mergeFields(
+    {
+      10: {
+        type: "float32",
+        name: "gain",
+        value: 0.0,
+        pointerRules: DefaultParameterPointerRules,
+      },
+      11: {
+        type: "float32",
+        name: "cutoff",
+        value: 18000.0,
+        pointerRules: DefaultParameterPointerRules,
+      },
+      12: {
+        type: "float32",
+        name: "resonance",
+        pointerRules: DefaultParameterPointerRules,
+      },
+      13: {
+        type: "boolean",
+        name: "compressor",
+        pointerRules: DefaultParameterPointerRules,
+      },
+      20: { type: "int32", name: "patternIndex" },
+      21: {
+        type: "array",
+        name: "patterns",
+        length: 28,
+        element: {
+          type: "object",
+          class: {
+            name: "DrumPattern",
+            fields: {
+              10: {
+                type: "pointer",
+                name: "groove",
+                pointerType: PointerType.Groove,
+                mandatory: false,
+              },
+              11: { type: "int32", name: "length", value: 16 },
+              12: { type: "int32", name: "scale", value: 960 },
+              13: {
+                type: "array",
+                name: "steps",
+                length: 64,
+                element: {
+                  type: "object",
+                  class: {
+                    name: "DrumStep",
                     fields: {
-                        10: {type: "pointer", name: "groove", pointerType: PointerType.Groove, mandatory: false},
-                        11: {type: "int32", name: "length", value: 16},
-                        12: {type: "int32", name: "scale", value: 960},
-                        13: {
-                            type: "array", name: "steps", length: 64, element: {
-                                type: "object",
-                                class: {
-                                    name: "DrumStep",
-                                    fields: {
-                                        10: {type: "int32", name: "key"},
-                                        11: {type: "int32", name: "transpose"},
-                                        12: {type: "boolean", name: "mode", value: true},
-                                        13: {type: "boolean", name: "slide"},
-                                        14: {type: "boolean", name: "accent"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+                      10: { type: "int32", name: "key" },
+                      11: { type: "int32", name: "transpose" },
+                      12: { type: "boolean", name: "mode", value: true },
+                      13: { type: "boolean", name: "slide" },
+                      14: { type: "boolean", name: "accent" },
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
-        30: DefaultAudioOutput
-    }, Module)
-}
+      },
+      30: DefaultAudioOutput,
+    },
+    Module,
+  ),
+};
 
 const DelayBox: ClassSchema<PointerType> = {
-    name: "DelayBox",
-    fields: mergeFields(Module, {
-        10: {type: "float32", name: "delayTime", pointerRules: DefaultParameterPointerRules},
-        11: {type: "float32", name: "feedback", pointerRules: DefaultParameterPointerRules},
-        12: {type: "float32", name: "wet", pointerRules: DefaultParameterPointerRules},
-        13: {type: "float32", name: "dry", pointerRules: DefaultParameterPointerRules},
-        30: DefaultAudioInput,
-        31: DefaultAudioOutput
-    } as const)
-}
+  name: "DelayBox",
+  fields: mergeFields(Module, {
+    10: {
+      type: "float32",
+      name: "delayTime",
+      pointerRules: DefaultParameterPointerRules,
+    },
+    11: {
+      type: "float32",
+      name: "feedback",
+      pointerRules: DefaultParameterPointerRules,
+    },
+    12: {
+      type: "float32",
+      name: "wet",
+      pointerRules: DefaultParameterPointerRules,
+    },
+    13: {
+      type: "float32",
+      name: "dry",
+      pointerRules: DefaultParameterPointerRules,
+    },
+    30: DefaultAudioInput,
+    31: DefaultAudioOutput,
+  } as const),
+};
 
 BoxForge.gen<PointerType>({
-    path: "./test/gen",
-    pointers: {
-        from: "../Pointers",
-        enum: "PointerType",
-        print: pointer => `PointerType.${PointerType[pointer]}`
-    },
-    boxes: [NetworkBox, AudioConnectionBox, DrumBox, DelayBox].map(clazz => ({type: "box", class: clazz}))
-}).then(() => console.debug("forge complete"))
+  path: "./test/gen",
+  pointers: {
+    from: "../Pointers",
+    enum: "PointerType",
+    print: (pointer) => `PointerType.${PointerType[pointer]}`,
+  },
+  boxes: [NetworkBox, AudioConnectionBox, DrumBox, DelayBox].map((clazz) => ({
+    type: "box",
+    class: clazz,
+  })),
+}).then(() => console.debug("forge complete"));


### PR DESCRIPTION
## Summary
- document Box Forge schema helpers and forge compiler
- clarify test usage of generated boxes
- add developer docs and sidebar entries for Box Forge

## Testing
- `npx --yes eslint packages/lib/box-forge/src/index.ts packages/lib/box-forge/src/header.ts packages/lib/box-forge/src/schema.ts packages/lib/box-forge/src/forge.ts packages/lib/box-forge/test/forge.test.ts packages/lib/box-forge/test/schema.ts packages/lib/box-forge/test/Pointers.ts` *(fails: ESLint couldn't find an eslint.config file)*
- `npm --workspace packages/lib- box-forge test` *(fails: Cannot find module '@opendaw/lib-std/dist/index.js')*
- `npm --workspace packages/docs run typecheck` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a81a6a88321a0dcaf3f384d7185