### PR TITLE
docs: refresh developer guides

### DIFF
--- a/packages/docs/docs-dev/api-coverage.md
+++ b/packages/docs/docs-dev/api-coverage.md
@@ -2,9 +2,11 @@
 
 Documentation coverage measured with `typedoc-plugin-coverage`:
 
-- `@opendaw/lib-runtime`: 0%
-- `@opendaw/lib-dsp`: 0%
-- `@opendaw/lib-midi`: 2%
+- [`@opendaw/lib-runtime`](./package-inventory.md#lib) – 0%
+- [`@opendaw/lib-dsp`](./package-inventory.md#lib) – 0%
+- [`@opendaw/lib-midi`](./package-inventory.md#lib) – 2%
+
+See the full list of packages in the [package inventory](./package-inventory.md).
 
 ## Running `typedoc-plugin-coverage`
 
@@ -54,3 +56,6 @@ A typical `coverage.json` looks like:
 - Include descriptions, parameter/return tags, and examples as needed.
 - Re‑run the coverage command to ensure the percentage increases and the
   `notDocumented` list shrinks.
+
+Contributions to improve coverage are welcome—see
+[Contributing](./contributing.md) for guidelines.

--- a/packages/docs/docs-dev/architecture/audio-path.md
+++ b/packages/docs/docs-dev/architecture/audio-path.md
@@ -1,6 +1,8 @@
 # Audio Path and Scheduler
 
-The sequence below shows how audio events travel through the system.
+openDAW's timing engine lives in
+[`@opendaw/studio-core`](../package-inventory.md#studio). The sequence below
+shows how audio events travel through the system.
 
 ```mermaid
 sequenceDiagram
@@ -34,3 +36,5 @@ stateDiagram-v2
 
 Events enter the **queued** state when the app submits them to the scheduler. At their scheduled time they move to the **running** state as the scheduler dispatches them to the audio engine. Once an event has been processed by the audio engine it reaches the **completed** state, leaving the scheduler's active set.
 
+See the [architecture overview](./overview.md) for the big picture and
+the [performance guide](../performance.md) for profiling tips.

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -1,6 +1,9 @@
 # Architecture Overview
 
-The architecture of openDAW is described using the C4 model.
+openDAW is composed of several packages such as
+[`@opendaw/app-studio`](../package-inventory.md#app) and
+[`@opendaw/studio-core`](../package-inventory.md#studio). The architecture is
+described using the C4 model.
 
 ## Context
 
@@ -51,7 +54,14 @@ C4Component
     Rel(studio, lib, "Uses")
 ```
 
-- **App** – Provides the user interface and coordinates system interactions.
-- **Studio** – Handles audio processing, scheduling, and engine control.
-- **Lib** – Supplies shared utilities and reusable logic across modules.
-- **Config** – Delivers runtime and build settings consumed by other components.
+- **App** – Provides the user interface and coordinates system interactions. Implemented in
+  [`@opendaw/app-studio`](../package-inventory.md#app).
+- **Studio** – Handles audio processing, scheduling, and engine control. Powered by
+  [`@opendaw/studio-core`](../package-inventory.md#studio).
+- **Lib** – Supplies shared utilities and reusable logic across modules from packages like
+  [`@opendaw/lib-runtime`](../package-inventory.md#lib).
+- **Config** – Delivers runtime and build settings consumed by other components through
+  [`@opendaw/eslint-config`](../package-inventory.md#config) and related packages.
+
+For a deeper look at timing, see the [audio path](./audio-path.md), and
+learn how to build the project in [Build and Run](../build-and-run/setup.md).

--- a/packages/docs/docs-dev/browser-support.md
+++ b/packages/docs/docs-dev/browser-support.md
@@ -1,10 +1,16 @@
 # Browser Support
 
-openDAW targets modern browsers with full Web Audio and WebAssembly support. The project is regularly tested on:
+openDAW targets modern browsers with full Web Audio and WebAssembly support.
+Packages like [`@opendaw/app-studio`](./package-inventory.md#app) and
+[`@opendaw/lib-dsp`](./package-inventory.md#lib) rely on these APIs. The project
+is regularly tested on:
 
 - **Chrome** (latest stable)
 - **Firefox** (latest stable)
 - **Safari** on macOS/iOS
 - **Edge** (Chromium)
 
-Other evergreen browsers that implement the necessary APIs may work but are not officially supported. Ensure your browser is updated to the latest version for the best experience.
+Other evergreen browsers that implement the necessary APIs may work but are not
+officially supported. Ensure your browser is updated to the latest version for
+the best experience. See [Build and Run](./build-and-run/setup.md) for setup
+instructions.

--- a/packages/docs/docs-dev/build-and-run/profiling.md
+++ b/packages/docs/docs-dev/build-and-run/profiling.md
@@ -1,0 +1,24 @@
+# Profiling
+
+Profiling helps catch hot spots in packages like
+[`@opendaw/lib-dsp`](../package-inventory.md#lib) and
+[`@opendaw/app-studio`](../package-inventory.md#app).
+Complete the [tests](./tests.md) before capturing profiles.
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant App as App
+  participant Tools as DevTools
+  Dev->>App: run scenario
+  App->>Tools: record trace
+  Tools-->>Dev: performance data
+```
+
+1. Open Chrome and launch the studio with `npm run dev:studio`.
+2. In DevTools, switch to the **Performance** panel and start recording.
+3. Interact with openDAW, then stop the recording to review CPU and audio
+   statistics.
+
+Refer to the [performance guide](../performance.md) for detailed screenshots and
+hints.

--- a/packages/docs/docs-dev/build-and-run/setup.md
+++ b/packages/docs/docs-dev/build-and-run/setup.md
@@ -1,5 +1,10 @@
 # Setup
 
+These steps build the packages
+[`@opendaw/app-studio`](../package-inventory.md#app) and
+[`@opendaw/app-headless`](../package-inventory.md#app). Follow them after
+confirming [browser support](../browser-support.md).
+
 ## Prerequisites
 
 Before starting, install the following tools for your platform.
@@ -59,6 +64,9 @@ Before starting, install the following tools for your platform.
    ```bash
    npm run dev:headless
    ```
+
+Proceed to [running tests](./tests.md) or learn about
+[profiling](./profiling.md).
 
 ## Troubleshooting
 

--- a/packages/docs/docs-dev/build-and-run/tests.md
+++ b/packages/docs/docs-dev/build-and-run/tests.md
@@ -1,0 +1,22 @@
+# Tests
+
+After completing the [setup](./setup.md), verify that all packages build and
+behave correctly by running the monorepo tests.
+
+```bash
+npm test
+```
+
+This command executes unit tests for packages such as
+[`@opendaw/lib-runtime`](../package-inventory.md#lib) and
+[`@opendaw/studio-core`](../package-inventory.md#studio).
+
+```mermaid
+flowchart LR
+  A[Build] --> B[Test]
+  B --> C[Profile]
+```
+
+If a test fails, consult the logs for the specific package. See
+[Contributing](../contributing.md) for pull request guidelines and proceed to
+[profiling](./profiling.md) to analyze performance.

--- a/packages/docs/docs-dev/contributing.md
+++ b/packages/docs/docs-dev/contributing.md
@@ -1,13 +1,19 @@
 # Contributing
 
-This project welcomes pull requests from the community. Before submitting changes, please:
+This project welcomes pull requests from the community. openDAW consists of
+packages like [`@opendaw/app-studio`](./package-inventory.md#app) and
+[`@opendaw/lib-dsp`](./package-inventory.md#lib). Before submitting changes,
+please:
 
 1. Fork the repository and create a feature branch.
-2. Install dependencies with `npm install`.
+2. Install dependencies with `npm install`. See
+   [Setup](./build-and-run/setup.md) for details.
 3. Format and lint your work:
    - `npx prettier --write <files>`
    - `npm run lint`
-4. Run tests with `npm test`.
+4. Run tests with `npm test` (see [Tests](./build-and-run/tests.md)).
 5. Commit with clear messages and open a pull request against `main`.
 
-For more detail, see the root [CONTRIBUTING.md](../../../../CONTRIBUTING.md).
+For profiling advice, read the [Profiling guide](./build-and-run/profiling.md).
+See [Licensing](./licensing.md) for information on the dual license. For more
+detail, see the root [CONTRIBUTING.md](../../../../CONTRIBUTING.md).

--- a/packages/docs/docs-dev/extending/opendaw-sdk.md
+++ b/packages/docs/docs-dev/extending/opendaw-sdk.md
@@ -1,6 +1,10 @@
 # openDAW SDK
 
-The openDAW SDK enables developers to extend the workstation with custom devices, user interfaces, and tools. This guide covers installation, the device/box lifecycle, and the public extension points exposed by the platform.
+The openDAW SDK enables developers to extend the workstation with custom
+devices, user interfaces, and tools. The SDK is published as
+[`@opendaw/sdk`](../package-inventory.md#studio). This guide covers
+installation, the device/box lifecycle, and the public extension points exposed
+by the platform.
 
 ## Installation
 
@@ -73,3 +77,8 @@ The following APIs are stable and intended for third‑party development:
 - **Project tooling** – Use the SDK's serialization helpers to read and write project data for import/export tools.
 
 These entry points provide flexibility for building plugins, tools, or entire workflows on top of openDAW.
+
+Next steps:
+
+- Follow the [Plugin guide](./plugin-guide.md) to integrate custom UI.
+- Implement audio nodes with the [Processor guide](./processor-guide.md).

--- a/packages/docs/docs-dev/extending/plugin-guide.md
+++ b/packages/docs/docs-dev/extending/plugin-guide.md
@@ -1,0 +1,18 @@
+# Plugin Guide
+
+Use the openDAW SDK to build UI plugins that run inside
+[`@opendaw/app-studio`](../package-inventory.md#app).
+Start with the [openDAW SDK](./opendaw-sdk.md) and stage a box that exposes
+parameters and controls.
+
+```mermaid
+flowchart LR
+  A[Plugin UI] --> B[@opendaw/app-studio]
+  B --> C[Audio Graph]
+```
+
+1. Create a new project and install `@opendaw/sdk`.
+2. Implement a box with parameters that drive your UI.
+3. Register the plugin so the Studio can load it.
+
+For DSP customization see the [Processor guide](./processor-guide.md).

--- a/packages/docs/docs-dev/extending/processor-guide.md
+++ b/packages/docs/docs-dev/extending/processor-guide.md
@@ -1,0 +1,21 @@
+# Processor Guide
+
+Processors perform custom audio worklets or DSP in packages like
+[`@opendaw/lib-dsp`](../package-inventory.md#lib).
+Combine them with plugins from the [Plugin guide](./plugin-guide.md) for a full
+extension.
+
+```mermaid
+sequenceDiagram
+  participant Host as Studio
+  participant Proc as Processor
+  Host->>Proc: call process()
+  Proc-->>Host: audio frames
+```
+
+1. Implement an AudioWorkletProcessor or Box that processes audio buffers.
+2. Expose parameters using fields so plugins can control them.
+3. Profile performance using the [Profiling guide](../build-and-run/profiling.md).
+
+Review the [openDAW SDK](./opendaw-sdk.md) for shared utilities and best
+practices.

--- a/packages/docs/docs-dev/intro.md
+++ b/packages/docs/docs-dev/intro.md
@@ -1,9 +1,22 @@
 # Developer Docs
 
-The developer documentation provides guidance for contributing to openDAW. Learn how to [build and run](./build-and-run/setup.md) the project, explore its [architecture](./architecture/overview.md), and ensure quality with [testing and QA](./testing-and-qa/index.md).
+The developer documentation provides guidance for contributing to openDAW's
+packages such as [`@opendaw/app-studio`](./package-inventory.md#app). Learn how
+to [build and run](./build-and-run/setup.md) the project, explore its
+[architecture](./architecture/overview.md), and ensure quality with
+[testing and QA](./testing-and-qa/index.md).
 
 ## Table of Contents
 
 - [Build and Run](./build-and-run/setup.md)
+- [Tests](./build-and-run/tests.md)
+- [Profiling](./build-and-run/profiling.md)
 - [Architecture](./architecture/overview.md)
-- [Testing and QA](./testing-and-qa/index.md)
+- [Audio Path](./architecture/audio-path.md)
+- [Browser Support](./browser-support.md)
+- [Package Inventory](./package-inventory.md)
+- [API Coverage](./api-coverage.md)
+- [Performance](./performance.md)
+- [Extending](./extending/opendaw-sdk.md)
+- [Contributing](./contributing.md)
+- [Licensing](./licensing.md)

--- a/packages/docs/docs-dev/licensing.md
+++ b/packages/docs/docs-dev/licensing.md
@@ -1,10 +1,12 @@
 # Licensing
 
-openDAW is released under a dual-license model:
+openDAW and all [`@opendaw`](./package-inventory.md) packages are released
+under a dual-license model:
 
 - **GPL v3 (or later)** for open-source use. Derivative works must also be GPL-compatible.
 - **Commercial licenses** are available for projects that cannot comply with GPL requirements.
 
-To obtain a commercial license, contact `andre.michelle@opendaw.org` with your project details.
+To obtain a commercial license, contact `andre.michelle@opendaw.org` with your
+project details. Contributors should review the [Contributing guide](./contributing.md).
 
 See the root [LICENSE](../../../../LICENSE) file and [README](../../../../README.md#dual-licensing-model) for more information.

--- a/packages/docs/docs-dev/package-inventory.md
+++ b/packages/docs/docs-dev/package-inventory.md
@@ -4,8 +4,11 @@ A high level overview of the packages in this repository.
 
 | Package  | Responsibility                                                        |
 | -------- | --------------------------------------------------------------------- |
-| `app`    | User-facing applications. Includes the Studio and Headless apps.      |
-| `config` | Shared configuration such as ESLint and TypeScript settings.          |
-| `docs`   | Documentation site and developer guides.                              |
-| `lib`    | Reusable libraries for DSP, DOM helpers, runtime utilities, and more. |
-| `studio` | Core audio engine components, adapters, and scheduling modules.       |
+| `app`    | User-facing applications. Includes `@opendaw/app-studio` and `@opendaw/app-headless`. |
+| `config` | Shared configuration such as `@opendaw/eslint-config` and TypeScript settings. |
+| `docs`   | Documentation site and developer guides like this one.                |
+| `lib`    | Reusable libraries for DSP, DOM helpers, runtime utilities, and more, e.g. `@opendaw/lib-dsp` and `@opendaw/lib-runtime`. |
+| `studio` | Core audio engine components, adapters, and scheduling modules such as `@opendaw/studio-core`. |
+
+Refer back to these packages when following the [build and run](./build-and-run/setup.md)
+instructions or the [extending guides](./extending/opendaw-sdk.md).

--- a/packages/docs/docs-dev/performance.md
+++ b/packages/docs/docs-dev/performance.md
@@ -1,6 +1,9 @@
 # Performance
 
-openDAW runs entirely in the browser and aims to stay responsive even with complex projects. Performance tips for contributors:
+openDAW runs entirely in the browser and aims to stay responsive even with
+complex projects. Packages like [`@opendaw/lib-dsp`](./package-inventory.md#lib)
+and [`@opendaw/app-studio`](./package-inventory.md#app) benefit from regular
+profiling. Performance tips for contributors:
 
 - Avoid heavy allocations in the audio thread; prefer pre-allocated buffers.
 - Use Web Workers or AudioWorklets for CPU‑intensive tasks.
@@ -9,7 +12,8 @@ openDAW runs entirely in the browser and aims to stay responsive even with compl
 
 ## Capturing performance traces in Chrome DevTools
 
-Chrome's Performance panel helps diagnose rendering or audio hiccups. To capture a trace:
+Chrome's Performance panel helps diagnose rendering or audio hiccups. To capture
+a trace (see also the [Profiling guide](./build-and-run/profiling.md)):
 
 1. **Open DevTools** – Press `F12` or `Cmd+Option+I` / `Ctrl+Shift+I` in Chrome.
    ![Open DevTools](../static/img/performance-open-devtools.svg) <!-- TODO: add screenshot -->
@@ -22,4 +26,5 @@ Chrome's Performance panel helps diagnose rendering or audio hiccups. To capture
 5. **Save the trace (optional)** – Use the export icon to save a `.json` trace file for sharing in pull requests.
    ![Save trace](../static/img/performance-save.svg) <!-- TODO: add screenshot -->
 
-Contributors are encouraged to document any performance benchmarks or profiling results in pull requests.
+Contributors are encouraged to document any performance benchmarks or profiling
+results in pull requests.


### PR DESCRIPTION
## Summary
- cross-link docs and reference current `@opendaw` packages
- add test, profiling, plugin, and processor guides
- refresh architecture, performance, licensing, and other pages

## Testing
- `npx prettier packages/docs/docs-dev/**/*.md --check`
- `npm run lint` *(fails: command exited (2))*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae9a8a11e8832190f89eaeaf24c054