### PR TITLE
docs: document ESLint configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   root: true,
-  extends: ["@opendaw/eslint-config/index.js"],
+  ignorePatterns: [".eslintrc.js"],
+  extends: ["@opendaw/eslint-config"],
 };

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ Thank you for your interest in contributing to openDAW! This guide outlines the 
 
 ## Style Guidelines
 
-- Use **Prettier** for formatting and **ESLint** for linting.
+- Use **Prettier** for formatting and **ESLint** for linting. See the
+  [ESLint configuration guide](./packages/docs/docs-dev/configuration/eslint.md).
 - Prefer clear, self-documenting code and avoid unnecessary abstractions.
 - Write Markdown documentation using ATX headings (`#`, `##`, etc.) and keep line length reasonable.
 - Include tests or documentation updates alongside code changes when appropriate.

--- a/packages/app/headless/.eslintrc.cjs
+++ b/packages/app/headless/.eslintrc.cjs
@@ -1,5 +1,10 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   root: true,
-  extends: ["@opendaw/eslint-config/index.js"],
+  ignorePatterns: [".eslintrc.cjs"],
+  extends: ["@opendaw/eslint-config"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: true,
+  },
 };

--- a/packages/app/studio/.eslintrc.cjs
+++ b/packages/app/studio/.eslintrc.cjs
@@ -1,5 +1,10 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   root: true,
-  extends: ["@opendaw/eslint-config/index.js"],
+  ignorePatterns: [".eslintrc.cjs"],
+  extends: ["@opendaw/eslint-config"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    project: true,
+  },
 };

--- a/packages/config/eslint/.eslintrc.cjs
+++ b/packages/config/eslint/.eslintrc.cjs
@@ -1,0 +1,24 @@
+/**
+ * Example usage of the shared ESLint config:
+ *
+ * ```js
+ * // .eslintrc.cjs
+ * module.exports = {
+ *   root: true,
+ *   extends: ['@opendaw/eslint-config'],
+ *   parserOptions: {
+ *     project: true,
+ *   }, // optional for TypeScript projects
+ * };
+ * ```
+ *
+ * This file lints the config package itself and demonstrates how to consume
+ * the configuration.
+ */
+
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  ignorePatterns: [".eslintrc.cjs"],
+  extends: ["@opendaw/eslint-config"],
+};

--- a/packages/config/eslint/README.md
+++ b/packages/config/eslint/README.md
@@ -1,0 +1,29 @@
+# @opendaw/eslint-config
+
+Shared ESLint configuration for openDAW packages.
+
+## Usage
+
+Install the required packages:
+
+```bash
+npm install -D eslint @opendaw/eslint-config \
+  @typescript-eslint/eslint-plugin @typescript-eslint/parser \
+  eslint-config-prettier
+```
+
+Create an `.eslintrc.cjs` in your project:
+
+```js
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@opendaw/eslint-config"],
+  parserOptions: {
+    project: true, // optional for TypeScript projects
+  },
+};
+```
+
+The config forbids direct imports from `src` folders. Use package exports
+instead.

--- a/packages/config/eslint/package.json
+++ b/packages/config/eslint/package.json
@@ -2,7 +2,14 @@
   "name": "@opendaw/eslint-config",
   "version": "0.0.18",
   "private": true,
+  "description": "Shared ESLint configuration for openDAW packages.",
   "main": "index.js",
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.1.0",
+    "@typescript-eslint/parser": "^7.1.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/docs/docs-dev/configuration/eslint.md
+++ b/packages/docs/docs-dev/configuration/eslint.md
@@ -1,0 +1,28 @@
+# ESLint
+
+openDAW ships a shared ESLint configuration published as
+`@opendaw/eslint-config`.
+
+## Usage
+
+Install the required packages:
+
+```bash
+npm install -D eslint @opendaw/eslint-config \
+  @typescript-eslint/eslint-plugin @typescript-eslint/parser \
+  eslint-config-prettier
+```
+
+Create an `.eslintrc.cjs`:
+
+```js
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+  root: true,
+  extends: ["@opendaw/eslint-config"],
+  parserOptions: { project: true }, // optional for TypeScript projects
+};
+```
+
+The config forbids direct imports from `src` folders. Use package exports
+instead.

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -6,6 +6,11 @@ module.exports = {
     { type: "doc", id: "performance" },
     { type: "doc", id: "security-privacy" },
     { type: "doc", id: "browser-support" },
+    {
+      type: "category",
+      label: "Configuration",
+      items: ["configuration/eslint"],
+    },
     { type: "doc", id: "licensing" },
     {
       type: "category",
@@ -21,7 +26,7 @@ module.exports = {
         "xml/pitfalls",
         "xml/best-practices",
         "xml/troubleshooting",
-        ]
+      ],
     },
     {
       type: "category",

--- a/packages/lib/dsp/.eslintrc.cjs
+++ b/packages/lib/dsp/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   root: true,
   ignorePatterns: [".eslintrc.cjs"],
-  extends: ["@opendaw/eslint-config/index.js"],
+  extends: ["@opendaw/eslint-config"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: true,

--- a/packages/studio/core/.eslintrc.cjs
+++ b/packages/studio/core/.eslintrc.cjs
@@ -2,7 +2,7 @@
 module.exports = {
   root: true,
   ignorePatterns: [".eslintrc.cjs"],
-  extends: ["@opendaw/eslint-config/index.js"],
+  extends: ["@opendaw/eslint-config"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: true,


### PR DESCRIPTION
## Summary
- add usage example and README for `@opendaw/eslint-config`
- align project and package ESLint configs
- document ESLint setup in developer docs and link from contributing guide

## Testing
- `npm test` *(fails: command /workspace/openDAW/packages/lib/dsp tsc exited 2)*
- `npm run lint` *(fails: command /workspace/openDAW/packages/studio/boxes eslint exited 2)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3cf8e848321af38d65d1d3293de