### PR TITLE
docs(dom): expand docs and fix modifier key file name

### DIFF
--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -54,7 +54,6 @@ C4Component
     Rel(studio, lib, "Uses")
 ```
 
-
 - **App** – Provides the user interface and coordinates system interactions. Implemented in
   [`@opendaw/app-studio`](../package-inventory.md#app).
 - **Studio** – Handles audio processing, scheduling, and engine control. Powered by
@@ -91,4 +90,4 @@ needed.
 For details about the studio runtime internals see the
 [studio core README](../../../studio/core/README.md).
 
-
+Additional utilities for DOM interactions are described in the [DOM developer docs](../dom/overview.md).

--- a/packages/docs/docs-dev/dom/errors.md
+++ b/packages/docs/docs-dev/dom/errors.md
@@ -1,0 +1,14 @@
+# Errors
+
+`errors.ts` contains helpers for working with DOM related error conditions
+such as wrapping thrown exceptions or normalising browser specific error
+messages.
+
+```ts
+import { DomError } from "@opendaw/lib-dom";
+try {
+  // risky operation
+} catch (e) {
+  throw new DomError("Failed to execute", e);
+}
+```

--- a/packages/docs/docs-dev/dom/events.md
+++ b/packages/docs/docs-dev/dom/events.md
@@ -1,0 +1,15 @@
+# Events
+
+Utilities for dealing with DOM events live in `events.ts`. They provide
+strongly typed wrappers around common event patterns.
+
+```ts
+import { Events } from "@opendaw/lib-dom";
+const sub = Events.subscribe(window, "resize", () => console.log("resized"));
+// later
+sub.terminate();
+```
+
+The module also contains helpers for pointer capturing and text-input
+checks that are used by higher level features such as dragging and
+keyboard shortcuts.

--- a/packages/docs/docs-dev/dom/graphics.md
+++ b/packages/docs/docs-dev/dom/graphics.md
@@ -1,0 +1,13 @@
+# Graphics
+
+The graphics oriented helpers include `context-2d.ts` for canvas text
+measurement and `svg.ts` for constructing path strings.
+
+```ts
+import { Context2d, Svg } from "@opendaw/lib-dom";
+
+const ctx = canvas.getContext("2d")!;
+const { text } = Context2d.truncateText(ctx, "Hello", 50);
+
+const path = Svg.pathBuilder().moveTo(0, 0).lineTo(10, 10).close().get();
+```

--- a/packages/docs/docs-dev/dom/keyboard.md
+++ b/packages/docs/docs-dev/dom/keyboard.md
@@ -1,0 +1,15 @@
+# Keyboard
+
+Keyboard related helpers live in `keyboard.ts` and `modifier-keys.ts`.
+They normalise platform specific modifier keys and expose common shortcut
+checks.
+
+```ts
+import { Keyboard, ModfierKeys } from "@opendaw/lib-dom";
+
+window.addEventListener("keydown", (e) => {
+  if (Keyboard.GlobalShortcut.isDelete(e)) {
+    console.log("remove selection", ModfierKeys.System.Cmd);
+  }
+});
+```

--- a/packages/docs/docs-dev/dom/overview.md
+++ b/packages/docs/docs-dev/dom/overview.md
@@ -1,0 +1,14 @@
+# DOM Utilities
+
+The `@opendaw/lib-dom` package contains small helpers for working with
+browser APIs. It is split into focused modules that can be imported
+individually or via the package entrypoint.
+
+- [Events](./events.md)
+- [Streams](./streams.md)
+- [Keyboard](./keyboard.md)
+- [Graphics](./graphics.md)
+- [Errors](./errors.md)
+
+These utilities are used throughout the openDAW applications and are kept
+lightweight with no external runtime dependencies.

--- a/packages/docs/docs-dev/dom/streams.md
+++ b/packages/docs/docs-dev/dom/streams.md
@@ -1,0 +1,14 @@
+# Streams
+
+The `stream.ts` module exposes helpers for consuming Web streams. Currently
+it provides a single `read` function that collects a `ReadableStream` into
+an `ArrayBuffer`.
+
+```ts
+import { Stream } from "@opendaw/lib-dom";
+const reader = response.body!.getReader();
+const buffer = await Stream.read(reader);
+```
+
+This is useful when working with fetch responses or other streaming APIs
+that deliver binary data.

--- a/packages/lib/dom/README.md
+++ b/packages/lib/dom/README.md
@@ -2,39 +2,64 @@ _This package is part of the openDAW SDK_
 
 # @opendaw/lib-dom
 
-DOM utilities and web browser interaction helpers for TypeScript projects.
+Utility helpers for working with the browser DOM and related Web APIs. The
+module groups together small focused utilities that are shared across the
+openDAW projects.
 
-## HTML & DOM Manipulation
+## Installation
 
-* HTML element creation and manipulation utilities **html.ts**
-* SVG element creation and manipulation **svg.ts**
-* CSS styling utilities and helpers **css-utils.ts**
+```bash
+npm install @opendaw/lib-dom
+```
 
-## Input & Interaction
+## Usage
 
-* Event handling utilities and abstractions **events.ts**
-* Keyboard input handling and key mapping **keyboard.ts**
-* Drag and drop functionality **dragging.ts**
-* Modifier key state management **modfier-keys.ts**
+```ts
+import { Browser, AnimationFrame } from "@opendaw/lib-dom";
 
-## Graphics & Canvas
+if (Browser.isMacOS()) {
+  console.log("Running on macOS");
+}
 
-* 2D canvas context utilities and helpers **context-2d.ts**
+AnimationFrame.add(() => console.log("frame"));
+AnimationFrame.start();
+```
 
-## File Operations
+## Modules
 
-* File handling and manipulation utilities **files.ts**
-* File compression and decompression **compression.ts**
+### HTML & DOM Manipulation
 
-## System & Browser
+- HTML element creation and manipulation utilities **html.ts**
+- SVG element creation and manipulation **svg.ts**
+- CSS styling utilities and helpers **css-utils.ts**
 
-* Browser detection and compatibility utilities **browser.ts**
-* Font loading and management **fonts.ts**
-* Error handling for DOM operations **errors.ts**
-* Console utility commands **console-commands.ts**
+### Input & Interaction
 
-## Performance & Lifecycle
+- Event handling utilities and abstractions **events.ts**
+- Keyboard input handling and key mapping **keyboard.ts**
+- Drag and drop functionality **dragging.ts**
+- Modifier key state management **modifier-keys.ts**
 
-* Animation frame utilities **frames.ts**
-* Stream processing for DOM operations **stream.ts**
-* Resource cleanup and termination handling **terminable.ts**
+### Graphics & Canvas
+
+- 2D canvas context utilities and helpers **context-2d.ts**
+
+### File Operations
+
+- File handling and manipulation utilities **files.ts**
+- File compression and decompression **compression.ts**
+
+### System & Browser
+
+- Browser detection and compatibility utilities **browser.ts**
+- Font loading and management **fonts.ts**
+- Error handling for DOM operations **errors.ts**
+- Console utility commands **console-commands.ts**
+
+### Performance & Lifecycle
+
+- Animation frame utilities **frames.ts**
+- Stream processing for DOM operations **stream.ts**
+- Resource cleanup and termination handling **terminable.ts**
+
+For more in‑depth discussion see the [developer docs](../docs/docs-dev/dom/overview.md).

--- a/packages/lib/dom/src/browser.ts
+++ b/packages/lib/dom/src/browser.ts
@@ -1,20 +1,55 @@
+/**
+ * Runtime environment and user agent detection helpers.
+ *
+ * Provides simple functions that query the global `window` and
+ * `navigator` objects to identify the current platform.
+ *
+ * @example
+ * ```ts
+ * import { Browser } from "@opendaw/lib-dom";
+ *
+ * if (Browser.isMacOS()) {
+ *   // Enable macOS specific shortcuts
+ * }
+ * ```
+ */
 // noinspection PlatformDetectionJS
-
 export namespace Browser {
-    const hasLocation = typeof self !== "undefined" && "location" in self && typeof self.location !== undefined
-    const hasNavigator = typeof self !== "undefined" && "navigator" in self && typeof self.navigator !== undefined
-    export const isLocalHost = () => hasLocation && location.host.includes("localhost")
-    export const isMacOS = () => hasNavigator && navigator.userAgent.includes("Mac OS X")
-    export const isWindows = () => hasNavigator && navigator.userAgent.includes("Windows")
-    export const isFirefox = () => hasNavigator && navigator.userAgent.toLowerCase().includes("firefox")
-    export const isWeb = () => !isTauriApp()
-    export const isVitest = typeof process !== "undefined" && process.env?.VITEST === "true"
-    export const isTauriApp = () => "__TAURI__" in window
-    export const userAgent = hasNavigator ? navigator.userAgent
+  const hasLocation =
+    typeof self !== "undefined" &&
+    "location" in self &&
+    typeof self.location !== undefined;
+  const hasNavigator =
+    typeof self !== "undefined" &&
+    "navigator" in self &&
+    typeof self.navigator !== undefined;
+  /** Determines whether the current host is a localhost instance. */
+  export const isLocalHost = () =>
+    hasLocation && location.host.includes("localhost");
+  /** True when the user agent indicates macOS. */
+  export const isMacOS = () =>
+    hasNavigator && navigator.userAgent.includes("Mac OS X");
+  /** True when the user agent indicates Windows. */
+  export const isWindows = () =>
+    hasNavigator && navigator.userAgent.includes("Windows");
+  /** True when the user agent is Firefox. */
+  export const isFirefox = () =>
+    hasNavigator && navigator.userAgent.toLowerCase().includes("firefox");
+  /** True when running in a web context instead of the Tauri app. */
+  export const isWeb = () => !isTauriApp();
+  /** Detects vitest environment via `process.env`. */
+  export const isVitest =
+    typeof process !== "undefined" && process.env?.VITEST === "true";
+  /** True when running inside a Tauri application. */
+  export const isTauriApp = () => "__TAURI__" in window;
+  /** Normalised user agent string or `"N/A"` when unavailable. */
+  export const userAgent = hasNavigator
+    ? navigator.userAgent
         .replace(/^Mozilla\/[\d.]+\s*/, "")
         .replace(/\bAppleWebKit\/[\d.]+\s*/g, "")
         .replace(/\(KHTML, like Gecko\)\s*/g, "")
         .replace(/\bSafari\/[\d.]+\s*/g, "")
         .replace(/\s+/g, " ")
-        .trim() : "N/A"
+        .trim()
+    : "N/A";
 }

--- a/packages/lib/dom/src/context-2d.ts
+++ b/packages/lib/dom/src/context-2d.ts
@@ -1,29 +1,62 @@
-import {int} from "@opendaw/lib-std"
+/**
+ * Helpers for working with `CanvasRenderingContext2D`.
+ *
+ * @example
+ * ```ts
+ * const ctx = canvas.getContext("2d")!;
+ * const result = Context2d.truncateText(ctx, "Hello World", 80);
+ * console.log(result.text);
+ * ```
+ */
+import { int } from "@opendaw/lib-std";
 
-const ellipsis = "…"
+const ellipsis = "…";
 
 export namespace Context2d {
-    export const truncateText = (context: CanvasRenderingContext2D, text: string, maxWidth: number): {
-        text: string,
-        width: number
-    } => {
-        if (text.length === 0) {return {text: "", width: 0}}
-        let width: number = context.measureText(text).width
-        if (width <= maxWidth) {return {text, width}}
-        const ellipseWidth = context.measureText(ellipsis).width
-        let l: int = 0 | 0
-        let r: int = text.length | 0
-        while (l < r) {
-            const mid: number = (r + l) >>> 1
-            width = context.measureText(text.substring(0, mid + 1)).width + ellipseWidth
-            if (width <= maxWidth) {
-                l = mid + 1
-            } else {
-                r = mid
-            }
-        }
-        if (l === 0) {return {text: "", width: 0}}
-        const result = text.substring(0, l)
-        return {text: result + ellipsis, width: context.measureText(result).width + ellipseWidth}
+  /**
+   * Truncates a text so that its rendered width does not exceed the
+   * provided `maxWidth`. When truncated an ellipsis character is appended.
+   *
+   * @param context Canvas 2D context used for measurement
+   * @param text Text to measure and possibly truncate
+   * @param maxWidth Maximum allowed width in pixels
+   * @returns The truncated text and its measured width
+   */
+  export const truncateText = (
+    context: CanvasRenderingContext2D,
+    text: string,
+    maxWidth: number,
+  ): {
+    text: string;
+    width: number;
+  } => {
+    if (text.length === 0) {
+      return { text: "", width: 0 };
     }
+    let width: number = context.measureText(text).width;
+    if (width <= maxWidth) {
+      return { text, width };
+    }
+    const ellipseWidth = context.measureText(ellipsis).width;
+    let l: int = 0 | 0;
+    let r: int = text.length | 0;
+    while (l < r) {
+      const mid: number = (r + l) >>> 1;
+      width =
+        context.measureText(text.substring(0, mid + 1)).width + ellipseWidth;
+      if (width <= maxWidth) {
+        l = mid + 1;
+      } else {
+        r = mid;
+      }
+    }
+    if (l === 0) {
+      return { text: "", width: 0 };
+    }
+    const result = text.substring(0, l);
+    return {
+      text: result + ellipsis,
+      width: context.measureText(result).width + ellipseWidth,
+    };
+  };
 }

--- a/packages/lib/dom/src/dragging.ts
+++ b/packages/lib/dom/src/dragging.ts
@@ -1,123 +1,189 @@
-import {Func, Option, Terminable, Terminator} from "@opendaw/lib-std"
-import {Browser} from "./browser"
-import {AnimationFrame} from "./frames"
-import {Events, PointerCaptureTarget} from "./events"
-import {Keyboard} from "./keyboard"
+/**
+ * High level helpers for pointer‑based dragging interactions.
+ *
+ * The `attach` function wires pointer events to a target and reports
+ * movement to a user supplied `Process` implementation.
+ *
+ * @example
+ * ```ts
+ * import {Dragging} from "@opendaw/lib-dom";
+ * import {Option} from "@opendaw/lib-std";
+ *
+ * const detach = Dragging.attach(element, ev => Option.some({
+ *   update(e) { console.log(e.clientX, e.clientY); }
+ * }));
+ * ```
+ */
+import { Func, Option, Terminable, Terminator } from "@opendaw/lib-std";
+import { Browser } from "./browser";
+import { AnimationFrame } from "./frames";
+import { Events, PointerCaptureTarget } from "./events";
+import { Keyboard } from "./keyboard";
 
 export namespace Dragging {
-    export interface Process {
-        update(event: Event): void
-        cancel?(): void
-        approve?(): void
-        finally?(): void
-        abortSignal?: AbortSignal
-    }
+  export interface Process {
+    /** Receives updated pointer information. */
+    update(event: Event): void;
+    /** Invoked when the drag is cancelled. */
+    cancel?(): void;
+    /** Called when drag is approved (pointer released normally). */
+    approve?(): void;
+    /** Called after completion or cancellation. */
+    finally?(): void;
+    /** Optional abort signal to terminate the drag externally. */
+    abortSignal?: AbortSignal;
+  }
 
-    export interface Event {
-        readonly clientX: number
-        readonly clientY: number
-        readonly altKey: boolean
-        readonly shiftKey: boolean
-        readonly ctrlKey: boolean
-    }
+  /** Normalised pointer event passed to `Process.update`. */
+  export interface Event {
+    readonly clientX: number;
+    readonly clientY: number;
+    readonly altKey: boolean;
+    readonly shiftKey: boolean;
+    readonly ctrlKey: boolean;
+  }
 
-    export interface ProcessOptions {
-        multiTouch?: boolean
-        immediate?: boolean
-        permanentUpdates?: boolean
-    }
+  /** Additional configuration for `attach`. */
+  export interface ProcessOptions {
+    /** Allow multiple simultaneous touches. */
+    multiTouch?: boolean;
+    /** Trigger `update` immediately after pointer down. */
+    immediate?: boolean;
+    /** Continue issuing `update` callbacks even without pointer moves. */
+    permanentUpdates?: boolean;
+  }
 
-    export const attach = <T extends PointerCaptureTarget>(target: T,
-                                                           factory: Func<PointerEvent, Option<Process>>,
-                                                           options?: ProcessOptions): Terminable => {
-        const processCycle = new Terminator()
-        return Terminable.many(processCycle, Events.subscribe(target, "pointerdown", (event: PointerEvent) => {
-            if (options?.multiTouch !== true && !event.isPrimary) {return}
-            if (event.buttons !== 1 || (Browser.isMacOS() && event.ctrlKey)) {return}
-            const option: Option<Process> = factory(event)
-            if (option.isEmpty()) {return}
-            const process: Process = option.unwrap()
-            const pointerId: number = event.pointerId
-            event.stopPropagation()
-            event.stopImmediatePropagation()
-            target.setPointerCapture(pointerId)
-            const moveEvent = {
-                clientX: event.clientX,
-                clientY: event.clientY,
-                altKey: event.altKey,
-                shiftKey: event.shiftKey,
-                ctrlKey: Keyboard.isControlKey(event)
-            } satisfies Event
-            if (options?.immediate === true) {
-                process.update(moveEvent)
-            }
-            if (options?.permanentUpdates === true) {
-                processCycle.own(AnimationFrame.add(() => process.update(moveEvent)))
-                processCycle.own(Events.subscribe(target, "pointermove", (event: PointerEvent) => {
-                    if (event.pointerId === pointerId) {
-                        moveEvent.clientX = event.clientX
-                        moveEvent.clientY = event.clientY
-                        moveEvent.altKey = event.altKey
-                        moveEvent.shiftKey = event.shiftKey
-                        moveEvent.ctrlKey = Keyboard.isControlKey(event)
-                    }
-                }))
+  /**
+   * Attaches pointer listeners to `target` and creates a dragging lifecycle
+   * managed by a `Process` instance produced by `factory`.
+   */
+  export const attach = <T extends PointerCaptureTarget>(
+    target: T,
+    factory: Func<PointerEvent, Option<Process>>,
+    options?: ProcessOptions,
+  ): Terminable => {
+    const processCycle = new Terminator();
+    return Terminable.many(
+      processCycle,
+      Events.subscribe(target, "pointerdown", (event: PointerEvent) => {
+        if (options?.multiTouch !== true && !event.isPrimary) {
+          return;
+        }
+        if (event.buttons !== 1 || (Browser.isMacOS() && event.ctrlKey)) {
+          return;
+        }
+        const option: Option<Process> = factory(event);
+        if (option.isEmpty()) {
+          return;
+        }
+        const process: Process = option.unwrap();
+        const pointerId: number = event.pointerId;
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        target.setPointerCapture(pointerId);
+        const moveEvent = {
+          clientX: event.clientX,
+          clientY: event.clientY,
+          altKey: event.altKey,
+          shiftKey: event.shiftKey,
+          ctrlKey: Keyboard.isControlKey(event),
+        } satisfies Event;
+        if (options?.immediate === true) {
+          process.update(moveEvent);
+        }
+        if (options?.permanentUpdates === true) {
+          processCycle.own(AnimationFrame.add(() => process.update(moveEvent)));
+          processCycle.own(
+            Events.subscribe(target, "pointermove", (event: PointerEvent) => {
+              if (event.pointerId === pointerId) {
+                moveEvent.clientX = event.clientX;
+                moveEvent.clientY = event.clientY;
+                moveEvent.altKey = event.altKey;
+                moveEvent.shiftKey = event.shiftKey;
+                moveEvent.ctrlKey = Keyboard.isControlKey(event);
+              }
+            }),
+          );
+        } else {
+          processCycle.own(
+            Events.subscribe(target, "pointermove", (event: PointerEvent) => {
+              if (event.pointerId === pointerId) {
+                moveEvent.clientX = event.clientX;
+                moveEvent.clientY = event.clientY;
+                moveEvent.altKey = event.altKey;
+                moveEvent.shiftKey = event.shiftKey;
+                moveEvent.ctrlKey = Keyboard.isControlKey(event);
+                process.update(moveEvent);
+              }
+            }),
+          );
+        }
+        const cancel = () => {
+          process.cancel?.call(process);
+          process.finally?.call(process);
+          processCycle.terminate();
+        };
+        processCycle.ownAll(
+          Events.subscribe(
+            target,
+            "pointerup",
+            (event: PointerEvent) => {
+              if (event.pointerId === pointerId) {
+                process.approve?.call(process);
+                process.finally?.call(process);
+                processCycle.terminate();
+              }
+            },
+            { capture: true },
+          ),
+          Events.subscribe(
+            target,
+            "pointercancel",
+            (event: PointerEvent) => {
+              console.debug(event.type);
+              if (event.pointerId === pointerId) {
+                target.releasePointerCapture(pointerId);
+                cancel();
+              }
+            },
+            { capture: true },
+          ),
+          Events.subscribe(
+            self,
+            "beforeunload",
+            (_event: BeforeUnloadEvent) => {
+              // Workaround for Chrome (does not release or cancel pointer)
+              target.releasePointerCapture(pointerId);
+              cancel();
+            },
+            { capture: true },
+          ),
+          Events.subscribe(window, "keydown", (event: KeyboardEvent) => {
+            moveEvent.altKey = event.altKey;
+            moveEvent.shiftKey = event.shiftKey;
+            moveEvent.ctrlKey = Keyboard.isControlKey(event);
+            if (event.key === "Escape") {
+              cancel();
             } else {
-                processCycle.own(Events.subscribe(target, "pointermove", (event: PointerEvent) => {
-                    if (event.pointerId === pointerId) {
-                        moveEvent.clientX = event.clientX
-                        moveEvent.clientY = event.clientY
-                        moveEvent.altKey = event.altKey
-                        moveEvent.shiftKey = event.shiftKey
-                        moveEvent.ctrlKey = Keyboard.isControlKey(event)
-                        process.update(moveEvent)
-                    }
-                }))
+              process.update(moveEvent);
             }
-            const cancel = () => {
-                process.cancel?.call(process)
-                process.finally?.call(process)
-                processCycle.terminate()
-            }
-            processCycle.ownAll(
-                Events.subscribe(target, "pointerup", (event: PointerEvent) => {
-                    if (event.pointerId === pointerId) {
-                        process.approve?.call(process)
-                        process.finally?.call(process)
-                        processCycle.terminate()
-                    }
-                }, {capture: true}),
-                Events.subscribe(target, "pointercancel", (event: PointerEvent) => {
-                    console.debug(event.type)
-                    if (event.pointerId === pointerId) {
-                        target.releasePointerCapture(pointerId)
-                        cancel()
-                    }
-                }, {capture: true}),
-                Events.subscribe(self, "beforeunload", (_event: BeforeUnloadEvent) => {
-                    // Workaround for Chrome (does not release or cancel pointer)
-                    target.releasePointerCapture(pointerId)
-                    cancel()
-                }, {capture: true}),
-                Events.subscribe(window, "keydown", (event: KeyboardEvent) => {
-                    moveEvent.altKey = event.altKey
-                    moveEvent.shiftKey = event.shiftKey
-                    moveEvent.ctrlKey = Keyboard.isControlKey(event)
-                    if (event.key === "Escape") {cancel()} else {process.update(moveEvent)}
-                }),
-                Events.subscribe(window, "keyup", (event: KeyboardEvent) => {
-                    moveEvent.altKey = event.altKey
-                    moveEvent.shiftKey = event.shiftKey
-                    moveEvent.ctrlKey = Keyboard.isControlKey(event)
-                    process.update(moveEvent)
-                })
-            )
-            if (process.abortSignal) {
-                processCycle.own(Events.subscribe(process.abortSignal, "abort", () => {
-                    target.releasePointerCapture(pointerId)
-                    cancel()
-                }))
-            }
-        }))
-    }
+          }),
+          Events.subscribe(window, "keyup", (event: KeyboardEvent) => {
+            moveEvent.altKey = event.altKey;
+            moveEvent.shiftKey = event.shiftKey;
+            moveEvent.ctrlKey = Keyboard.isControlKey(event);
+            process.update(moveEvent);
+          }),
+        );
+        if (process.abortSignal) {
+          processCycle.own(
+            Events.subscribe(process.abortSignal, "abort", () => {
+              target.releasePointerCapture(pointerId);
+              cancel();
+            }),
+          );
+        }
+      }),
+    );
+  };
 }

--- a/packages/lib/dom/src/files.ts
+++ b/packages/lib/dom/src/files.ts
@@ -1,58 +1,97 @@
-import {Arrays, asDefined, isDefined} from "@opendaw/lib-std"
-import {Promises} from "@opendaw/lib-runtime"
+/**
+ * Wrapper functions for the File System Access API with graceful fallbacks.
+ *
+ * @example
+ * ```ts
+ * const arrayBuffer = await fetch(url).then(r => r.arrayBuffer());
+ * await Files.save(arrayBuffer, { suggestedName: "sample.bin" });
+ * ```
+ */
+import { Arrays, asDefined, isDefined } from "@opendaw/lib-std";
+import { Promises } from "@opendaw/lib-runtime";
 
 export namespace Files {
-    export const save = async (arrayBuffer: ArrayBuffer, options?: SaveFilePickerOptions): Promise<string> => {
-        if (isDefined(window.showSaveFilePicker)) {
-            const handle = await window.showSaveFilePicker(options)
-            const writable = await handle.createWritable()
-            await writable.truncate(0)
-            await writable.write(arrayBuffer)
-            await writable.close()
-            return handle.name ?? "unknown"
-        } else {
-            const blob = new Blob([arrayBuffer])
-            const url = URL.createObjectURL(blob)
-            const anchor = document.createElement("a")
-            anchor.href = url
-            anchor.download = options?.suggestedName ?? `unknown`
-            anchor.click()
-            URL.revokeObjectURL(url)
-            return options?.suggestedName ?? "Unknown"
-        }
+  /**
+   * Saves an `ArrayBuffer` as a file using the File System Access API when
+   * available, falling back to a download link otherwise.
+   *
+   * @returns Name of the created file.
+   */
+  export const save = async (
+    arrayBuffer: ArrayBuffer,
+    options?: SaveFilePickerOptions,
+  ): Promise<string> => {
+    if (isDefined(window.showSaveFilePicker)) {
+      const handle = await window.showSaveFilePicker(options);
+      const writable = await handle.createWritable();
+      await writable.truncate(0);
+      await writable.write(arrayBuffer);
+      await writable.close();
+      return handle.name ?? "unknown";
+    } else {
+      const blob = new Blob([arrayBuffer]);
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = options?.suggestedName ?? `unknown`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      return options?.suggestedName ?? "Unknown";
     }
+  };
 
-    export const open = async (options?: OpenFilePickerOptions): Promise<ReadonlyArray<File>> => {
-        if (isDefined(window.showOpenFilePicker)) {
-            const {status, value: fileHandles, error} = await Promises.tryCatch(window.showOpenFilePicker(options))
-            if (status === "rejected") {return Promise.reject(error)}
-            return Promise.all(fileHandles.map(fileHandle => fileHandle.getFile()))
-        } else {
-            return new Promise<ReadonlyArray<File>>((resolve, reject) => {
-                if (isDefined(options)) {
-                    console.warn("FileApi.showOpenFilePicker is emulated in this browser. OpenFilePickerOptions are ignored.")
-                }
-                const fileInput = document.createElement("input")
-                fileInput.type = "file"
-                fileInput.multiple = options?.multiple ?? false
-                fileInput.style.display = "none"
-                fileInput.addEventListener("cancel", async () => {
-                    fileInput.remove()
-                    reject(new DOMException("cancel", "AbortError"))
-                })
-                fileInput.addEventListener("change", async (event: Event) => {
-                    const target = event.target as HTMLInputElement
-                    const files = target.files
-                    if (isDefined(files)) {
-                        resolve(Arrays.create(index => asDefined(files.item(index), `No file at index ${index}`), files.length))
-                    } else {
-                        reject(new DOMException("cancel", "AbortError"))
-                    }
-                    fileInput.remove()
-                })
-                document.body.appendChild(fileInput)
-                fileInput.click()
-            })
+  /**
+   * Opens a file selection dialog and returns the selected `File` objects.
+   * Uses the File System Access API when supported and falls back to a
+   * hidden `<input>` element otherwise.
+   */
+  export const open = async (
+    options?: OpenFilePickerOptions,
+  ): Promise<ReadonlyArray<File>> => {
+    if (isDefined(window.showOpenFilePicker)) {
+      const {
+        status,
+        value: fileHandles,
+        error,
+      } = await Promises.tryCatch(window.showOpenFilePicker(options));
+      if (status === "rejected") {
+        return Promise.reject(error);
+      }
+      return Promise.all(fileHandles.map((fileHandle) => fileHandle.getFile()));
+    } else {
+      return new Promise<ReadonlyArray<File>>((resolve, reject) => {
+        if (isDefined(options)) {
+          console.warn(
+            "FileApi.showOpenFilePicker is emulated in this browser. OpenFilePickerOptions are ignored.",
+          );
         }
+        const fileInput = document.createElement("input");
+        fileInput.type = "file";
+        fileInput.multiple = options?.multiple ?? false;
+        fileInput.style.display = "none";
+        fileInput.addEventListener("cancel", async () => {
+          fileInput.remove();
+          reject(new DOMException("cancel", "AbortError"));
+        });
+        fileInput.addEventListener("change", async (event: Event) => {
+          const target = event.target as HTMLInputElement;
+          const files = target.files;
+          if (isDefined(files)) {
+            resolve(
+              Arrays.create(
+                (index) =>
+                  asDefined(files.item(index), `No file at index ${index}`),
+                files.length,
+              ),
+            );
+          } else {
+            reject(new DOMException("cancel", "AbortError"));
+          }
+          fileInput.remove();
+        });
+        document.body.appendChild(fileInput);
+        fileInput.click();
+      });
     }
+  };
 }

--- a/packages/lib/dom/src/index.ts
+++ b/packages/lib/dom/src/index.ts
@@ -1,27 +1,45 @@
-const key = Symbol.for("@openDAW/lib-dom")
+/**
+ * Entry point for the DOM utilities library. Importing this module exposes
+ * a set of helpers for interacting with browser APIs.
+ *
+ * @example
+ * ```ts
+ * import {AnimationFrame} from "@opendaw/lib-dom";
+ * AnimationFrame.start();
+ * ```
+ */
+const key = Symbol.for("@openDAW/lib-dom");
 
 if ((globalThis as any)[key]) {
-    console.debug(`%c${key.description}%c is already available in ${globalThis.constructor.name}.`, "color: hsl(10, 83%, 60%)", "color: inherit")
+  console.debug(
+    `%c${key.description}%c is already available in ${globalThis.constructor.name}.`,
+    "color: hsl(10, 83%, 60%)",
+    "color: inherit",
+  );
 } else {
-    (globalThis as any)[key] = true
-    console.debug(`%c${key.description}%c is now available in ${globalThis.constructor.name}.`, "color: hsl(200, 83%, 60%)", "color: inherit")
+  (globalThis as any)[key] = true;
+  console.debug(
+    `%c${key.description}%c is now available in ${globalThis.constructor.name}.`,
+    "color: hsl(200, 83%, 60%)",
+    "color: inherit",
+  );
 }
 
-export * from "./browser"
-export * from "./compression"
-export * from "./console-commands"
-export * from "./constraint"
-export * from "./context-2d"
-export * from "./css-utils"
-export * from "./dragging"
-export * from "./events"
-export * from "./errors"
-export * from "./files"
-export * from "./fonts"
-export * from "./frames"
-export * from "./html"
-export * from "./keyboard"
-export * from "./modfier-keys"
-export * from "./stream"
-export * from "./svg"
-export * from "./terminable"
+export * from "./browser";
+export * from "./compression";
+export * from "./console-commands";
+export * from "./constraint";
+export * from "./context-2d";
+export * from "./css-utils";
+export * from "./dragging";
+export * from "./events";
+export * from "./errors";
+export * from "./files";
+export * from "./fonts";
+export * from "./frames";
+export * from "./html";
+export * from "./keyboard";
+export * from "./modifier-keys";
+export * from "./stream";
+export * from "./svg";
+export * from "./terminable";

--- a/packages/lib/dom/src/keyboard.ts
+++ b/packages/lib/dom/src/keyboard.ts
@@ -1,17 +1,44 @@
-import {Browser} from "./browser"
-import {Events} from "./events"
+/**
+ * Keyboard related utilities including modifier key detection and common
+ * shortcuts.
+ *
+ * @example
+ * ```ts
+ * import {Keyboard} from "@opendaw/lib-dom";
+ * window.addEventListener("keydown", e => {
+ *   if (Keyboard.GlobalShortcut.isSelectAll(e)) {
+ *     console.log("select all");
+ *   }
+ * });
+ * ```
+ */
+import { Browser } from "./browser";
+import { Events } from "./events";
 
 export namespace Keyboard {
-    export const isControlKey = ({ctrlKey, metaKey}: {
-        ctrlKey: boolean,
-        metaKey: boolean
-    }) => Browser.isMacOS() ? metaKey : ctrlKey
+  /** Returns whether the platform specific control key is pressed. */
+  export const isControlKey = ({
+    ctrlKey,
+    metaKey,
+  }: {
+    ctrlKey: boolean;
+    metaKey: boolean;
+  }) => (Browser.isMacOS() ? metaKey : ctrlKey);
 
-    export const isCopyKey = ({altKey}: { altKey: boolean }) => altKey
+  /** Indicates if the copy/alternate key (Alt) is active. */
+  export const isCopyKey = ({ altKey }: { altKey: boolean }) => altKey;
 
-    export const GlobalShortcut = Object.freeze({
-        isDelete: (event: KeyboardEvent) => !Events.isTextInput(event.target) && (event.code === "Delete" || event.code === "Backspace"),
-        isSelectAll: (event: KeyboardEvent) => isControlKey(event) && !event.shiftKey && event.code === "KeyA",
-        isDeselectAll: (event: KeyboardEvent) => isControlKey(event) && event.shiftKey && event.code === "KeyA"
-    })
+  /** Collection of global shortcut helpers. */
+  export const GlobalShortcut = Object.freeze({
+    /** Delete or Backspace outside text inputs. */
+    isDelete: (event: KeyboardEvent) =>
+      !Events.isTextInput(event.target) &&
+      (event.code === "Delete" || event.code === "Backspace"),
+    /** Cmd/Ctrl+A without Shift: select all. */
+    isSelectAll: (event: KeyboardEvent) =>
+      isControlKey(event) && !event.shiftKey && event.code === "KeyA",
+    /** Cmd/Ctrl+Shift+A: deselect all. */
+    isDeselectAll: (event: KeyboardEvent) =>
+      isControlKey(event) && event.shiftKey && event.code === "KeyA",
+  });
 }

--- a/packages/lib/dom/src/modfier-keys.ts
+++ b/packages/lib/dom/src/modfier-keys.ts
@@ -1,7 +1,0 @@
-import {Browser} from "./browser"
-
-export const ModfierKeys = (() => {
-    const Mac = {Cmd: "⌘", Opt: "⌥", Shift: "⇧"}
-    const Win = {Cmd: "Ctrl", Opt: "Alt", Shift: "⇧"}
-    return Object.freeze({Mac, Win, System: Browser.isMacOS() ? Mac : Win})
-})()

--- a/packages/lib/dom/src/modifier-keys.ts
+++ b/packages/lib/dom/src/modifier-keys.ts
@@ -1,0 +1,7 @@
+import { Browser } from "./browser";
+
+export const ModfierKeys = (() => {
+  const Mac = { Cmd: "⌘", Opt: "⌥", Shift: "⇧" };
+  const Win = { Cmd: "Ctrl", Opt: "Alt", Shift: "⇧" };
+  return Object.freeze({ Mac, Win, System: Browser.isMacOS() ? Mac : Win });
+})();

--- a/packages/lib/dom/src/stream.ts
+++ b/packages/lib/dom/src/stream.ts
@@ -1,20 +1,37 @@
-import {int} from "@opendaw/lib-std"
+/**
+ * Utilities for working with `ReadableStream` objects.
+ *
+ * @example
+ * ```ts
+ * const reader = response.body!.getReader();
+ * const buffer = await Stream.read(reader);
+ * ```
+ */
+import { int } from "@opendaw/lib-std";
 
 export namespace Stream {
-    export const read = async (reader: ReadableStreamDefaultReader<Uint8Array>): Promise<ArrayBuffer> => {
-        const chunks: Array<Uint8Array> = []
-        while (true) {
-            const {done, value} = await reader.read()
-            if (done) {break}
-            chunks.push(value)
-        }
-        const length = chunks.reduce((acc, val) => acc + val.length, 0)
-        const output = new Uint8Array(length)
-        let position: int = 0 | 0
-        for (let chunk of chunks) {
-            output.set(chunk, position)
-            position += chunk.length
-        }
-        return output.buffer
+  /**
+   * Reads all chunks from a `ReadableStreamDefaultReader` into a single
+   * `ArrayBuffer`.
+   */
+  export const read = async (
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+  ): Promise<ArrayBuffer> => {
+    const chunks: Array<Uint8Array> = [];
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      chunks.push(value);
     }
+    const length = chunks.reduce((acc, val) => acc + val.length, 0);
+    const output = new Uint8Array(length);
+    let position: int = 0 | 0;
+    for (let chunk of chunks) {
+      output.set(chunk, position);
+      position += chunk.length;
+    }
+    return output.buffer;
+  };
 }

--- a/packages/lib/dom/src/svg.ts
+++ b/packages/lib/dom/src/svg.ts
@@ -1,65 +1,128 @@
+/**
+ * Helper utilities for constructing SVG path commands.
+ *
+ * @example
+ * ```ts
+ * const d = Svg.pathBuilder().moveTo(0,0).lineTo(10,10).close().get();
+ * ```
+ */
 export namespace Svg {
-    export interface PathBuilder {
-        moveTo(x: number, y: number): this
-        lineTo(x: number, y: number): this
-        quadratic(x1: number, y1: number, x: number, y: number): this
-        quadraticTo(x: number, y: number): this
-        cubic(x1: number, y1: number, x2: number, y2: number, x: number, y: number): this
-        arc(rx: number, ry: number, deg: number, largeArc: boolean, sweep: boolean, x: number, y: number): this
-        circleSegment(cx: number, cy: number, radius: number, a0: number, a1: number): this
-        close(): this
-        get(): string
-    }
+  export interface PathBuilder {
+    moveTo(x: number, y: number): this;
+    lineTo(x: number, y: number): this;
+    quadratic(x1: number, y1: number, x: number, y: number): this;
+    quadraticTo(x: number, y: number): this;
+    cubic(
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      x: number,
+      y: number,
+    ): this;
+    arc(
+      rx: number,
+      ry: number,
+      deg: number,
+      largeArc: boolean,
+      sweep: boolean,
+      x: number,
+      y: number,
+    ): this;
+    circleSegment(
+      cx: number,
+      cy: number,
+      radius: number,
+      a0: number,
+      a1: number,
+    ): this;
+    close(): this;
+    get(): string;
+  }
 
-    export const pathBuilder = (): PathBuilder => new class implements PathBuilder {
-        #d: string = ""
+  /** Creates a new `PathBuilder` instance. */
+  export const pathBuilder = (): PathBuilder =>
+    new (class implements PathBuilder {
+      #d: string = "";
 
-        moveTo(x: number, y: number): this {
-            this.#d += `M${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      moveTo(x: number, y: number): this {
+        this.#d += `M${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        lineTo(x: number, y: number): this {
-            this.#d += `L${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      lineTo(x: number, y: number): this {
+        this.#d += `L${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        quadratic(x1: number, y1: number, x: number, y: number): this {
-            this.#d += `Q${x1.toFixed(3)} ${y1.toFixed(3)} ${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      quadratic(x1: number, y1: number, x: number, y: number): this {
+        this.#d += `Q${x1.toFixed(3)} ${y1.toFixed(3)} ${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        quadraticTo(x: number, y: number): this {
-            this.#d += `T${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      quadraticTo(x: number, y: number): this {
+        this.#d += `T${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        cubic(x1: number, y1: number, x2: number, y2: number, x: number, y: number): this {
-            this.#d += `Q${
-                x1.toFixed(3)} ${y1.toFixed(3)} ${x2.toFixed(3)} ${y2.toFixed(3)} ${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      cubic(
+        x1: number,
+        y1: number,
+        x2: number,
+        y2: number,
+        x: number,
+        y: number,
+      ): this {
+        this.#d += `Q${x1.toFixed(
+          3,
+        )} ${y1.toFixed(3)} ${x2.toFixed(3)} ${y2.toFixed(3)} ${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        arc(rx: number, ry: number, deg: number, largeArc: boolean, sweep: boolean, x: number, y: number): this {
-            this.#d += `A${rx} ${ry} ${deg} ${largeArc ? 1 : 0} ${sweep ? 1 : 0} ${x.toFixed(3)} ${y.toFixed(3)}`
-            return this
-        }
+      arc(
+        rx: number,
+        ry: number,
+        deg: number,
+        largeArc: boolean,
+        sweep: boolean,
+        x: number,
+        y: number,
+      ): this {
+        this.#d += `A${rx} ${ry} ${deg} ${largeArc ? 1 : 0} ${sweep ? 1 : 0} ${x.toFixed(3)} ${y.toFixed(3)}`;
+        return this;
+      }
 
-        circleSegment(cx: number, cy: number, radius: number, a0: number, a1: number): this {
-            const x0 = cx + Math.cos(a0) * radius
-            const y0 = cy + Math.sin(a0) * radius
-            const x1 = cx + Math.cos(a1) * radius
-            const y1 = cy + Math.sin(a1) * radius
-            let range = a1 - a0
-            while (range < 0.0) range += Math.PI * 2.0
-            return this.moveTo(x0, y0).arc(radius, radius, 0, range > Math.PI, true, x1, y1)
-        }
+      circleSegment(
+        cx: number,
+        cy: number,
+        radius: number,
+        a0: number,
+        a1: number,
+      ): this {
+        const x0 = cx + Math.cos(a0) * radius;
+        const y0 = cy + Math.sin(a0) * radius;
+        const x1 = cx + Math.cos(a1) * radius;
+        const y1 = cy + Math.sin(a1) * radius;
+        let range = a1 - a0;
+        while (range < 0.0) range += Math.PI * 2.0;
+        return this.moveTo(x0, y0).arc(
+          radius,
+          radius,
+          0,
+          range > Math.PI,
+          true,
+          x1,
+          y1,
+        );
+      }
 
-        close(): this {
-            this.#d += "Z"
-            return this
-        }
+      close(): this {
+        this.#d += "Z";
+        return this;
+      }
 
-        get(): string {return this.#d}
-    }
+      get(): string {
+        return this.#d;
+      }
+    })();
 }


### PR DESCRIPTION
## Summary
- rename misspelled `modfier-keys.ts` to `modifier-keys.ts`
- document DOM utilities with TSDoc examples
- add DOM developer docs and link from architecture overview

## Testing
- `npm test` *(fails: command @opendaw/lib-dsp:build exited (2))*
- `npm run lint` *(fails: command @opendaw/studio-boxes#lint exited (2))*

------
https://chatgpt.com/codex/tasks/task_b_68aea3c6e39083218b6aa5335079526e