### PR TITLE
Add interactive lessons with diagrams and quizzes

### DIFF
--- a/packages/docs/docs-learn/daw-basics-101.md
+++ b/packages/docs/docs-learn/daw-basics-101.md
@@ -26,3 +26,15 @@ flowchart LR
 ## Next Steps
 
 Continue to the next lesson to learn how to create tracks, record audio, and use basic effects.
+
+## Quiz
+
+1. What component combines tracks and controls their levels?
+   - [ ] Timeline
+   - [x] Mixer
+   - [ ] Automation lane
+2. Automation is used to record changes to parameters over what?
+   - [ ] Frequency
+   - [ ] File size
+   - [x] Time
+

--- a/packages/docs/docs-learn/how-it-works/latency-and-buffers.md
+++ b/packages/docs/docs-learn/how-it-works/latency-and-buffers.md
@@ -5,6 +5,14 @@ contains a fixed number of samples that the audio hardware consumes at regular
 intervals. The time between these hardware callbacks determines the base
 latency of the system.
 
+```mermaid
+flowchart LR
+    UserInput[User Input] --> Engine
+    Engine --> Buffer[Audio Buffer]
+    Buffer --> Hardware[Audio Hardware]
+    Hardware --> Output[Speakers]
+```
+
 ## Buffer size and latency
 
 Smaller buffers reduce latency because the audio thread delivers audio to the
@@ -28,3 +36,15 @@ graph, are queued into buffers, and finally emerge from the speakers after the
 hardware has processed them. Monitoring external signals adds another trip
 through the converters. Understanding this round-trip time is essential when
 recording or synchronising with other gear.
+
+## Quiz
+
+1. What is the trade-off when using smaller audio buffers?
+   - [ ] More stable playback but higher latency
+   - [x] Lower latency but increased risk of glitches
+   - [ ] No change in latency or performance
+2. Which component ultimately turns buffered audio into sound?
+   - [ ] Mixer
+   - [ ] Sequencer
+   - [x] Audio hardware
+

--- a/packages/docs/docs-learn/how-it-works/storage-model.md
+++ b/packages/docs/docs-learn/how-it-works/storage-model.md
@@ -28,3 +28,15 @@ To avoid data loss, openDAW periodically creates a backup of the OPFS data. The
 backup can be written to IndexedDB or synchronised with a backend service when
 the user is online. Restoring from a backup repopulates the OPFS directory so
 that work can continue even after clearing browser storage.
+
+## Quiz
+
+1. What browser feature does openDAW use to store project data locally?
+   - [x] Origin Private File System (OPFS)
+   - [ ] LocalStorage
+   - [ ] Cookies
+2. Why might you export a backup of your project?
+   - [ ] To increase latency
+   - [x] To protect against data loss
+   - [ ] To change the audio sample rate
+

--- a/packages/docs/docs-learn/intro.md
+++ b/packages/docs/docs-learn/intro.md
@@ -5,12 +5,38 @@ Start with **[DAW Basics 101](./daw-basics-101.md)** to learn core concepts
 like tracks, the mixer, and automation. Lessons build on each other, so work
 through them in order or jump to topics using the sidebar.
 
+```mermaid
+graph LR
+    Basics["DAW Basics"] --> Arrangement["Arrangement Basics"]
+    Arrangement --> Effects["Audio Effects"]
+    Effects --> MIDI["MIDI & Synthesis"]
+    MIDI --> Mixing["Mixing Techniques"]
+    Mixing --> Automation["Automation"]
+    Automation --> Export["Exporting & Sharing"]
+```
+
 ## Lessons
 
 - [Audio Effects and Signal Chain](./lessons/audio-effects-and-signal-chain.md)
 - [MIDI and Synthesis](./lessons/midi-and-synthesis.md)
+- [Arrangement Basics](./lessons/arrangement-basics.md)
+- [Mixing Techniques](./lessons/mixing-techniques.md)
+- [Automation](./lessons/automation.md)
+- [Exporting and Sharing](./lessons/exporting-and-sharing.md)
 - [Latency and Buffers](./how-it-works/latency-and-buffers.md)
 - [Storage Model](./how-it-works/storage-model.md)
 
 Each page includes links to the next step so you can follow a continuous
 learning path or explore individual subjects as needed.
+
+## Quiz
+
+1. Which lesson covers balancing levels and EQ?
+   - [ ] Arrangement Basics
+   - [x] Mixing Techniques
+   - [ ] Storage Model
+2. Which topic shows how to share your finished track?
+   - [ ] MIDI and Synthesis
+   - [ ] Latency and Buffers
+   - [x] Exporting and Sharing
+

--- a/packages/docs/docs-learn/lessons/arrangement-basics.md
+++ b/packages/docs/docs-learn/lessons/arrangement-basics.md
@@ -1,0 +1,22 @@
+# Arrangement Basics
+
+Crafting a song involves placing sections on the timeline so that the music unfolds logically.
+
+## Song Structure
+
+```mermaid
+graph LR
+    Intro --> Verse --> Chorus --> Bridge --> Outro
+```
+
+## Quiz
+
+1. Which section typically follows the verse in a pop song?
+   - [ ] Intro
+   - [x] Chorus
+   - [ ] Outro
+2. What does arranging primarily focus on?
+   - [x] Ordering clips and sections
+   - [ ] Adjusting effect parameters
+   - [ ] Exporting audio files
+

--- a/packages/docs/docs-learn/lessons/audio-effects-and-signal-chain.md
+++ b/packages/docs/docs-learn/lessons/audio-effects-and-signal-chain.md
@@ -25,3 +25,15 @@ graph LR
 ```
 
 Experiment by reordering effects to discover new textures.
+
+## Quiz
+
+1. Where do you insert an effect in openDAW?
+   - [ ] On the master bus only
+   - [x] On individual tracks via the effects panel
+   - [ ] You cannot insert effects
+2. What happens when you change the order of effects in a chain?
+   - [ ] The sound is unaffected
+   - [x] Each processor receives a different input resulting in new textures
+   - [ ] The track is muted
+

--- a/packages/docs/docs-learn/lessons/automation.md
+++ b/packages/docs/docs-learn/lessons/automation.md
@@ -1,0 +1,22 @@
+# Automation
+
+Automation records parameter changes so they play back exactly as performed.
+
+## Envelope Flow
+
+```mermaid
+graph LR
+    Envelope --> Parameter --> Sound
+```
+
+## Quiz
+
+1. Automation data changes a parameter over what?
+   - [x] Time
+   - [ ] File size
+   - [ ] Tempo only
+2. Where can you edit automation in openDAW?
+   - [ ] The export window
+   - [x] An automation lane
+   - [ ] The audio hardware
+

--- a/packages/docs/docs-learn/lessons/exporting-and-sharing.md
+++ b/packages/docs/docs-learn/lessons/exporting-and-sharing.md
@@ -1,0 +1,22 @@
+# Exporting and Sharing
+
+Once a mix is finished you can render it to a file and share it with others.
+
+## Export Path
+
+```mermaid
+flowchart LR
+    Project --> Mixdown --> File --> Share["Share Online"]
+```
+
+## Quiz
+
+1. What is the final step before distributing your track?
+   - [ ] Recording more instruments
+   - [x] Exporting or bouncing to an audio file
+   - [ ] Deleting the project
+2. Why choose a lossless format when exporting?
+   - [x] To preserve audio quality
+   - [ ] To reduce file size as much as possible
+   - [ ] To remove effects from the mix
+

--- a/packages/docs/docs-learn/lessons/midi-and-synthesis.md
+++ b/packages/docs/docs-learn/lessons/midi-and-synthesis.md
@@ -43,3 +43,15 @@ flowchart LR
 6. **Experiment further** – Change note lengths, velocities or instrument presets to explore how MIDI data affects synthesis.
 
 By sending MIDI messages to a synth and tweaking its parameters you build an intuitive understanding of how electronic instruments create sound.
+
+## Quiz
+
+1. What does a MIDI clip contain?
+   - [x] Note data
+   - [ ] Audio samples
+   - [ ] Effect presets
+2. Which message tells a synth to start playing a note?
+   - [ ] noteOff
+   - [x] noteOn
+   - [ ] velocityChange
+

--- a/packages/docs/docs-learn/lessons/mixing-techniques.md
+++ b/packages/docs/docs-learn/lessons/mixing-techniques.md
@@ -1,0 +1,22 @@
+# Mixing Techniques
+
+Mixing balances the elements of a project so that they work together.
+
+## Signal Flow
+
+```mermaid
+graph LR
+    Tracks --> Mixer --> Effects --> Master --> Output
+```
+
+## Quiz
+
+1. What component controls the level of each track in a mix?
+   - [x] Mixer fader
+   - [ ] Arrangement view
+   - [ ] Export dialog
+2. Which processor shapes the frequency content of audio?
+   - [x] Equaliser (EQ)
+   - [ ] MIDI sequencer
+   - [ ] File browser
+


### PR DESCRIPTION
## Summary
- add quizzes to existing learning hub pages
- introduce four new lessons with diagrams and review questions
- map out learning path with a mermaid diagram

## Testing
- `npm test` *(fails: command exited (1))*
- `npm run lint` *(fails: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_b_68ae9a8d4d508321820f6fab8ec28727