### PR TITLE
docs: add style guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 
 * [openDAW](https://github.com/andremichelle/opendaw)
 
+### Style Documentation
+
+- [Style Guidelines](styles/OpenDAW/style-guidelines.md)
+- [Developer Style Guide](packages/docs/docs-dev/style-guide.md)
+- [User Style Customization](packages/docs/docs-user/style-customization.md)
+
 ### Prepare, Clone, Installation, and Run
 
 openDAW tries to avoid external libraries and frameworks. Following is a list of the external libraries we currently use in the web studio:

--- a/packages/app/headless/src/style.css
+++ b/packages/app/headless/src/style.css
@@ -1,4 +1,5 @@
-/* Basic styles for the headless demo page. */
+/* Basic styles for the headless demo page.
+   Naming follows styles/OpenDAW/style-guidelines.md */
 :root {
     font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
     font-size: 16px;

--- a/packages/app/studio/public/favicon.svg
+++ b/packages/app/studio/public/favicon.svg
@@ -1,3 +1,4 @@
+<!-- Favicon generated per styles/OpenDAW/style-guidelines.md -->
 <svg viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <path d="M8,3L8,21C8,22.104 7.104,23 6,23L3,23C1.896,23 1,22.104 1,21L1,3C1,1.896 1.896,1 3,1L6,1C7.104,1 8,1.896 8,3Z"
           style="fill:rgb(221,221,221);"/>

--- a/packages/app/studio/public/grid16.svg
+++ b/packages/app/studio/public/grid16.svg
@@ -1,3 +1,4 @@
+<!-- Grid pattern icon; see styles/OpenDAW/style-guidelines.md -->
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="rgba(255, 255, 255, 0.08)">
     <rect x="0" y="0" width="1" height="1"/>
 </svg>

--- a/packages/app/studio/public/update.html
+++ b/packages/app/studio/public/update.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <!-- Update spinner shown during application refresh -->
+<!-- Styles adhere to styles/OpenDAW/style-guidelines.md -->
 <html lang="en">
 <head>
 	<meta charset="UTF-8">

--- a/packages/app/studio/src/colors.sass
+++ b/packages/app/studio/src/colors.sass
@@ -1,3 +1,4 @@
+// Color palette variables; see styles/OpenDAW/style-guidelines.md
 \:root
   color-scheme: dark
   --color-blue: hsl(189, 100%, 65%)

--- a/packages/app/studio/src/main.sass
+++ b/packages/app/studio/src/main.sass
@@ -1,6 +1,8 @@
 @use "@/colors"
 @use "@/mixins"
 
+// Global styles follow styles/OpenDAW/style-guidelines.md
+
 html, body
   font-size: 16px
   font-family: Rubik, sans-serif

--- a/packages/app/studio/src/mixins.sass
+++ b/packages/app/studio/src/mixins.sass
@@ -1,3 +1,4 @@
+// Shared mixins follow styles/OpenDAW/style-guidelines.md
 @use "@/colors"
 
 @mixin width-available

--- a/packages/docs/docs-dev/style-guide.md
+++ b/packages/docs/docs-dev/style-guide.md
@@ -1,0 +1,10 @@
+# Style Guide
+
+Developers extending openDAW should follow the shared styling rules.
+
+- CSS custom properties use kebab-case, e.g. `--color-blue`.
+- Core variables live in [`colors.sass`](../../../packages/app/studio/src/colors.sass).
+- Classes, mixins and files are named with hyphens rather than camelCase.
+- Asset metadata or comments should link back to the [style guidelines](../../../styles/OpenDAW/style-guidelines.md).
+
+These conventions keep the look of the project consistent and predictable.

--- a/packages/docs/docs-user/style-customization.md
+++ b/packages/docs/docs-user/style-customization.md
@@ -1,0 +1,15 @@
+# Style Customization
+
+openDAW's appearance can be adjusted by overriding the CSS variables defined in
+[`colors.sass`](../../../packages/app/studio/src/colors.sass). Variables and
+class names use kebab-case such as `--color-green` or `.help-section`.
+
+To create a custom theme:
+
+1. Fork or clone the repository.
+2. Edit the desired variables in `colors.sass` or provide your own stylesheet
+   that overrides them.
+3. Rebuild the app to apply your changes.
+
+For more details see the [developer style guide](../docs-dev/style-guide.md) and
+the central [style guidelines](../../../styles/OpenDAW/style-guidelines.md).

--- a/styles/OpenDAW/style-guidelines.md
+++ b/styles/OpenDAW/style-guidelines.md
@@ -1,0 +1,26 @@
+# OpenDAW Style Guidelines
+
+This document outlines the conventions used for CSS and Sass across the project.
+
+## Variables
+
+- CSS custom properties use kebab-case and live in `packages/app/studio/src/colors.sass`.
+- Color values use the `--color-*` prefix, e.g. `--color-blue` or `--color-green`.
+- Layout constants follow the same pattern such as `--lane-height` and `--timeline-header-width`.
+- Panel backgrounds are available via `--panel-background`, `--panel-background-bright`, and `--panel-background-dark`.
+- Group related variables together and document new entries when introduced.
+
+## Naming
+
+- Class names, mixins, and variables use kebab-case (`.help-section`, `@mixin width-available`).
+- Avoid camelCase and underscores in selectors and custom properties.
+- Asset filenames in `packages/app/studio/public` also follow kebab-case.
+- Style assets include comments or metadata pointing back to this guide.
+
+The following files demonstrate these conventions:
+
+- `packages/app/headless/src/style.css`
+- `packages/app/studio/src/main.sass`
+- `packages/app/studio/src/mixins.sass`
+- `packages/app/studio/src/colors.sass`
+- `packages/app/studio/public` assets


### PR DESCRIPTION
## Summary
- document shared CSS/Sass conventions in styles/OpenDAW/style-guidelines.md
- reference style guide across headless and studio styling files
- add developer and user style docs and link them from README
- revert binary public image changes so only textual assets are updated

## Testing
- `npm test` *(fails: @opendaw/lib-dsp build error)*
- `npm run format` *(fails: SyntaxError in packages/lib/dsp/src/events.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3d527d0832197173a92a51fde89