### PR TITLE
docs: add jsx documentation and tsdoc

### DIFF
--- a/packages/docs/docs-dev/jsx/custom-elements.md
+++ b/packages/docs/docs-dev/jsx/custom-elements.md
@@ -1,0 +1,3 @@
+# Custom Elements
+
+Custom elements can be created with `createElement` by passing the tag name. Attributes and children work the same as with built-in elements.

--- a/packages/docs/docs-dev/jsx/examples.md
+++ b/packages/docs/docs-dev/jsx/examples.md
@@ -1,0 +1,11 @@
+# Examples
+
+```ts
+import {createElement, Inject} from '@opendaw/lib-jsx'
+
+const message = Inject.value('Hello')
+
+document.body.append(
+  createElement('div', null, message)
+)
+```

--- a/packages/docs/docs-dev/jsx/faq.md
+++ b/packages/docs/docs-dev/jsx/faq.md
@@ -1,0 +1,5 @@
+# FAQ
+
+### Why use `Inject.value` instead of state libraries?
+
+It offers a minimal reactive primitive that updates bound text nodes without requiring a full framework.

--- a/packages/docs/docs-dev/jsx/overview.md
+++ b/packages/docs/docs-dev/jsx/overview.md
@@ -1,0 +1,3 @@
+# JSX Overview
+
+`@opendaw/lib-jsx` provides helpers for building DOM structures with JSX syntax. It exposes a small factory that understands both HTML and SVG elements and utilities for reactive values and routing.

--- a/packages/docs/docs-dev/jsx/routing.md
+++ b/packages/docs/docs-dev/jsx/routing.md
@@ -1,0 +1,14 @@
+# Routing
+
+The library offers simple routing via `RouteLocation` and `RouteMatcher`. `RouteLocation` monitors the browser's location, while `RouteMatcher` resolves paths against a list of routes.
+
+```ts
+import {RouteLocation, RouteMatcher} from '@opendaw/lib-jsx'
+
+const routes = [{ path: '/' }, { path: '/about' }]
+const matcher = RouteMatcher.create(routes)
+
+RouteLocation.get().catchupAndSubscribe(loc => {
+  console.log('route', matcher.resolve(loc.path))
+})
+```

--- a/packages/docs/docs-dev/jsx/svg.md
+++ b/packages/docs/docs-dev/jsx/svg.md
@@ -1,0 +1,3 @@
+# SVG Support
+
+Only certain SVG tags are supported to avoid collisions with HTML. The list is available via `SupportedSvgTags` and can be extended if necessary.

--- a/packages/docs/docs-dev/jsx/weak-refs.md
+++ b/packages/docs/docs-dev/jsx/weak-refs.md
@@ -1,0 +1,3 @@
+# Weak References
+
+To avoid memory leaks, the library stores DOM references in `WeakRefSet`. Injection helpers such as `Inject.value` and `Inject.classList` rely on weak references so elements can be garbage collected when removed from the DOM.

--- a/packages/lib/jsx/README.md
+++ b/packages/lib/jsx/README.md
@@ -4,6 +4,35 @@ _This package is part of the openDAW SDK_
 
 JSX utilities and components for TypeScript projects with DOM manipulation.
 
+## Usage
+
+```ts
+import {createElement, Inject, RouteLocation, RouteMatcher} from '@opendaw/lib-jsx'
+
+const counter = Inject.value(0)
+
+const button = createElement('button', {
+    onClick: () => counter.value++,
+}, 'Increment')
+
+// Bind the reactive value as text content
+const label = createElement('span', null, counter)
+
+document.body.append(button, label)
+
+// Simple routing example
+type AppRoute = { path: string, title: string }
+const matcher = RouteMatcher.create<AppRoute>([
+    { path: '/', title: 'Home' },
+    { path: '/about', title: 'About' },
+])
+
+RouteLocation.get().catchupAndSubscribe(loc => {
+    const route = matcher.resolve(loc.path)
+    console.log('navigated to', route?.path)
+})
+```
+
 ## Core JSX
 
 * **create-element.ts** - JSX element creation and factory functions

--- a/packages/lib/jsx/src/create-element.ts
+++ b/packages/lib/jsx/src/create-element.ts
@@ -4,6 +4,8 @@ import {SupportedSvgTags} from "./supported-svg-tags"
 import {Inject} from "./inject"
 import {DomElement, JsxValue} from "./types"
 
+/** Utility functions for creating and manipulating JSX-backed DOM elements. */
+
 type Factory = (attributes: Readonly<Record<string, any>>, children?: ReadonlyArray<JsxValue>) => JsxValue
 type TagOrFactoryOrElement = string | Factory | DomElement
 
@@ -11,14 +13,20 @@ const EmptyAttributes = Object.freeze({})
 const EmptyChildren: ReadonlyArray<JsxValue> = Object.freeze([])
 
 /**
- * This method must be exposed as the "createElement" method
- * to be passively called on each element defined in jsx files.
- * This is secured by injection defined in vite.config
- * Most magic happens here, but we try to keep it civil.
+ * JSX factory function wired up via the `createElement` pragma. It handles
+ * both intrinsic elements and functional components.
+ *
+ * @param tagOrFactoryOrElement - Element tag name, component factory or an
+ * existing DOM element to be reused.
+ * @param attributes - Attribute record to apply to the created element.
+ * @param children - Child nodes or values appended to the element.
+ * @returns The created element or primitive value returned by a component.
  */
-export function createElement(tagOrFactoryOrElement: TagOrFactoryOrElement,
-                              attributes: Readonly<Record<string, any>> | null,
-                              ...children: ReadonlyArray<JsxValue>): JsxValue {
+export function createElement(
+    tagOrFactoryOrElement: TagOrFactoryOrElement,
+    attributes: Readonly<Record<string, any>> | null,
+    ...children: ReadonlyArray<JsxValue>
+): JsxValue {
     if (tagOrFactoryOrElement instanceof HTMLElement || tagOrFactoryOrElement instanceof SVGElement) {
         // already an element > early out
         return tagOrFactoryOrElement
@@ -58,11 +66,18 @@ export function createElement(tagOrFactoryOrElement: TagOrFactoryOrElement,
     return element
 }
 
+/**
+ * Replaces all existing children of the element with the provided JSX values.
+ */
 export const replaceChildren = (element: DomElement, ...children: ReadonlyArray<JsxValue>) => {
     Html.empty(element)
     appendChildren(element, ...children)
 }
 
+/**
+ * Appends JSX values or nodes to a DOM element, recursively handling nested
+ * arrays and {@link Inject.Value} instances.
+ */
 export const appendChildren = (element: DomElement, ...children: ReadonlyArray<JsxValue>) => {
     children.forEach((value: JsxValue | Inject.Value) => {
         if (value === null || value === undefined || value === false) {return}

--- a/packages/lib/jsx/src/index.ts
+++ b/packages/lib/jsx/src/index.ts
@@ -1,10 +1,28 @@
+/**
+ * Entry point for `@opendaw/lib-jsx`. Initializes the module once and
+ * re-exports the public JSX helpers.
+ */
+
+/**
+ * Symbol used as a flag to mark when the JSX utilities have been injected
+ * into the global scope. This avoids duplicate initialization when the module
+ * is imported multiple times.
+ */
 const key = Symbol.for("@openDAW/lib-jsx")
 
 if ((globalThis as any)[key]) {
-    console.debug(`%c${key.description}%c is already available in ${globalThis.constructor.name}.`, "color: hsl(10, 83%, 60%)", "color: inherit")
+    console.debug(
+        `%c${key.description}%c is already available in ${globalThis.constructor.name}.`,
+        "color: hsl(10, 83%, 60%)",
+        "color: inherit",
+    )
 } else {
     (globalThis as any)[key] = true
-    console.debug(`%c${key.description}%c is now available in ${globalThis.constructor.name}.`, "color: hsl(200, 83%, 60%)", "color: inherit")
+    console.debug(
+        `%c${key.description}%c is now available in ${globalThis.constructor.name}.`,
+        "color: hsl(200, 83%, 60%)",
+        "color: inherit",
+    )
 }
 
 export * from "./types"

--- a/packages/lib/jsx/src/inject.ts
+++ b/packages/lib/jsx/src/inject.ts
@@ -1,22 +1,63 @@
 import {isDefined, Option, Stringifiable, Terminable} from "@opendaw/lib-std"
 import {WeakRefSet} from "./weak"
 
+/**
+ * Lightweight dependency injection helpers that bind reactive values to DOM
+ * elements. Instances created here keep only weak references to their
+ * targets so they can be garbage collected when removed from the DOM.
+ */
 export namespace Inject {
+    /**
+     * Creates a new {@link Ref} instance that can later expose a DOM element
+     * to other parts of the application.
+     */
     export const ref = <T>() => new Ref<T>()
+
+    /**
+     * Creates a reactive text node value. Updating the returned {@link Value}
+     * propagates the change to all bound text nodes.
+     */
     export const value = <T extends Stringifiable>(initialValue: T) => new Value<T>(initialValue)
+
+    /**
+     * Creates a class list manager which keeps class names in sync across
+     * multiple elements.
+     */
     export const classList = (...initialClassNames: Array<string>) => new ClassList(initialClassNames)
+
+    /**
+     * Creates a reactive attribute value. All bound elements will receive the
+     * attribute whenever the value changes.
+     */
     export const attribute = (initialAttributeValue: string) => new Attribute(initialAttributeValue)
 
+    /** Internal interface used by the injection helpers. */
     interface Injector<T> extends Terminable {addTarget(target: T, ...args: Array<unknown>): void}
 
+    /**
+     * Holds a reference to a single DOM element. Calling {@link Ref.get}
+     * returns the element, throwing if no element was bound.
+     */
     export class Ref<T> implements Injector<T> {
         #target: Option<T> = Option.None
+
+        /** Returns the bound target or throws when none is present. */
         get(): T {return this.#target.unwrap("No target provided")}
+
+        /** Binds the target element. */
         addTarget(target: T): void {this.#target = Option.wrap(target)}
+
+        /** Indicates whether a target has been bound. */
         hasTarget(): boolean {return this.#target.nonEmpty()}
+
+        /** Clears the bound target. */
         terminate(): void {this.#target = Option.None}
     }
 
+    /**
+     * Reactive text value that updates all registered text nodes whenever the
+     * underlying value changes.
+     */
     export class Value<T extends Stringifiable = Stringifiable> implements Injector<Text> {
         readonly #targets = new WeakRefSet<Text>()
 
@@ -24,16 +65,26 @@ export namespace Inject {
 
         constructor(value: T) {this.#value = value}
 
+        /** Current value of the text. */
         get value(): T {return this.#value}
+
+        /** Updates the value and synchronizes all bound text nodes. */
         set value(value: T) {
             if (this.#value === value) {return}
             this.#value = value
             this.#targets.forEach(text => {text.nodeValue = String(value)})
         }
+
+        /** Registers a text node to be updated. */
         addTarget(text: Text): void {this.#targets.add(text)}
+
+        /** Releases all registered text nodes. */
         terminate(): void {this.#targets.clear()}
     }
 
+    /**
+     * Manages a synchronized set of CSS class names across multiple elements.
+     */
     export class ClassList implements Injector<Element> {
         readonly #targets: WeakRefSet<Element>
         readonly #classes: Set<string>
@@ -43,16 +94,22 @@ export namespace Inject {
             this.#classes = new Set<string>(classes)
         }
 
+        /** Adds a class name to the set and updates all targets. */
         add(className: string): void {
             this.#classes.add(className)
             this.#updateElements()
         }
 
+        /** Removes a class name from the set and updates all targets. */
         remove(className: string): void {
             this.#classes.delete(className)
             this.#updateElements()
         }
 
+        /**
+         * Toggles a class name, optionally forcing the resulting state.
+         * When `force` is omitted the class is simply toggled.
+         */
         toggle(className: string, force?: boolean): void {
             if (isDefined(force)) {
                 if (force) {
@@ -70,11 +127,13 @@ export namespace Inject {
             this.#updateElements()
         }
 
+        /** Registers a new element to receive class updates. */
         addTarget(target: Element): void {
             this.#targets.add(target)
             this.#updateElement(target)
         }
 
+        /** Clears all tracked elements. */
         terminate(): void {this.#targets.clear()}
 
         #updateElements(): void {this.#targets.forEach(this.#updateElement)}
@@ -83,6 +142,10 @@ export namespace Inject {
             (element: Element) => {element.className = Array.from(this.#classes).join(" ")}
     }
 
+    /**
+     * Represents a mutable attribute value that can be shared across multiple
+     * elements.
+     */
     export class Attribute implements Injector<Element> {
         readonly #targets: WeakRefSet<Element>
         readonly #keys: WeakMap<Element, string>
@@ -95,23 +158,29 @@ export namespace Inject {
             this.#value = value
         }
 
+        /** Current attribute value. */
         get value(): string {return this.#value}
+
+        /** Updates the attribute value on all registered elements. */
         set value(value: string) {
             if (this.#value === value) {return}
             this.#value = value
             this.#updateElements()
         }
 
+        /** Toggles the attribute between two values. */
         toggle(expected: string, alternative: string): void {
             this.value = this.value === expected ? alternative : expected
         }
 
+        /** Registers an element and the attribute key it should receive. */
         addTarget(target: Element, key: string): void {
             this.#targets.add(target)
             this.#keys.set(target, key)
             this.#updateElement(target)
         }
 
+        /** Releases all tracked elements. */
         terminate(): void {this.#targets.clear()}
 
         #updateElements(): void {this.#targets.forEach(this.#updateElement)}

--- a/packages/lib/jsx/src/routes.ts
+++ b/packages/lib/jsx/src/routes.ts
@@ -1,5 +1,9 @@
 import {isDefined, Lazy, Notifier, Observer, Option, Subscription} from "@opendaw/lib-std"
 
+/**
+ * Tracks the current browser location and emits notifications when navigation
+ * occurs. The class also keeps the canonical link element up to date.
+ */
 export class RouteLocation {
     @Lazy
     static get(): RouteLocation {return new RouteLocation()}
@@ -11,6 +15,11 @@ export class RouteLocation {
         this.#setCanonical()
     }
 
+    /**
+     * Navigates to the given path and notifies subscribers when the path has
+     * changed.
+     * @returns `true` if navigation occurred, otherwise `false`.
+     */
     navigateTo(path: string): boolean {
         if (this.path === path) {
             return false
@@ -21,11 +30,16 @@ export class RouteLocation {
         return true
     }
 
+    /**
+     * Immediately invokes the observer with the current location and
+     * subscribes it for future changes.
+     */
     catchupAndSubscribe(observer: Observer<RouteLocation>): Subscription {
         observer(this)
         return this.#notifier.subscribe(observer)
     }
 
+    /** Current path component of the location. */
     get path(): string {return location.pathname}
 
     #setCanonical(): void {
@@ -42,13 +56,22 @@ export class RouteLocation {
     }
 }
 
+/** Descriptor for a route entry used by {@link RouteMatcher}. */
 export type Route = { path: string }
 
+/**
+ * Utility for resolving a path against a list of route descriptors.
+ * Wildcard segments (`*`) are supported.
+ */
 export class RouteMatcher<R extends Route> {
+    /** Factory method to create a matcher from a list of routes. */
     static create<R extends Route>(routes: ReadonlyArray<R>): RouteMatcher<R> {
         return new RouteMatcher<R>(routes)
     }
 
+    /**
+     * Checks whether a given path matches a route pattern.
+     */
     static match(route: string, path: string): boolean {
         if (!path.startsWith("/") || !route.startsWith("/")) {
             return false
@@ -80,6 +103,7 @@ export class RouteMatcher<R extends Route> {
         })
     }
 
+    /** Resolves the first matching route for the given path. */
     resolve(path: string): Option<R> {
         return Option.wrap(this.#routes.find(route => RouteMatcher.match(route.path, path)))
     }

--- a/packages/lib/jsx/src/supported-svg-tags.ts
+++ b/packages/lib/jsx/src/supported-svg-tags.ts
@@ -1,5 +1,8 @@
-// We cannot support tags that are used in html as well.
-// TSX builds its DOM from the bottom up, meaning you have no information about the scope (html or svg).
+/**
+ * Set of SVG tag names that can be safely created by the JSX factory. Tags
+ * that overlap with HTML are intentionally omitted because JSX cannot infer
+ * the correct namespace when constructing elements from the bottom up.
+ */
 export const SupportedSvgTags = new Set([
     // "a",
     "altGlyph",

--- a/packages/lib/jsx/src/types.ts
+++ b/packages/lib/jsx/src/types.ts
@@ -1,16 +1,29 @@
 import {Procedure} from "@opendaw/lib-std"
 import {Inject} from "./inject"
 
+/** DOM element type supported by the JSX helper functions. */
 export type DomElement = HTMLElement | SVGElement
+
+/**
+ * Any value that can appear within JSX markup including nested arrays and
+ * primitive values.
+ */
 export type JsxValue = null | undefined | boolean | string | number | DomElement | Array<JsxValue>
 
-// These are all utility type to let jsx understand usual HTML and SVG elements.
-//
+// These are all utility types to let JSX understand usual HTML and SVG elements.
+
+/**
+ * Attributes that receive special handling by the JSX factory.
+ */
 type AttributeMap = {
     className?: string | Inject.ClassList
     style?: Partial<CSSStyleDeclaration>
 }
 
+/**
+ * Extracts valid properties from a given DOM element type and augments them
+ * with the special attributes understood by this library.
+ */
 type ExtractProperties<T extends Element> = Partial<{
     [K in keyof T]:
     K extends keyof AttributeMap ? AttributeMap[K] :
@@ -23,7 +36,9 @@ type ExtractProperties<T extends Element> = Partial<{
                                 T[K] extends boolean ? boolean | string :
                                     string) | Inject.Attribute
 }> & {
+    /** Reference to the backing DOM element. */
     ref?: Inject.Ref<T>
+    /** Called when the element has been inserted into the DOM. */
     onLoad?: Procedure<T>
 } & Record<string, unknown>
 

--- a/packages/lib/jsx/src/weak.ts
+++ b/packages/lib/jsx/src/weak.ts
@@ -1,8 +1,17 @@
+/**
+ * Set implementation backed by {@link WeakRef} values. The set automatically
+ * purges entries whose targets have been garbage collected.
+ */
 export class WeakRefSet<T extends WeakKey> {
     readonly #set = new Set<WeakRef<T>>()
 
+    /** Adds a value to the set. */
     add(value: T): void {this.#set.add(new WeakRef<T>(value))}
 
+    /**
+     * Iterates over all live entries, removing those whose targets have been
+     * collected.
+     */
     forEach(callback: (value: T) => void): void {
         for (const weakRef of this.#set) {
             const value = weakRef.deref()
@@ -14,5 +23,6 @@ export class WeakRefSet<T extends WeakKey> {
         }
     }
 
+    /** Clears all entries from the set. */
     clear(): void {this.#set.clear()}
 }


### PR DESCRIPTION
## Summary
- add TSDoc for JSX helpers and routing utilities
- expand JSX README with usage examples
- document JSX APIs under docs-dev

## Testing
- `npm --workspace packages/lib/jsx run lint` *(fails: no-explicit-any and other ESLint rules)*
- `npm --workspace packages/lib/jsx test`

------
https://chatgpt.com/codex/tasks/task_b_68ae9a8302708321af53e28892ca01c6