### PR TITLE
Document test project fixtures

### DIFF
--- a/packages/docs/docs-dev/testing/test-files.md
+++ b/packages/docs/docs-dev/testing/test-files.md
@@ -1,0 +1,13 @@
+# Test files
+
+A set of sample projects is available in the [`test-files`](../../../test-files) directory. These fixtures
+cover common scenarios and are used across packages for development and regression tests.
+
+| File | Description |
+| --- | --- |
+| `all-devices.od` | OpenDAW project exercising a wide range of built-in devices. |
+| `eq.dawproject` | DAWproject fixture containing EQ settings. |
+| `note-regions.dawproject` | Demonstrates note regions across tracks. |
+| `automation.dawproject` | Includes parameter automation curves. |
+| `audio-regions.dawproject` | Contains audio regions with linked media. |
+| `bitwig.example.xml` | Minimal Bitwig project used for parser tests. |

--- a/packages/docs/docs-user/examples/test-projects.md
+++ b/packages/docs/docs-user/examples/test-projects.md
@@ -1,0 +1,13 @@
+# Test projects
+
+To try out openDAW features without starting from scratch, load one of the sample
+projects in the [`test-files`](../../../../test-files) directory:
+
+- **all-devices.od** – showcases a variety of built‑in devices.
+- **eq.dawproject** – demonstrates equaliser configuration.
+- **note-regions.dawproject** – contains several note regions on multiple tracks.
+- **automation.dawproject** – includes automation lane examples.
+- **audio-regions.dawproject** – provides audio region editing samples.
+- **bitwig.example.xml** – a tiny Bitwig project useful for import experiments.
+
+These projects are read‑only fixtures; copy them before making changes.

--- a/packages/lib/dawproject/README.md
+++ b/packages/lib/dawproject/README.md
@@ -9,3 +9,8 @@ helpers in [`src/utils.ts`](./src/utils.ts) for working with parameters.
 
 See the [developer documentation](../../docs/docs-dev/dawproject/overview.md) for a detailed overview,
 data format description, and additional examples.
+
+## Test fixtures
+
+Example project files for experimentation live in [`test-files`](../../test-files). A developer overview
+of these fixtures is available in the [testing docs](../../docs/docs-dev/testing/test-files.md).

--- a/packages/lib/midi/README.md
+++ b/packages/lib/midi/README.md
@@ -47,3 +47,8 @@ if (MidiData.isNoteOn(message)) {
   osc.generate(buffer, freq / 44100, Waveform.sine, 0, buffer.length);
 }
 ```
+
+## Test fixtures
+
+Sample MIDI and DAW project files can be found in [`test-files`](../../test-files). See the
+[test file overview](../../docs/docs-dev/testing/test-files.md) for details on available fixtures.

--- a/packages/studio/core-processors/README.md
+++ b/packages/studio/core-processors/README.md
@@ -14,3 +14,8 @@ flowchart LR
 ```
 
 The diagram illustrates how note events are transformed into audio, mixed, and analysed within the engine.
+
+## Test fixtures
+
+Processor behaviour can be verified with the example projects in [`test-files`](../../../test-files).
+Additional details are documented in the [developer testing guide](../../docs/docs-dev/testing/test-files.md).

--- a/test-files/README.md
+++ b/test-files/README.md
@@ -1,0 +1,12 @@
+# Test Project Fixtures
+
+These files provide example projects for development and automated tests.
+
+- `all-devices.od` – OpenDAW project exercising a wide range of built-in devices.
+- `eq.dawproject` – DAWproject fixture containing EQ settings.
+- `note-regions.dawproject` – Demonstrates note regions across tracks.
+- `automation.dawproject` – Includes parameter automation curves.
+- `audio-regions.dawproject` – Contains audio regions with linked media.
+- `bitwig.example.xml` – Minimal Bitwig project used for parser tests.
+
+They can be referenced from documentation and README files.

--- a/test-files/bitwig.example.xml
+++ b/test-files/bitwig.example.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- Example Bitwig project used as a test fixture -->
 <Project version="1.0">
     <Application name="Bitwig Studio" version="5.0"/>
     <Transport>


### PR DESCRIPTION
## Summary
- document fixture files in test-files/ README and Bitwig XML
- reference test fixtures from package READMEs
- add developer and user docs describing sample test projects

## Testing
- `npm test` *(fails: @opendaw/lib-dsp build error)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3d4026c8321bd6456821d9ad26d