### PR TITLE
docs: document adapters and usage

### DIFF
--- a/packages/studio/adapters/README.md
+++ b/packages/studio/adapters/README.md
@@ -1,1 +1,61 @@
-This package is part of the openDAW SDK
+# Studio Adapters
+
+The adapter layer forms the glue between the structured **box** data model and
+audio worklet **processors**. Adapters wrap boxes exported from
+`@opendaw/studio-boxes` and expose convenient TypeScript APIs for the user
+interface and higher level services.
+
+## Adapter pattern
+
+Adapters usually follow the pattern shown below:
+
+```mermaid
+graph LR
+    Box["Box" ] --> Adapter["BoxAdapter"]
+    Adapter --> Processor["Processor"]
+    Adapter --> UI["UI Component"]
+```
+
+* A **Box** stores persistent state.
+* A **BoxAdapter** translates that state into a richer API.
+* A **Processor** (for example {@link @opendaw/studio-core-processors#RecordingProcessor | RecordingProcessor})
+  consumes the state on the audio thread.
+* UI components interact solely with adapters and remain unaware of the
+  underlying storage format.
+
+## Field adapters
+
+The {@link FieldAdapter} and {@link AutomatableParameterFieldAdapter} classes
+wrap individual {@link @opendaw/lib-box#PrimitiveField | primitive fields}.
+They provide value mapping, formatting and—where applicable—automation support
+via the {@link @opendaw/studio-core-processors#AutomatableParameter | AutomatableParameter}
+processor.
+
+```mermaid
+graph LR
+    Field["PrimitiveField"] --> FAdapter["FieldAdapter"]
+    FAdapter --> UI
+    FAdapter --> AP["AutomatableParameter"]
+```
+
+## Collections
+
+When multiple adapters need to be managed, collections such as
+{@link IndexedBoxAdapterCollection} maintain ordering by using the
+{@link IndexComparator}. This is typically employed for device chains or track
+lists where the order is significant.
+
+```mermaid
+graph LR
+    subgraph Chain
+        A1["Device"]
+        A2["Device"]
+        A3["Device"]
+    end
+    Chain --> Collection["IndexedBoxAdapterCollection"] --> Processor
+```
+
+These patterns allow the studio to share behaviour across many different parts
+of the application while keeping the underlying data structures immutable and
+serialisable.
+

--- a/packages/studio/adapters/src/CaptureBox.ts
+++ b/packages/studio/adapters/src/CaptureBox.ts
@@ -1,3 +1,11 @@
 import {CaptureAudioBox, CaptureMidiBox} from "@opendaw/studio-boxes"
 
+/**
+ * Union type for capture boxes used by the {@link @opendaw/studio-core-processors#RecordingProcessor | RecordingProcessor}.
+ *
+ * @remarks
+ * A capture box holds either audio or MIDI data waiting to be recorded. The
+ * corresponding processor reads from these boxes and writes the content to a
+ * {@link RecordingProcessorOptions | ring buffer}.
+ */
 export type CaptureBox = CaptureAudioBox | CaptureMidiBox

--- a/packages/studio/adapters/src/ClipNotifications.ts
+++ b/packages/studio/adapters/src/ClipNotifications.ts
@@ -1,15 +1,27 @@
 import {UUID} from "@opendaw/lib-std"
 
+/**
+ * Describes clip state transitions reported by the
+ * {@link @opendaw/studio-core-processors#EngineProcessor | engine processor}.
+ */
 export type ClipSequencingUpdates = {
+    /** Clips that started playing. */
     started: ReadonlyArray<UUID.Format>
+    /** Clips that stopped playing. */
     stopped: ReadonlyArray<UUID.Format>
-    obsolete: ReadonlyArray<UUID.Format> // were scheduled but never started
+    /** Clips scheduled but never started. */
+    obsolete: ReadonlyArray<UUID.Format>
 }
 
+/**
+ * Notification emitted when clip sequencing state changes.
+ */
 export type ClipNotification = {
+    /** Sequencing changes such as start/stop events. */
     type: "sequencing"
     changes: ClipSequencingUpdates
 } | {
+    /** Clips waiting for resources. */
     type: "waiting"
     clips: ReadonlyArray<UUID.Format>
 }

--- a/packages/studio/adapters/src/ClipSequencing.ts
+++ b/packages/studio/adapters/src/ClipSequencing.ts
@@ -2,12 +2,32 @@ import {Option, Terminable, UUID} from "@opendaw/lib-std"
 import {ppqn} from "@opendaw/lib-dsp"
 import {AnyClipBoxAdapter} from "./UnionAdapterTypes"
 
+/**
+ * A section of the timeline that may contain an optional clip.
+ */
 export type Section = {
+    /** Possible clip adapter active in this section. */
     optClip: Option<AnyClipBoxAdapter>
+    /** Start position of the section in PPQN. */
     sectionFrom: ppqn
+    /** End position of the section in PPQN. */
     sectionTo: ppqn
 }
 
+/**
+ * Iterates over clip sections on a track.
+ *
+ * @remarks
+ * Implementations bridge the timeline adapters with the
+ * {@link @opendaw/studio-core-processors#ClipSequencingAudioContext | audio worklet clip sequencer}.
+ */
 export interface ClipSequencing extends Terminable {
+    /**
+     * Returns all clip sections that intersect the given range.
+     *
+     * @param trackKey - Identifier of the track to query
+     * @param a - start position in PPQN
+     * @param b - end position in PPQN
+     */
     iterate(trackKey: UUID.Format, a: ppqn, b: ppqn): Generator<Section>
 }

--- a/packages/studio/adapters/src/DeviceBox.ts
+++ b/packages/studio/adapters/src/DeviceBox.ts
@@ -2,22 +2,34 @@ import {Pointers} from "@opendaw/studio-enums"
 import {BooleanField, Box, Int32Field, PointerField, StringField} from "@opendaw/lib-box"
 import {isDefined, isInstanceOf, Nullish, panic} from "@opendaw/lib-std"
 
+/**
+ * Shared structure of all device boxes consumed by device processors.
+ *
+ * @see {@link @opendaw/studio-core-processors#DeviceProcessorFactory}
+ */
 export type DeviceBox = {
+    /** Pointer to the hosting track or chain. */
     host: PointerField
+    /** User facing name. */
     label: StringField
+    /** Indicates whether the device is active. */
     enabled: BooleanField
+    /** Persisted UI state. */
     minimized: BooleanField
 } & Box
 
+/** Box describing an instrument device. */
 export type InstrumentDeviceBox = {
     host: PointerField<Pointers.InstrumentHost>
 } & DeviceBox
 
+/** Box describing an audio or MIDI effect device. */
 export type EffectDeviceBox = {
     host: PointerField<Pointers.AudioEffectHost | Pointers.MidiEffectHost>
     index: Int32Field
 } & DeviceBox
 
+/** Helper functions for working with {@link DeviceBox} instances. */
 export namespace DeviceBoxUtils {
     export const isDeviceBox = (box: Box): box is DeviceBox =>
         "host" in box && isInstanceOf(box.host, PointerField) &&

--- a/packages/studio/adapters/src/IconSymbol.ts
+++ b/packages/studio/adapters/src/IconSymbol.ts
@@ -1,3 +1,10 @@
+/**
+ * Enumerates all SVG symbols available in the {@link packages/app/studio/src/ui/components/Icon.tsx | Icon} system.
+ *
+ * @remarks
+ * Adapters and UI components reference these values instead of dealing with raw
+ * paths.  New icons can be added here and consumed throughout the application.
+ */
 export enum IconSymbol {
     Rectangle,
     Checkbox,
@@ -114,7 +121,9 @@ export enum IconSymbol {
 }
 
 export namespace IconSymbol {
+    /** Returns the enum key for the given symbol. */
     export const toName = (symbol: IconSymbol): string => IconSymbol[symbol]
+    /** Looks up a symbol by its string name. */
     export const fromName = (name: keyof typeof IconSymbol | string): IconSymbol =>
         <IconSymbol>IconSymbol[name as keyof typeof IconSymbol] ?? IconSymbol.Rectangle
 }

--- a/packages/studio/adapters/src/IndexComparator.ts
+++ b/packages/studio/adapters/src/IndexComparator.ts
@@ -1,5 +1,10 @@
 import {Comparator, int, panic} from "@opendaw/lib-std"
 
+/**
+ * Comparator used for sorting adapter collections by their index field.
+ *
+ * @see {@link IndexedBoxAdapterCollection}
+ */
 export const IndexComparator: Comparator<int> = (a: int, b: int): int => {
     if (a === b) {return 0}
     const difference: int = a - b
@@ -8,3 +13,4 @@ export const IndexComparator: Comparator<int> = (a: int, b: int): int => {
     }
     return difference
 }
+

--- a/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
+++ b/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
@@ -18,14 +18,23 @@ import {AdapterCollectionListener} from "./BoxAdapterCollection"
 import {IndexComparator} from "./IndexComparator"
 import {BoxAdapter} from "./BoxAdapter"
 
+/** Adapter that exposes an `index` field used for ordering. */
 export interface IndexedBoxAdapter extends BoxAdapter {
     indexField: Int32Field
 }
 
+/** Listener receiving notifications about collection changes. */
 export interface IndexedAdapterCollectionListener<A extends IndexedBoxAdapter> extends AdapterCollectionListener<A> {
     onReorder(adapter: A): void
 }
 
+/**
+ * Manages a set of adapters ordered by an index field.
+ *
+ * @remarks
+ * Internally a {@link SortedSet} keyed by {@link UUID} is used. Reordering
+ * is detected via {@link IndexComparator} and broadcast to listeners.
+ */
 export class IndexedBoxAdapterCollection<A extends IndexedBoxAdapter, P extends Pointers> implements Terminable {
     static create<A extends IndexedBoxAdapter, P extends Pointers>(field: Field<P>,
                                                                    provider: Func<Box, A>,

--- a/packages/studio/adapters/src/NoteSender.ts
+++ b/packages/studio/adapters/src/NoteSender.ts
@@ -1,11 +1,24 @@
 import {byte, Terminable, unitValue} from "@opendaw/lib-std"
 
+/**
+ * Abstraction for sending note events to an instrument or processor.
+ *
+ * @remarks
+ * Used by adapters to trigger notes on devices such as the
+ * {@link @opendaw/studio-core-processors#PlayfieldDeviceProcessor | Playfield} instrument.
+ */
 export interface NoteSender {
+    /** Starts a note with the given velocity. */
     noteOn(note: byte, velocity: unitValue): void
+    /** Stops a playing note. */
     noteOff(note: byte): void
 }
 
+/** Utilities for sustaining notes until explicitly released. */
 export namespace NoteSustainer {
+    /**
+     * Starts a note and returns a handle that releases it when terminated.
+     */
     export const start = (sender: NoteSender, note: byte, velocity: unitValue = 1.0): Terminable => {
         let playing = true
         sender.noteOn(note, velocity)

--- a/packages/studio/adapters/src/PeakMeterProcessorOptions.ts
+++ b/packages/studio/adapters/src/PeakMeterProcessorOptions.ts
@@ -1,8 +1,20 @@
 import {int} from "@opendaw/lib-std"
 
+/**
+ * Options for the {@link @opendaw/studio-core-processors#MeterProcessor | peak meter processor}.
+ *
+ * @remarks
+ * The processor writes level information into the supplied `SharedArrayBuffer`.
+ * Adapters mirror that state on the main thread to visualise signal peaks and
+ * RMS levels.
+ */
 export interface PeakMeterProcessorOptions {
+    /** Shared buffer used to exchange metering data. */
     sab: SharedArrayBuffer
+    /** Number of channels the meter processes. */
     numberOfChannels: int
+    /** Window size for RMS calculation. */
     rmsWindowInSeconds: number
+    /** Decay factor applied to peak values. */
     valueDecay: number
 }

--- a/packages/studio/adapters/src/PianoModeAdapter.ts
+++ b/packages/studio/adapters/src/PianoModeAdapter.ts
@@ -3,6 +3,14 @@ import {float, int, Observer, StringMapping, Subscription, ValueMapping} from "@
 import {FieldAdapter} from "./FieldAdapter"
 import {Propagation} from "@opendaw/lib-box"
 
+/**
+ * Adapter exposing the editable fields of {@link PianoMode} to the UI.
+ *
+ * @remarks
+ * The piano mode controls the visual appearance of the piano roll. The adapter
+ * wraps individual fields with {@link FieldAdapter}s so that widgets can bind
+ * to them easily.
+ */
 export class PianoModeAdapter {
     readonly #object: PianoMode
 
@@ -39,6 +47,9 @@ export class PianoModeAdapter {
             StringMapping.numeric({fractionDigits: 0}), "Transpose")
     }
 
+    /**
+     * Subscribes to changes on any field contained in the piano mode.
+     */
     subscribe(observer: Observer<this>): Subscription {
         return this.#object.box.subscribe(Propagation.Children, () => observer(this))
     }

--- a/packages/studio/adapters/src/RecordingProcessorOptions.ts
+++ b/packages/studio/adapters/src/RecordingProcessorOptions.ts
@@ -1,3 +1,11 @@
 import {RingBuffer} from "./RingBuffer"
 
+/**
+ * Configuration for the {@link @opendaw/studio-core-processors#RecordingProcessor | RecordingProcessor}.
+ *
+ * @remarks
+ * These options describe the shared audio {@link RingBuffer} that transfers
+ * recorded data from the audio worklet to the main thread.
+ */
 export interface RecordingProcessorOptions extends RingBuffer.Config {}
+

--- a/packages/studio/adapters/src/RingBuffer.ts
+++ b/packages/studio/adapters/src/RingBuffer.ts
@@ -2,7 +2,13 @@ import {Arrays, assert, int, panic, Procedure} from "@opendaw/lib-std"
 
 declare let document: any
 
+/**
+ * Utility for transferring planar audio data between threads using a shared
+ * {@link SharedArrayBuffer}.  The same structure is used by the
+ * {@link @opendaw/studio-core-processors#RecordingProcessor | RecordingProcessor}.
+ */
 export namespace RingBuffer {
+    /** Configuration for a ring buffer. */
     export interface Config {
         sab: SharedArrayBuffer
         numChunks: int
@@ -10,10 +16,15 @@ export namespace RingBuffer {
         bufferSize: int
     }
 
+    /** Writes chunks of audio into the buffer. */
     export interface Writer {write(channels: ReadonlyArray<Float32Array>): void}
 
+    /** Reads chunks from the buffer until {@link Reader.stop} is called. */
     export interface Reader {stop(): void}
 
+    /**
+     * Creates a reader that appends each chunk to the provided callback.
+     */
     export const reader = ({
                                sab,
                                numChunks,
@@ -58,6 +69,9 @@ export namespace RingBuffer {
         return {stop: () => running = false}
     }
 
+    /**
+     * Creates a writer for the given configuration.
+     */
     export const writer = ({sab, numChunks, numberOfChannels, bufferSize}: Config): Writer => {
         const pointers = new Int32Array(sab, 0, 2)
         const audio = new Float32Array(sab, 8)
@@ -81,7 +95,9 @@ export namespace RingBuffer {
         })
     }
 }
-
+/**
+ * Flattens an array of planar chunks into contiguous channel buffers.
+ */
 export const mergeChunkPlanes = (chunks: ReadonlyArray<ReadonlyArray<Float32Array>>,
                                  bufferSize: int,
                                  maxFrames: int = Number.MAX_SAFE_INTEGER): ReadonlyArray<Float32Array> => {

--- a/packages/studio/adapters/src/UnionAdapterTypes.ts
+++ b/packages/studio/adapters/src/UnionAdapterTypes.ts
@@ -7,14 +7,22 @@ import {AudioClipBoxAdapter} from "./timeline/clip/AudioClipBoxAdapter"
 import {BoxAdapter} from "./BoxAdapter"
 import {UnionBoxTypes} from "./unions"
 
+/** Union type of any clip adapter. */
 export type AnyClipBoxAdapter = NoteClipBoxAdapter | ValueClipBoxAdapter | AudioClipBoxAdapter
 
+/** Union type of any region adapter. */
 export type AnyRegionBoxAdapter = NoteRegionBoxAdapter | ValueRegionBoxAdapter | AudioRegionBoxAdapter
+/** Region adapter that supports looping. */
 export type AnyLoopableRegionBoxAdapter = AnyRegionBoxAdapter // TODO Clarify
 
+/**
+ * Type guards for working with unions of adapter types.
+ */
 export const UnionAdapterTypes = {
+    /** Returns true when the adapter wraps a region box. */
     isRegion: (adapter: BoxAdapter): adapter is AnyRegionBoxAdapter =>
         UnionBoxTypes.isRegionBox(adapter.box),
+    /** Returns true when the adapter wraps a loopable region. */
     isLoopableRegion: (adapter: BoxAdapter): adapter is AnyLoopableRegionBoxAdapter =>
         UnionBoxTypes.isLoopableRegionBox(adapter.box)
 }

--- a/packages/studio/adapters/src/UpdateClockRate.ts
+++ b/packages/studio/adapters/src/UpdateClockRate.ts
@@ -1,3 +1,13 @@
 import {PPQN} from "@opendaw/lib-dsp"
 
+/**
+ * Pulse–per–quarter-note resolution used by the {@link @opendaw/studio-core-processors#UpdateClock | UpdateClock} processor.
+ *
+ * @remarks
+ * The constant defines how often the engine emits update events.  Adapters that
+ * schedule parameter changes should use the same resolution so that the main
+ * thread and the audio worklet remain in sync.
+ *
+ * @see {@link @opendaw/studio-core-processors#UpdateClock}
+ */
 export const UpdateClockRate = PPQN.fromSignature(1, 384)


### PR DESCRIPTION
## Summary
- add TSDoc and usage guidance across adapter helpers and collections
- explain adapter patterns with diagrams in a new README

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/studio-enums#lint)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a8896ec8321868e262acd4d3097