### PR TITLE
feat: scaffold studio box modules and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ public/dist
 public/build-info.json
 lerna-debug.log
 /packages/lib/box-forge/test/gen/**
-/packages/studio/boxes/src/**
 /packages/studio/adapters/src/index.ts
 /packages/app/studio/public/build-info.json
 /packages/app/localhost.pem

--- a/packages/docs/docs-dev/boxes/diagram.md
+++ b/packages/docs/docs-dev/boxes/diagram.md
@@ -1,0 +1,12 @@
+# Boxes Diagram
+
+The following diagram illustrates the relationships between box groups.
+
+```mermaid
+graph TD
+  Device --> Instrument
+  Instrument --> Effect
+```
+
+Refer to the [`@opendaw/lib-box` README](../../../lib/box/README.md) for the
+core graph concepts.

--- a/packages/docs/docs-dev/boxes/examples.md
+++ b/packages/docs/docs-dev/boxes/examples.md
@@ -1,0 +1,12 @@
+# Boxes Examples
+
+Basic usage of the studio box modules:
+
+```ts
+import { deviceBoxes } from "@opendaw/studio-boxes";
+
+console.log(deviceBoxes.length);
+```
+
+For details on underlying box mechanics see the
+[`@opendaw/lib-box` README](../../../lib/box/README.md).

--- a/packages/docs/docs-dev/boxes/faq.md
+++ b/packages/docs/docs-dev/boxes/faq.md
@@ -1,0 +1,9 @@
+# Boxes FAQ
+
+## Why are these boxes generated?
+
+They are produced by `@opendaw/studio-forge-boxes` to ensure type safety.
+
+## Where can I learn more about the box system?
+
+See the [`@opendaw/lib-box` README](../../../lib/box/README.md).

--- a/packages/docs/docs-dev/boxes/overview.md
+++ b/packages/docs/docs-dev/boxes/overview.md
@@ -1,0 +1,6 @@
+# Boxes Overview
+
+`@opendaw/studio-boxes` provides collections of typed boxes that model devices,
+instruments, effects and other entities used by the studio. It builds upon the
+graph engine described in the
+[`@opendaw/lib-box` README](../../../lib/box/README.md).

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -33,5 +33,15 @@ module.exports = {
         { type: "doc", id: "box-forge/integration" },
       ],
     },
+    {
+      type: "category",
+      label: "Boxes",
+      items: [
+        { type: "doc", id: "boxes/overview" },
+        { type: "doc", id: "boxes/examples" },
+        { type: "doc", id: "boxes/diagram" },
+        { type: "doc", id: "boxes/faq" },
+      ],
+    },
   ],
 };

--- a/packages/studio/boxes/README.md
+++ b/packages/studio/boxes/README.md
@@ -1,1 +1,21 @@
-This package is part of the openDAW SDK
+# Studio Boxes
+
+Collection of statically typed box definitions used by the openDAW studio.
+These modules describe devices, instruments, effects and other entities within a
+project. They rely on the core graph engine provided by
+[`@opendaw/lib-box`](../../lib/box/README.md).
+
+## Modules
+
+- `device-boxes` – hardware and software device definitions.
+- `instrument-boxes` – musical instrument boxes.
+- `effect-boxes` – audio effect boxes.
+- `midi-boxes` – MIDI related boxes.
+- `audio-boxes` – audio file and stream boxes.
+- `mixer-boxes` – routing and mixing boxes.
+- `workspace-boxes` – workspace state containers.
+- `project-boxes` – project level boxes.
+- `state-sync` – utilities for synchronizing box state.
+
+Further details and examples can be found in the
+[Boxes documentation](../../docs/docs-dev/boxes/overview.md).

--- a/packages/studio/boxes/src/audio-boxes.ts
+++ b/packages/studio/boxes/src/audio-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Audio file and stream box definitions.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder audio box definition. */
+export interface AudioBox {
+  /** Source file name or identifier. */
+  source: string;
+}
+
+/** Registered audio box definitions. */
+export const audioBoxes: AudioBox[] = [];

--- a/packages/studio/boxes/src/device-boxes.ts
+++ b/packages/studio/boxes/src/device-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Definitions for device related boxes used by the studio.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder interface representing a generic device box. */
+export interface DeviceBox {
+  /** Unique device identifier. */
+  id: string;
+}
+
+/** Collection of registered device boxes. */
+export const deviceBoxes: DeviceBox[] = [];

--- a/packages/studio/boxes/src/effect-boxes.ts
+++ b/packages/studio/boxes/src/effect-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Effect box definitions describing audio effects.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder effect box. */
+export interface EffectBox {
+  /** Effect identifier. */
+  id: string;
+}
+
+/** Registered effect box definitions. */
+export const effectBoxes: EffectBox[] = [];

--- a/packages/studio/boxes/src/index.ts
+++ b/packages/studio/boxes/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Entry point aggregating all studio box modules.
+ *
+ * @packageDocumentation
+ */
+
+export * from "./device-boxes";
+export * from "./instrument-boxes";
+export * from "./effect-boxes";
+export * from "./midi-boxes";
+export * from "./audio-boxes";
+export * from "./mixer-boxes";
+export * from "./workspace-boxes";
+export * from "./project-boxes";
+export * from "./state-sync";

--- a/packages/studio/boxes/src/instrument-boxes.ts
+++ b/packages/studio/boxes/src/instrument-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Instrument box definitions for musical instruments.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder instrument box. */
+export interface InstrumentBox {
+  /** Human readable name of the instrument. */
+  name: string;
+}
+
+/** Registered instrument box definitions. */
+export const instrumentBoxes: InstrumentBox[] = [];

--- a/packages/studio/boxes/src/midi-boxes.ts
+++ b/packages/studio/boxes/src/midi-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * MIDI related box definitions.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder MIDI box definition. */
+export interface MidiBox {
+  /** MIDI channel assigned to the box. */
+  channel: number;
+}
+
+/** Collection of MIDI box definitions. */
+export const midiBoxes: MidiBox[] = [];

--- a/packages/studio/boxes/src/mixer-boxes.ts
+++ b/packages/studio/boxes/src/mixer-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Mixer and routing box definitions.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder mixer box definition. */
+export interface MixerBox {
+  /** Name of the mixer channel. */
+  channel: string;
+}
+
+/** Registered mixer box definitions. */
+export const mixerBoxes: MixerBox[] = [];

--- a/packages/studio/boxes/src/project-boxes.ts
+++ b/packages/studio/boxes/src/project-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Project level box definitions describing DAW projects.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder project box definition. */
+export interface ProjectBox {
+  /** File name for the project. */
+  file: string;
+}
+
+/** Registered project box definitions. */
+export const projectBoxes: ProjectBox[] = [];

--- a/packages/studio/boxes/src/state-sync.ts
+++ b/packages/studio/boxes/src/state-sync.ts
@@ -1,0 +1,17 @@
+/**
+ * Helpers for synchronizing box state between contexts.
+ *
+ * @packageDocumentation
+ */
+
+/**
+ * Synchronize the provided source with a target.
+ *
+ * @param source - An arbitrary source object.
+ * @param target - The target to receive state updates.
+ */
+export function syncState(source: unknown, target: unknown): void {
+  // Placeholder implementation
+  void source;
+  void target;
+}

--- a/packages/studio/boxes/src/workspace-boxes.ts
+++ b/packages/studio/boxes/src/workspace-boxes.ts
@@ -1,0 +1,14 @@
+/**
+ * Workspace level box definitions controlling global state.
+ *
+ * @packageDocumentation
+ */
+
+/** Placeholder workspace box definition. */
+export interface WorkspaceBox {
+  /** Title of the workspace. */
+  title: string;
+}
+
+/** Workspace box collection used by the application. */
+export const workspaceBoxes: WorkspaceBox[] = [];


### PR DESCRIPTION
## Summary
- add placeholder box modules for studio package and aggregate in index
- document box modules and create developer docs pages
- expose boxes docs in sidebar

## Testing
- `npm test` (fails: @opendaw/lib-dsp#test)
- `npm run lint` (fails: @opendaw/lib-midi#lint)


------
https://chatgpt.com/codex/tasks/task_b_68aea3cbe174832193856d32b8e81d17