### PR TITLE
docs: document helper scripts and add usage references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ Thank you for your interest in contributing to openDAW! This guide outlines the 
 ## Pull Request Workflow
 
 1. **Fork and clone** the repository, then create a descriptive branch for your work.
-2. **Install dependencies** with `npm install` and make sure the project builds locally.
+2. **Install dependencies**:
+   - `npm run install:deps` to install required system tools.
+   - `npm install` to fetch project packages.
 3. **Keep commits focused** and write clear commit messages that describe the change.
 4. **Format and lint** your changes:
    - `npx prettier --write <files>`
@@ -23,3 +25,8 @@ Thank you for your interest in contributing to openDAW! This guide outlines the 
 - Include tests or documentation updates alongside code changes when appropriate.
 
 Following these steps helps maintain a clean git history and a stable codebase. We appreciate every contribution—thank you for helping improve openDAW!
+
+## Useful Scripts
+
+- `npm run clean` – remove build artifacts and dependencies.
+- `npm run cert` – regenerate the HTTPS development certificate.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "cert": "bash ./scripts/cert.sh",
     "clean": "bash ./scripts/clean.sh",
+    "install:deps": "node ./scripts/install_dependencies.js",
     "build": "turbo build",
     "dev:studio": "turbo run dev --filter=@opendaw/app-studio",
     "dev:headless": "turbo run dev --filter=@opendaw/app-headless",

--- a/packages/docs/docs-dev/build-and-run/scripts.md
+++ b/packages/docs/docs-dev/build-and-run/scripts.md
@@ -1,0 +1,53 @@
+# Scripts
+
+Helper scripts automate common setup tasks for the development environment.
+
+## install_dependencies.js
+
+Checks for required system tools and installs any that are missing, then runs
+`npm install` for the workspace.
+
+```bash
+npm run install:deps
+```
+
+```mermaid
+flowchart TD
+  A[Start] --> B{Tool installed?}
+  B -->|Yes| C[Next tool]
+  B -->|No| D[Install tool]
+  D --> B
+  C --> E[Install npm packages]
+```
+
+## cert.sh
+
+Generates a trusted HTTPS certificate for `localhost` using mkcert.
+
+```bash
+npm run cert
+```
+
+```mermaid
+flowchart LR
+  A[Run script] --> B[cd packages/app]
+  B --> C[mkcert localhost]
+```
+
+## clean.sh
+
+Removes build artifacts, lock files and `node_modules` to reset the workspace.
+
+```bash
+npm run clean
+```
+
+```mermaid
+flowchart TD
+  A[Run script] --> B[Remove node_modules]
+  B --> C[Remove dist folders]
+  C --> D[Delete lock files]
+  D --> E[Clear .turbo caches]
+  E --> F[Clean studio boxes]
+```
+

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,10 @@
+# Scripts
+
+Utility scripts that help manage the development environment.
+
+| Script | Description | Usage |
+| ------ | ----------- | ----- |
+| `cert.sh` | Generate a trusted HTTPS certificate for `localhost` using [`mkcert`](https://github.com/FiloSottile/mkcert). | `npm run cert` |
+| `clean.sh` | Remove all `node_modules`, build outputs, lock files and Turbo caches to reset the workspace. | `npm run clean` |
+| `install_dependencies.js` | Check for required system tools (Git, Node.js, mkcert, Sass, TypeScript, OpenSSL) and install any missing ones. Also runs `npm install`. | `npm run install:deps` |
+

--- a/scripts/cert.sh
+++ b/scripts/cert.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
+
+# Generate a local HTTPS certificate for development using mkcert.
+#
+# Usage:
+#   npm run cert
+#
+# Requires mkcert to be installed and trusted on the machine.
+
 set -euo pipefail
-echo "mkcert localhost"
-cd packages/app && mkcert localhost || exit 1
+
+echo "Creating localhost certificate with mkcert"
+# Switch to the web app directory and generate a certificate for localhost.
+cd packages/app && mkcert localhost || {
+  echo "mkcert failed. Is mkcert installed and initialized?" >&2
+  exit 1
+}

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,19 +1,31 @@
 #!/bin/bash
 
-# This script cleans everything
+# Remove build artifacts and dependencies across the monorepo.
+#
+# Usage:
+#   npm run clean
+#
+# This command is destructive; it deletes node_modules and other generated
+# directories to reset the workspace.
 
 set -e  # Exit on any error
 
 echo "📦 Removing all node_modules folders..."
+# Remove every node_modules directory in the repository.
 find . -name "node_modules" -type d -exec rm -rf {} + 2>/dev/null || true
 
 echo "🗂️  Removing all dist folders..."
+# Delete compiled output directories.
 find . -name "dist" -type d -exec rm -rf {} + 2>/dev/null || true
 
 echo "🔒 Removing all package-lock.json files..."
+# Remove lock files to force a fresh npm install.
 find . -name "package-lock.json" -type f -delete 2>/dev/null || true
 
 echo "🔒 Removing all .turbo files..."
+# Clear Turbo cache directories.
 find . -name ".turbo" -type d -exec rm -rf {} + 2>/dev/null || true
 
+# Remove generated box sources for the studio package.
 rm -rf packages/studio/boxes/src/* 2>/dev/null || true
+

--- a/scripts/install_dependencies.js
+++ b/scripts/install_dependencies.js
@@ -1,13 +1,29 @@
 #!/usr/bin/env node
+
+/**
+ * Install required system dependencies for developing openDAW.
+ *
+ * Usage:
+ *   npm run install:deps
+ *
+ * The script checks for common tools (Git, Node.js, mkcert, Sass,
+ * TypeScript, OpenSSL) and installs any missing ones using the
+ * platform's package manager. It finishes by running `npm install`
+ * to fetch JavaScript dependencies for the repository.
+ */
+
 const { execSync } = require('child_process');
 const os = require('os');
 
+// Determine the current operating system to select install commands.
 const platform = os.platform();
 
+// Helper to run shell commands and forward their output.
 function run(cmd) {
   execSync(cmd, { stdio: 'inherit' });
 }
 
+// List of external dependencies to verify and potentially install.
 const deps = [
   {
     name: 'git',
@@ -69,8 +85,10 @@ const deps = [
 for (const dep of deps) {
   let installed = false;
   try {
+    // Run the dependency's check command to see if it is installed.
     const output = execSync(dep.check, { stdio: 'pipe' }).toString().trim();
     if (dep.verify) {
+      // Some dependencies require version validation (e.g., Node.js >= 23).
       installed = dep.verify(output);
     } else {
       installed = true;
@@ -84,6 +102,7 @@ for (const dep of deps) {
     continue;
   }
 
+  // Select the installation command for the current platform.
   const installCmd = dep.install[platform];
   if (!installCmd) {
     console.log(`No install command for ${dep.name} on ${platform}. Please install manually.`);
@@ -98,7 +117,7 @@ for (const dep of deps) {
   }
 }
 
-// install project npm dependencies
+// Finally install Node.js packages for the repository itself.
 try {
   console.log('Installing npm packages...');
   run('npm install');


### PR DESCRIPTION
## Summary
- document cert, clean and dependency install scripts with inline comments
- add scripts overview docs and reference them in package.json and contributing guide
- add developer docs page with flowcharts for helper scripts

## Testing
- `npm test` *(fails: @opendaw/lib-dsp#build)*
- `npm run lint` *(fails: @opendaw/studio-boxes#lint)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3d0df488321a5154be8663cbff6