### PR TITLE
docs: add TSDoc and core processor diagram

### DIFF
--- a/packages/studio/core-processors/README.md
+++ b/packages/studio/core-processors/README.md
@@ -1,0 +1,16 @@
+# Core Processors
+
+This package contains the Web Audio `AudioWorkletProcessor` implementations that power the OpenDAW engine.
+
+## Processing flow
+
+```mermaid
+flowchart LR
+    NoteEventSource -->|notes| NoteEventInstrument --> InstrumentProcessor
+    InstrumentProcessor --> ChannelStripProcessor --> Mixer
+    ChannelStripProcessor -->|aux| AuxSendProcessor
+    ChannelStripProcessor -->|peaks| PeakBroadcaster
+    ChannelStripProcessor -->|spectrum| SpectrumAnalyser
+```
+
+The diagram illustrates how note events are transformed into audio, mixed, and analysed within the engine.

--- a/packages/studio/core-processors/src/AudioProcessor.ts
+++ b/packages/studio/core-processors/src/AudioProcessor.ts
@@ -5,11 +5,20 @@ import {AbstractProcessor} from "./AbstractProcessor"
 import {UpdateEvent} from "./UpdateClock"
 import {EngineContext} from "./EngineContext"
 
+/**
+ * Convenience base class for processors that output audio.
+ *
+ * It slices the render quantum into segments based on scheduled events and
+ * delegates audio rendering to {@link processAudio}.
+ */
 export abstract class AudioProcessor extends AbstractProcessor {
     protected constructor(context: EngineContext) {
         super(context)
     }
 
+    /**
+     * Processes all scheduled events and renders audio for each block.
+     */
     process({blocks}: ProcessInfo): void {
         blocks.forEach((block) => {
             this.introduceBlock(block)
@@ -42,11 +51,23 @@ export abstract class AudioProcessor extends AbstractProcessor {
         this.finishProcess()
     }
 
+    /**
+     * Renders audio samples for the given range of the current block.
+     */
     abstract processAudio(block: Block, fromIndex: int, toIndex: int): void
 
+    /**
+     * Hook executed before processing the first event in a block.
+     */
     introduceBlock(_block: Block): void {}
 
+    /**
+     * Handles non-update events routed to this processor.
+     */
     handleEvent(_event: Event): void {return panic(`${this} received an event but has no accepting method.`)}
 
+    /**
+     * Hook executed after all blocks have been processed.
+     */
     finishProcess(): void {}
 }

--- a/packages/studio/core-processors/src/AudioUnit.ts
+++ b/packages/studio/core-processors/src/AudioUnit.ts
@@ -10,6 +10,9 @@ import {AudioUnitOptions} from "./AudioUnitOptions"
 import {AudioUnitInputAdapter} from "@opendaw/studio-adapters"
 import {InstrumentDeviceProcessor} from "./InstrumentDeviceProcessor"
 
+/**
+ * High level container representing a track or device chain in the engine.
+ */
 export class AudioUnit implements Terminable {
     static ID: int = 0 | 0
 
@@ -25,6 +28,11 @@ export class AudioUnit implements Terminable {
 
     #input: Option<InstrumentDeviceProcessor | AudioBusProcessor> = Option.None
 
+    /**
+     * @param context - engine context used to resolve processors
+     * @param adapter - adapter exposing the backing box
+     * @param options - configuration for the created device chains
+     */
     constructor(context: EngineContext, adapter: AudioUnitBoxAdapter, options: AudioUnitOptions) {
         this.#context = context
         this.#adapter = adapter
@@ -43,8 +51,15 @@ export class AudioUnit implements Terminable {
         )
     }
 
+    /**
+     * Returns the currently connected input processor if any.
+     */
     input(): Option<InstrumentDeviceProcessor | AudioBusProcessor> {return this.#input}
+    /**
+     * Convenience wrapper that asserts the input is an {@link AudioBusProcessor}.
+     */
     inputAsAudioBus(): AudioBusProcessor {return asInstanceOf(this.#input.unwrap("No input available"), AudioBusProcessor)}
+    /** Access to the channel strip's audio output. */
     audioOutput(): AudioBuffer {return this.#audioDeviceChain.channelStrip.audioOutput}
 
     get midiDeviceChain(): MidiDeviceChain {return this.#midiDeviceChain}

--- a/packages/studio/core-processors/src/AuxSendProcessor.ts
+++ b/packages/studio/core-processors/src/AuxSendProcessor.ts
@@ -7,6 +7,9 @@ import {AutomatableParameter} from "./AutomatableParameter"
 import {dbToGain, Ramp} from "@opendaw/lib-dsp"
 import {AudioProcessor} from "./AudioProcessor"
 
+/**
+ * Taps a source {@link AudioBuffer} and routes it to an auxiliary send.
+ */
 export class AuxSendProcessor extends AudioProcessor implements Processor, AudioInput {
     readonly #adapter: AuxSendBoxAdapter
 
@@ -21,6 +24,10 @@ export class AuxSendProcessor extends AudioProcessor implements Processor, Audio
     #needsUpdate: boolean = true
     #processing: boolean = false
 
+    /**
+     * @param context - shared engine context
+     * @param adapter - adapter providing parameter access to the send box
+     */
     constructor(context: EngineContext, adapter: AuxSendBoxAdapter) {
         super(context)
 
@@ -36,17 +43,26 @@ export class AuxSendProcessor extends AudioProcessor implements Processor, Audio
         this.readAllParameters()
     }
 
+    /** Clears the output buffer. */
     reset(): void {this.#audioOutput.clear()}
 
+    /** Exposes the backing adapter for external wiring. */
     get adapter(): AuxSendBoxAdapter {return this.#adapter}
 
+    /**
+     * Sets the audio source to be routed through the send.
+     */
     setAudioSource(source: AudioBuffer): Terminable {
         this.#source = Option.wrap(source)
         return {terminate: () => this.#source = Option.None}
     }
 
+    /** Buffer that receives the processed send output. */
     get audioOutput(): AudioBuffer {return this.#audioOutput}
 
+    /**
+     * Applies gain and panning to the source and writes into the output buffer.
+     */
     processAudio(_block: Block, fromIndex: number, toIndex: number): void {
         if (this.#source.isEmpty()) {return}
         if (this.#needsUpdate) {
@@ -77,6 +93,7 @@ export class AuxSendProcessor extends AudioProcessor implements Processor, Audio
         this.#processing = true
     }
 
+    /** Marks internal state dirty when a parameter changes. */
     parameterChanged(_parameter: AutomatableParameter): void {
         this.#needsUpdate = true
     }

--- a/packages/studio/core-processors/src/DeviceProcessorFactory.ts
+++ b/packages/studio/core-processors/src/DeviceProcessorFactory.ts
@@ -54,6 +54,7 @@ import {InstrumentDeviceProcessor} from "./InstrumentDeviceProcessor"
 import {AudioEffectDeviceProcessor} from "./AudioEffectDeviceProcessor"
 import {UnknownMidiEffectDeviceProcessor} from "./devices/midi-effects/UnknownMidiEffectDeviceProcessor"
 
+/** Factory functions creating processor instances for instrument devices. */
 export namespace InstrumentDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): Nullish<InstrumentDeviceProcessor | AudioBusProcessor> =>
@@ -71,6 +72,7 @@ export namespace InstrumentDeviceProcessorFactory {
         })
 }
 
+/** Factory for processors wrapping MIDI-effect devices. */
 export namespace MidiEffectDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): MidiEffectProcessor =>
@@ -86,6 +88,7 @@ export namespace MidiEffectDeviceProcessorFactory {
         }), `Could not create midi-effect for'${box.name}'`)
 }
 
+/** Factory for audio-effect device processors. */
 export namespace AudioEffectDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): AudioEffectDeviceProcessor =>

--- a/packages/studio/core-processors/src/EngineContext.ts
+++ b/packages/studio/core-processors/src/EngineContext.ts
@@ -7,15 +7,27 @@ import {AudioUnit} from "./AudioUnit"
 import {Mixer} from "./Mixer"
 import {BoxAdaptersContext, EngineToClient} from "@opendaw/studio-adapters"
 
+/**
+ * Shared services and registries exposed to processors within the engine.
+ */
 export interface EngineContext extends BoxAdaptersContext, Terminable {
+    /** Live broadcast channel for metering and analysis data. */
     get broadcaster(): LiveStreamBroadcaster
+    /** Clock scheduling automation updates. */
     get updateClock(): UpdateClock
+    /** Provides transport related timing information. */
     get timeInfo(): TimeInfo
+    /** Global mixer instance. */
     get mixer(): Mixer
+    /** IPC bridge used to forward engine events to the client. */
     get engineToClient(): EngineToClient
 
+    /** Looks up an {@link AudioUnit} by UUID. */
     getAudioUnit(uuid: UUID.Format): AudioUnit
+    /** Registers a processor with the engine graph. */
     registerProcessor(processor: Processor): Terminable
+    /** Registers a connection between processors. */
     registerEdge(source: Processor, target: Processor): Terminable
+    /** Subscribes to notifications for each processing phase. */
     subscribeProcessPhase(observer: Observer<ProcessPhase>): Subscription
 }

--- a/packages/studio/core-processors/src/EventBuffer.ts
+++ b/packages/studio/core-processors/src/EventBuffer.ts
@@ -1,13 +1,20 @@
 import {Event} from "@opendaw/lib-dsp"
 import {ArrayMultimap, Arrays, int} from "@opendaw/lib-std"
 
+/**
+ * Small helper collecting {@link Event}s grouped by block index.
+ */
 export class EventBuffer {
     readonly #events: ArrayMultimap<int, Event>
 
     constructor() {this.#events = new ArrayMultimap(Arrays.empty(), Event.Comparator)}
 
+    /** Adds an event scheduled for the given block. */
     add(index: int, event: Event): void {this.#events.add(index, event)}
+    /** Returns the events for the block or an empty array. */
     get(index: int): ReadonlyArray<Event> {return this.#events.get(index)}
+    /** Iterates over all stored block/event pairs. */
     forEach(procedure: (index: int, values: ReadonlyArray<Event>) => void): void {return this.#events.forEach(procedure)}
+    /** Clears all stored events. */
     clear(): void {this.#events.clear()}
 }

--- a/packages/studio/core-processors/src/NoteEventSource.ts
+++ b/packages/studio/core-processors/src/NoteEventSource.ts
@@ -1,16 +1,24 @@
 import {Event, NoteEvent, ppqn} from "@opendaw/lib-dsp"
 import {byte, float, Id, int, Terminable} from "@opendaw/lib-std"
 
+/**
+ * Event emitted when a note stops playing.
+ */
 export type NoteCompleteEvent = Id<Event & {
     readonly type: "note-complete-event"
     readonly pitch: byte
 }>
 
+/**
+ * Union of note-on and note-off lifecycle events.
+ */
 export type NoteLifecycleEvent = Id<NoteEvent> | NoteCompleteEvent
 
 export namespace NoteLifecycleEvent {
+    /** Creates a note-on event. */
     export const start = (position: ppqn, duration: ppqn, pitch: byte, velocity: float, cent: number = 0.0): Id<NoteEvent> =>
         ({type: "note-event", position, duration, pitch, velocity, cent, id: ++$id})
+    /** Clones a note-on event optionally changing position or duration. */
     export const startWith = (source: NoteEvent, position?: ppqn, duration?: ppqn): Id<NoteEvent> => ({
         type: "note-event",
         position: position ?? source.position,
@@ -20,23 +28,33 @@ export namespace NoteLifecycleEvent {
         velocity: source.velocity,
         id: ++$id
     })
+    /** Creates a note-off event from a previously started note. */
     export const stop = ({id, pitch}: Id<NoteEvent>, position: ppqn): NoteCompleteEvent =>
         ({type: "note-complete-event", position, pitch, id})
+    /** Type guard for note-on events. */
     export const isStart = (event: Event): event is Id<NoteEvent> =>
         event.type === "note-event" && "id" in event && typeof event.id === "number"
+    /** Type guard for note-off events. */
     export const isStop = (event: Event): event is NoteCompleteEvent =>
         event.type === "note-complete-event"
     let $id: int = 0 | 0
 }
 
 export interface NoteEventSource {
-    // find all notes that start in given interval and returns them moved into global time space
+    /**
+     * Finds all notes that start within the interval and returns them in global
+     * time space.
+     */
     processNotes(from: ppqn, to: ppqn, flags: int /*BlockFlag*/): Generator<NoteLifecycleEvent>
 
-    // find all active local notes at given position
+    /** Iterates all active local notes at the given position. */
     iterateActiveNotesAt(position: ppqn, onlyExternal: boolean): Generator<NoteEvent>
 }
 
 export interface NoteEventTarget {
+    /**
+     * Installs a {@link NoteEventSource} and returns a terminable for
+     * disconnection.
+     */
     setNoteEventSource(source: NoteEventSource): Terminable
 }

--- a/packages/studio/core-processors/src/PeakBroadcaster.ts
+++ b/packages/studio/core-processors/src/PeakBroadcaster.ts
@@ -4,6 +4,10 @@ import {RMS, StereoMatrix} from "@opendaw/lib-dsp"
 import {LiveStreamBroadcaster} from "@opendaw/lib-fusion"
 import {RenderQuantum} from "./constants"
 
+/**
+ * Computes peak and RMS levels for a stereo signal and broadcasts them via a
+ * {@link LiveStreamBroadcaster}.
+ */
 export class PeakBroadcaster implements Terminable {
     static readonly PEAK_DECAY = Math.exp(-1.0 / (sampleRate * 0.250))
     static readonly RMS_WINDOW = Math.floor(sampleRate * 0.100)
@@ -20,6 +24,10 @@ export class PeakBroadcaster implements Terminable {
     #rmsL: number = 0.0
     #rmsR: number = 0.0
 
+    /**
+     * @param broadcaster - stream used to send metering updates
+     * @param address - address identifying the stream
+     */
     constructor(broadcaster: LiveStreamBroadcaster, address: Address) {
         this.#broadcaster = broadcaster
         this.#address = address
@@ -34,6 +42,7 @@ export class PeakBroadcaster implements Terminable {
         })
     }
 
+    /** Resets stored peak and RMS values. */
     clear(): void {
         this.#rms[0].clear()
         this.#rms[1].clear()
@@ -41,6 +50,9 @@ export class PeakBroadcaster implements Terminable {
         this.#peakR = 0.0
     }
 
+    /**
+     * Updates peak and RMS statistics for the given sample range.
+     */
     process(outL: Float32Array, outR: Float32Array, fromIndex: int = 0, toIndex: int = RenderQuantum): void {
         const [rmsL, rmsR] = this.#rms
         for (let i = fromIndex; i < toIndex; i++) {
@@ -53,6 +65,7 @@ export class PeakBroadcaster implements Terminable {
         }
     }
 
+    /** Convenience wrapper accepting a stereo channel tuple. */
     processStereo([l, r]: StereoMatrix.Channels, fromIndex: int = 0, toIndex: int = RenderQuantum): void {
         this.process(l, r, fromIndex, toIndex)
     }

--- a/packages/studio/core-processors/src/SpectrumAnalyser.ts
+++ b/packages/studio/core-processors/src/SpectrumAnalyser.ts
@@ -1,6 +1,9 @@
 import {FFT, Window} from "@opendaw/lib-dsp"
 import {int} from "@opendaw/lib-std"
 
+/**
+ * Simple FFT based spectrum analyser used for visualisation.
+ */
 export class SpectrumAnalyser {
     static readonly DEFAULT_SIZE = 1024
 
@@ -16,6 +19,9 @@ export class SpectrumAnalyser {
 
     decay: boolean = false
 
+    /**
+     * @param n - FFT size determining frequency resolution
+     */
     constructor(n: int = SpectrumAnalyser.DEFAULT_SIZE) {
         this.#fftSize = n
         this.#fft = new FFT(this.#fftSize)
@@ -26,14 +32,21 @@ export class SpectrumAnalyser {
         this.#bins = new Float32Array(this.#numBins)
     }
 
+    /** Clears accumulated spectrum data. */
     clear(): void {
         this.#bins.fill(0.0)
         this.#index = 0
     }
 
+    /** Returns the number of frequency bins. */
     numBins(): int {return this.#numBins}
+    /** Buffer containing the current spectrum magnitude per bin. */
     bins(): Float32Array {return this.#bins}
 
+    /**
+     * Accumulates samples and updates the spectrum once {@link #fftSize} samples
+     * have been collected.
+     */
     process(left: Float32Array, right: Float32Array, fromIndex: int, toIndex: int): void {
         for (let i = fromIndex; i < toIndex; ++i) {
             this.#real[this.#index] = this.#window[this.#index] * (left[i] + right[i])
@@ -43,6 +56,7 @@ export class SpectrumAnalyser {
         }
     }
 
+    /** Performs the FFT and updates the magnitude bins. */
     #update(): void {
         this.#fft.process(this.#real, this.#imag)
         const scale = 1.0 / this.#numBins

--- a/packages/studio/core-processors/src/UpdateClock.ts
+++ b/packages/studio/core-processors/src/UpdateClock.ts
@@ -7,12 +7,20 @@ import {EventBuffer} from "./EventBuffer"
 import {Fragmentor} from "@opendaw/lib-dsp"
 import {UpdateClockRate} from "@opendaw/studio-adapters"
 
+/**
+ * Automation update event distributed by the {@link UpdateClock}.
+ */
 export interface UpdateEvent extends Event {type: "update-event"}
 
 export namespace UpdateEvent {
+    /** Type guard for {@link UpdateEvent}. */
     export const isOfType = (event: Event): event is UpdateEvent => event.type === "update-event"
 }
 
+/**
+ * Generates {@link UpdateEvent}s at a fixed rate while the transport is
+ * running and dispatches them to registered outputs.
+ */
 export class UpdateClock extends AbstractProcessor {
     readonly #outputs: Array<EventBuffer> = []
 
@@ -24,6 +32,7 @@ export class UpdateClock extends AbstractProcessor {
 
     reset(): void {this.eventInput.clear()}
 
+    /** Adds another event buffer that should receive update events. */
     addEventOutput(output: EventBuffer): Terminable {
         this.#outputs.push(output)
         return {terminate: () => Arrays.remove(this.#outputs, output)}

--- a/packages/studio/core-processors/src/constants.ts
+++ b/packages/studio/core-processors/src/constants.ts
@@ -1,1 +1,7 @@
+/**
+ * Number of audio frames processed per Web Audio render quantum.
+ *
+ * The Web Audio API fixes the {@link AudioWorklet} block size to 128 samples.
+ * Using a bitwise OR coerces the number into an {@link int}.
+ */
 export const RenderQuantum = 128 | 0

--- a/packages/studio/core-processors/src/index.ts
+++ b/packages/studio/core-processors/src/index.ts
@@ -1,1 +1,5 @@
+/**
+ * Entry point for the core processor package. The module currently exposes no
+ * runtime API but exists for type documentation purposes.
+ */
 export {}


### PR DESCRIPTION
## Summary
- document core audio processor modules
- add processing flow diagram for core processors

## Testing
- `npm --workspace packages/studio/core-processors test`
- `npm --workspace packages/studio/core-processors run lint` *(fails: ES2015 module syntax is preferred over namespaces)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a86c6d08321a4477c4ebeb19600