### PR TITLE
docs: document and reference studio enums

### DIFF
--- a/packages/docs/docs-dev/enums/overview.md
+++ b/packages/docs/docs-dev/enums/overview.md
@@ -1,0 +1,12 @@
+# Enums Overview
+
+The `@opendaw/studio-enums` package contains enumerations shared across the
+project. They provide well-known constants for wiring boxes, describing audio
+unit kinds, and configuring signal routing.
+
+## Available enums
+
+- `Pointers` – references to boxes and collections in the graph.
+- `AudioSendRouting` – whether a send is tapped pre- or post-fader.
+- `AudioUnitType` – categories of audio units such as instruments or outputs.
+

--- a/packages/docs/docs-dev/enums/usage.md
+++ b/packages/docs/docs-dev/enums/usage.md
@@ -1,0 +1,18 @@
+# Using Studio Enums
+
+Import enumerations from `@opendaw/studio-enums` wherever consistent values are
+required.
+
+```ts
+import {AudioSendRouting, AudioUnitType, Pointers} from '@opendaw/studio-enums';
+
+// connect a device host
+box.host.refer(hostField as Pointers.InstrumentHost);
+
+// configure an audio unit
+audioUnit.type.setValue(AudioUnitType.Output);
+
+// route a send post-fader
+send.routing.setValue(AudioSendRouting.Post);
+```
+

--- a/packages/studio/adapters/src/UnionAdapterTypes.ts
+++ b/packages/studio/adapters/src/UnionAdapterTypes.ts
@@ -17,6 +17,9 @@ export type AnyLoopableRegionBoxAdapter = AnyRegionBoxAdapter // TODO Clarify
 
 /**
  * Type guards for working with unions of adapter types.
+ *
+ * These helpers operate on adapters that ultimately reference boxes
+ * addressed by {@link @opendaw/studio-enums#Pointers | Pointers}.
  */
 export const UnionAdapterTypes = {
     /** Returns true when the adapter wraps a region box. */

--- a/packages/studio/core-processors/src/AudioUnit.ts
+++ b/packages/studio/core-processors/src/AudioUnit.ts
@@ -12,6 +12,9 @@ import {InstrumentDeviceProcessor} from "./InstrumentDeviceProcessor"
 
 /**
  * High level container representing a track or device chain in the engine.
+ *
+ * Each instance corresponds to an
+ * {@link @opendaw/studio-enums#AudioUnitType | AudioUnitType}.
  */
 export class AudioUnit implements Terminable {
     static ID: int = 0 | 0

--- a/packages/studio/core-processors/src/DeviceProcessorFactory.ts
+++ b/packages/studio/core-processors/src/DeviceProcessorFactory.ts
@@ -54,7 +54,12 @@ import {InstrumentDeviceProcessor} from "./InstrumentDeviceProcessor"
 import {AudioEffectDeviceProcessor} from "./AudioEffectDeviceProcessor"
 import {UnknownMidiEffectDeviceProcessor} from "./devices/midi-effects/UnknownMidiEffectDeviceProcessor"
 
-/** Factory functions creating processor instances for instrument devices. */
+/**
+ * Factory functions creating processor instances for instrument devices.
+ *
+ * Instrument processors correspond to
+ * {@link @opendaw/studio-enums#AudioUnitType.Instrument | AudioUnitType.Instrument}.
+ */
 export namespace InstrumentDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): Nullish<InstrumentDeviceProcessor | AudioBusProcessor> =>
@@ -72,7 +77,12 @@ export namespace InstrumentDeviceProcessorFactory {
         })
 }
 
-/** Factory for processors wrapping MIDI-effect devices. */
+/**
+ * Factory for processors wrapping MIDI-effect devices.
+ *
+ * These processors can appear before or after instruments according to
+ * {@link @opendaw/studio-enums#AudioSendRouting | AudioSendRouting}.
+ */
 export namespace MidiEffectDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): MidiEffectProcessor =>
@@ -88,7 +98,12 @@ export namespace MidiEffectDeviceProcessorFactory {
         }), `Could not create midi-effect for'${box.name}'`)
 }
 
-/** Factory for audio-effect device processors. */
+/**
+ * Factory for audio-effect device processors.
+ *
+ * Effect routing follows
+ * {@link @opendaw/studio-enums#AudioSendRouting | AudioSendRouting} semantics.
+ */
 export namespace AudioEffectDeviceProcessorFactory {
     export const create = (context: EngineContext,
                            box: Box): AudioEffectDeviceProcessor =>

--- a/packages/studio/core/src/EffectBox.ts
+++ b/packages/studio/core/src/EffectBox.ts
@@ -14,9 +14,13 @@ import {
 /**
  * Union of all effect device boxes supported by the studio.
  *
+ * Effects can be inserted or reached via sends using
+ * {@link @opendaw/studio-enums#AudioSendRouting | AudioSendRouting}.
+ *
  * @public
  */
 export type EffectBox =
     | ArpeggioDeviceBox | PitchDeviceBox | ZeitgeistDeviceBox | UnknownMidiEffectDeviceBox
     | DelayDeviceBox | ReverbDeviceBox | RevampDeviceBox | StereoToolDeviceBox
     | ModularDeviceBox | UnknownAudioEffectDeviceBox
+

--- a/packages/studio/core/src/InstrumentFactories.ts
+++ b/packages/studio/core/src/InstrumentFactories.ts
@@ -19,6 +19,8 @@ import {Pointers} from "@opendaw/studio-enums"
  *
  * Several instruments rely on data prepared by background workers, such as
  * file operations or waveform analysis handled through {@link WorkerAgents}.
+ * Host routing uses {@link @opendaw/studio-enums#Pointers | Pointers} to
+ * connect instruments with their audio destinations.
  */
 export namespace InstrumentFactories {
     /** Factory for the tape-style audio player device. */

--- a/packages/studio/core/src/Project.ts
+++ b/packages/studio/core/src/Project.ts
@@ -34,6 +34,9 @@ import {CaptureManager} from "./capture/CaptureManager"
 /**
  * Represents a full project including all boxes, adapters and runtime services.
  *
+ * The master audio unit is created using
+ * {@link @opendaw/studio-enums#AudioUnitType.Output | AudioUnitType.Output}.
+ *
  * @public
  */
 export class Project implements BoxAdaptersContext, Terminable, TerminableOwner {

--- a/packages/studio/enums/README.md
+++ b/packages/studio/enums/README.md
@@ -1,1 +1,14 @@
-This package is part of the openDAW SDK
+## @opendaw/studio-enums
+
+Shared enumeration types for the studio.
+
+This package provides strongly typed constants used across the openDAW codebase.
+The enums describe common pointer identifiers, audio routing options and audio
+unit categories.
+
+### Enums
+
+- `Pointers` – symbolic references used to wire boxes together.
+- `AudioSendRouting` – whether a send taps the signal pre‑ or post‑fader.
+- `AudioUnitType` – categorises audio units as instruments, busses, auxes or
+  outputs.

--- a/packages/studio/enums/src/AudioSendRouting.ts
+++ b/packages/studio/enums/src/AudioSendRouting.ts
@@ -1,3 +1,13 @@
+/**
+ * Routing options for audio sends.
+ *
+ * Determines whether the send taps the signal before or after the channel fader.
+ *
+ * @public
+ */
 export enum AudioSendRouting {
-    Pre, Post
+    /** Signal is routed before the channel's fader. */
+    Pre,
+    /** Signal is routed after the channel's fader. */
+    Post
 }

--- a/packages/studio/enums/src/AudioUnitType.ts
+++ b/packages/studio/enums/src/AudioUnitType.ts
@@ -1,6 +1,15 @@
+/**
+ * Categories of audio units supported by the engine.
+ *
+ * @public
+ */
 export enum AudioUnitType {
+    /** An instrument or generator unit. */
     Instrument = "instrument",
+    /** A summing bus used for grouping. */
     Bus = "bus",
+    /** An auxiliary send/return unit. */
     Aux = "aux",
+    /** The final output unit in the project. */
     Output = "output"
-} 
+}

--- a/packages/studio/enums/src/Pointers.ts
+++ b/packages/studio/enums/src/Pointers.ts
@@ -1,3 +1,11 @@
+/**
+ * Predefined pointer identifiers used throughout the studio graph.
+ *
+ * Pointers reference named fields or collections so devices can connect
+ * to each other without sharing concrete instances.
+ *
+ * @public
+ */
 export enum Pointers {
     Timeline,
     Selection,
@@ -39,5 +47,5 @@ export enum Pointers {
     ValueEvents,
     ValueEventCollection,
     ValueInterpolation,
-    Sample,
-} 
+    Sample
+}

--- a/packages/studio/enums/src/index.ts
+++ b/packages/studio/enums/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Collection of enumeration types shared across studio packages.
+ *
+ * @packageDocumentation
+ */
 export * from "./Pointers"
 export * from "./AudioSendRouting"
 export * from "./AudioUnitType"
+


### PR DESCRIPTION
## Summary
- add TSDoc comments for studio enum exports
- reference enums from core, processor and adapter modules
- document enums package with README and developer docs

## Testing
- `npm test` *(fails: @opendaw/lib-dsp build command exited with code 2)*
- `npm run lint` *(fails: @opendaw/studio-boxes lint command exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3c8effc83218e220774a225e4f7