### PR TITLE
docs: document fusion messaging

### DIFF
--- a/packages/docs/docs-dev/fusion/error-handling.md
+++ b/packages/docs/docs-dev/fusion/error-handling.md
@@ -1,0 +1,5 @@
+# Error Handling
+
+Protocols include error codes and message types so the main thread can recover
+from failures. Always listen for `error` responses and surface meaningful
+messages to the user.

--- a/packages/docs/docs-dev/fusion/examples.md
+++ b/packages/docs/docs-dev/fusion/examples.md
@@ -1,0 +1,15 @@
+# Fusion Examples
+
+```ts
+// Broadcast microphone input to connected receivers
+const broadcaster = new LiveStreamBroadcaster(port)
+await broadcaster.start(stream)
+
+// Request waveform peaks
+const worker = new SamplePeakWorker()
+const peaks = await worker.generate(buffer)
+
+// Use OPFS through a worker
+const opfs = new OpfsWorker()
+await opfs.writeFile('demo.wav', data)
+```

--- a/packages/docs/docs-dev/fusion/faq.md
+++ b/packages/docs/docs-dev/fusion/faq.md
@@ -1,0 +1,6 @@
+# FAQ
+
+**Q:** Which browsers support Fusion protocols?
+
+**A:** Any browser with Web Worker and OPFS support. Chrome-based browsers
+currently provide the most complete feature set.

--- a/packages/docs/docs-dev/fusion/overview.md
+++ b/packages/docs/docs-dev/fusion/overview.md
@@ -1,0 +1,6 @@
+# Fusion Overview
+
+The Fusion utilities provide structured messaging channels for audio and file
+operations within openDAW. Live streaming, waveform peak generation and Origin
+Private File System (OPFS) access are exposed through dedicated workers and
+protocols.

--- a/packages/docs/docs-dev/fusion/performance.md
+++ b/packages/docs/docs-dev/fusion/performance.md
@@ -1,0 +1,4 @@
+# Performance
+
+Use transferable objects and avoid copying large audio buffers. Workers should
+stream results incrementally to keep the UI responsive.

--- a/packages/docs/docs-dev/fusion/protocols.md
+++ b/packages/docs/docs-dev/fusion/protocols.md
@@ -1,0 +1,10 @@
+# Fusion Protocols
+
+Fusion defines clear contracts for message exchange between the main thread and
+workers:
+
+- **LiveStream** – transfers raw audio frames between broadcaster and receiver
+  ports.
+- **SamplePeakProtocol** – requests waveform peak computation and returns the
+  resulting data.
+- **OpfsProtocol** – proxies file system operations to a dedicated OPFS worker.

--- a/packages/docs/docs-dev/fusion/worker-integration.md
+++ b/packages/docs/docs-dev/fusion/worker-integration.md
@@ -1,0 +1,5 @@
+# Worker Integration
+
+Fusion workers communicate via `postMessage` and structured clones. Instantiate
+a worker, pass a `MessagePort` to the main thread and follow the protocol's
+request/response patterns to coordinate long running tasks.

--- a/packages/lib/fusion/README.md
+++ b/packages/lib/fusion/README.md
@@ -9,6 +9,18 @@ Web-based audio workstation fusion utilities for TypeScript projects.
 * **OpfsWorker.ts** - Origin Private File System worker implementation
 * **OpfsProtocol.ts** - OPFS communication protocol definitions
 
+### Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Main
+    participant Worker
+    participant OPFS
+    Main->>Worker: OpfsProtocol.open
+    Worker->>OPFS: Read/Write
+    Worker-->>Main: Result
+```
+
 ## Audio Visualization
 
 * **Peaks.ts** - Audio peak data management and processing
@@ -16,9 +28,29 @@ Web-based audio workstation fusion utilities for TypeScript projects.
 * **PeakProtocol.ts** - Peak data communication protocol
 * **PeaksPainter.ts** - Canvas-based peak visualization rendering
 
+### Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Main
+    participant Worker
+    Main->>Worker: SamplePeakProtocol.request
+    Worker-->>Main: SamplePeakProtocol.response
+```
+
 ## Live Audio Streaming
 
 * **live-stream/** - Directory containing live audio stream processing utilities
+
+### Message Flow
+
+```mermaid
+sequenceDiagram
+    participant Broadcaster
+    participant Receiver
+    Broadcaster->>Receiver: AudioFrame
+    Receiver-->>Broadcaster: Acknowledgement
+```
 
 ## Core Types
 

--- a/packages/lib/fusion/src/index.ts
+++ b/packages/lib/fusion/src/index.ts
@@ -1,3 +1,17 @@
+/**
+ * @packageDocumentation
+ * Entry point for the Fusion utilities.
+ *
+ * Fusion exposes several messaging channels and protocol contracts that allow
+ * workers and the main thread to collaborate:
+ *
+ * - {@link LiveStreamBroadcaster} and {@link LiveStreamReceiver} exchange audio
+ *   frames over a dedicated message channel.
+ * - The {@link SamplePeakWorker} communicates with the main thread using the
+ *   {@link SamplePeakProtocol} to generate and transfer waveform peak data.
+ * - {@link OpfsWorker} implements file system access backed by the
+ *   {@link OpfsProtocol}.
+ */
 const key = Symbol.for("@openDAW/lib-fusion")
 
 if ((globalThis as any)[key]) {
@@ -9,11 +23,19 @@ if ((globalThis as any)[key]) {
 
 import './types'
 
+/** Receives audio frames from a {@link LiveStreamBroadcaster} channel. */
 export * from "./live-stream/LiveStreamReceiver"
+/** Broadcasts audio frames to connected {@link LiveStreamReceiver} instances. */
 export * from "./live-stream/LiveStreamBroadcaster"
+/** Utilities for managing waveform peaks. */
 export * from "./peaks/Peaks"
+/** Web Worker that implements the {@link SamplePeakProtocol}. */
 export * from "./peaks/SamplePeakWorker"
+/** Contract describing messages exchanged to compute audio peaks. */
 export * from "./peaks/SamplePeakProtocol"
+/** Renders peak data onto a canvas. */
 export * from "./peaks/PeaksPainter"
+/** Worker providing file system access using the {@link OpfsProtocol}. */
 export * from "./opfs/OpfsWorker"
+/** Messaging contract for OPFS operations. */
 export * from "./opfs/OpfsProtocol"

--- a/packages/lib/fusion/src/types.ts
+++ b/packages/lib/fusion/src/types.ts
@@ -1,9 +1,23 @@
-// Augment the existing DOM types instead of creating new ones
+/**
+ * @packageDocumentation
+ * DOM type augmentations supporting Fusion's messaging protocols.
+ *
+ * These definitions describe the Origin Private File System (OPFS) interfaces
+ * required by {@link OpfsWorker} and its {@link OpfsProtocol}.
+ */
 declare global {
+    /**
+     * File handle with the ability to create a synchronous access handle used by
+     * the OPFS channel.
+     */
     interface FileSystemFileHandle {
         createSyncAccessHandle(): Promise<FileSystemSyncAccessHandle>
     }
 
+    /**
+     * Synchronous access handle used by the OPFS protocol to read and write
+     * binary data.
+     */
     interface FileSystemSyncAccessHandle {
         write(buffer: BufferSource, options?: { at?: number }): number
         read(buffer: BufferSource, options?: { at?: number }): number
@@ -13,10 +27,16 @@ declare global {
         close(): void
     }
 
+    /**
+     * Provides access to storage-related features needed by the OPFS worker.
+     */
     interface Navigator {
         readonly storage: StorageManager
     }
 
+    /**
+     * Allows retrieval of the root directory for OPFS operations.
+     */
     interface StorageManager {
         getDirectory(): Promise<FileSystemDirectoryHandle>
     }


### PR DESCRIPTION
## Summary
- document fusion entry point with TSDoc describing live streaming, peak and OPFS channels
- explain OPFS DOM augmentations with TSDoc
- add messaging flow diagrams and fusion docs

## Testing
- `npm test`
- `npm run lint` *(fails: command sh -c eslint "src/**/*.ts" exited (1))*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a85a0cc83219ca5b90d1c0a1630