### PR TITLE
docs: document tsconfig presets

### DIFF
--- a/deploy/tsconfig.json
+++ b/deploy/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@opendaw/typescript-config/tsconfig.build.json",
   "//": "Deployment scripts disabled",
   "compilerOptions": {
     "target": "es2016",

--- a/packages/config/typescript/README.md
+++ b/packages/config/typescript/README.md
@@ -1,0 +1,22 @@
+# @opendaw/typescript-config
+
+Shared TypeScript configuration presets for openDAW packages.
+
+## Usage
+
+Extend one of the provided presets in your `tsconfig.json`:
+
+```json
+{
+  "extends": "@opendaw/typescript-config/tsconfig.base.json"
+}
+```
+
+### Available presets
+
+- `tsconfig.base.json` – minimal baseline options used across the monorepo.
+- `tsconfig.build.json` – extends the base preset for compiling packages.
+- `tsconfig.eslint.json` – configuration for tooling such as ESLint.
+- `vite.json` – settings for Vite powered applications.
+
+Each preset can be customised further in the consuming project.

--- a/packages/config/typescript/package.json
+++ b/packages/config/typescript/package.json
@@ -2,6 +2,17 @@
   "name": "@opendaw/typescript-config",
   "version": "0.0.19",
   "private": true,
+  "description": "Shared TypeScript configuration presets for openDAW",
+  "exports": {
+    "./tsconfig.base.json": "./tsconfig.base.json",
+    "./tsconfig.build.json": "./tsconfig.build.json",
+    "./tsconfig.eslint.json": "./tsconfig.eslint.json",
+    "./vite.json": "./vite.json"
+  },
+  "files": [
+    "*.json",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/config/typescript/tsconfig.base.json
+++ b/packages/config/typescript/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  // Base TypeScript preset for openDAW packages.
+  // Example usage:
+  // {
+  //   "extends": "@opendaw/typescript-config/tsconfig.base.json",
+  //   "compilerOptions": {
+  //     "outDir": "./dist",
+  //     "rootDir": "./src"
+  //   }
+  // }
+  "extends": "./base.json"
+}

--- a/packages/config/typescript/tsconfig.build.json
+++ b/packages/config/typescript/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  // Preset for compiling libraries and Node scripts.
+  // Example usage:
+  // {
+  //   "extends": "@opendaw/typescript-config/tsconfig.build.json",
+  //   "include": ["src"],
+  //   "exclude": ["dist", "node_modules", "**/*.test.ts"]
+  // }
+  "extends": "./base.json",
+  "compilerOptions": {
+    "noEmit": false
+  }
+}

--- a/packages/config/typescript/tsconfig.eslint.json
+++ b/packages/config/typescript/tsconfig.eslint.json
@@ -1,0 +1,11 @@
+{
+  // Preset to help ESLint resolve TypeScript sources.
+  // Example usage:
+  // {
+  //   "extends": "@opendaw/typescript-config/tsconfig.eslint.json"
+  // }
+  "extends": "./base.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/config/typescript/vite.json
+++ b/packages/config/typescript/vite.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,

--- a/packages/docs/docs-dev/configuration/typescript.md
+++ b/packages/docs/docs-dev/configuration/typescript.md
@@ -1,0 +1,23 @@
+# TypeScript Configuration
+
+The `@opendaw/typescript-config` package provides shared `tsconfig` presets used
+throughout the project.
+
+## Basic usage
+
+Extend one of the presets from your project's `tsconfig.json`:
+
+```json
+{
+  "extends": "@opendaw/typescript-config/tsconfig.base.json"
+}
+```
+
+### Presets
+
+- **tsconfig.base.json** – baseline compiler options.
+- **tsconfig.build.json** – build oriented options for libraries and scripts.
+- **tsconfig.eslint.json** – configuration used by ESLint and other tools.
+- **vite.json** – settings tailored for Vite applications.
+
+Each preset can be further customised as needed.

--- a/packages/lib/runtime/tsconfig.json
+++ b/packages/lib/runtime/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@opendaw/typescript-config/base.json",
+  "extends": "@opendaw/typescript-config/tsconfig.build.json",
   "compilerOptions": {
     "lib": [
       "ESNext",


### PR DESCRIPTION
## Summary
- add commented TypeScript preset examples
- document presets in package README and dev docs
- use new build preset in runtime and deploy configs

## Testing
- `npm test` (fails: command exited 1)
- `npm run lint` (fails: command exited 1)


------
https://chatgpt.com/codex/tasks/task_b_68aea3cb83c48321bce5660b93e11fc2