### PR TITLE
Add architecture diagrams and asset README

### DIFF
--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,9 @@
+# Asset Library
+
+This directory collects images and diagrams used across the openDAW project.  Each
+subfolder groups related artwork such as architecture diagrams or user interface
+mockups.
+
+Unless otherwise noted, all assets in this tree are licensed under the
+[Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/) license.
+Where possible, diagrams are stored as SVG files so they can be easily modified or reused.

--- a/assets/architecture/box-sync.svg
+++ b/assets/architecture/box-sync.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="120">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="40" width="100" height="40" fill="#fff" stroke="#000"/>
+  <rect x="200" y="40" width="100" height="40" fill="#fff" stroke="#000"/>
+  <text x="70" y="65" font-family="Arial" font-size="12" text-anchor="middle">Source</text>
+  <text x="250" y="65" font-family="Arial" font-size="12" text-anchor="middle">Target</text>
+  <line x1="120" y1="60" x2="200" y2="60" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+</svg>

--- a/assets/architecture/worker-flow.svg
+++ b/assets/architecture/worker-flow.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="120">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="20" y="40" width="100" height="40" fill="#fff" stroke="#000"/>
+  <rect x="200" y="40" width="100" height="40" fill="#fff" stroke="#000"/>
+  <text x="70" y="65" font-family="Arial" font-size="12" text-anchor="middle">Main</text>
+  <text x="250" y="65" font-family="Arial" font-size="12" text-anchor="middle">Worker</text>
+  <line x1="120" y1="60" x2="200" y2="60" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="200" y1="80" x2="120" y2="80" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+</svg>

--- a/assets/ui/component-hierarchy.svg
+++ b/assets/ui/component-hierarchy.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="360" height="160">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="10" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L10,5 L0,10 z" fill="#000" />
+    </marker>
+  </defs>
+  <rect x="150" y="20" width="60" height="40" fill="#fff" stroke="#000"/>
+  <rect x="60" y="100" width="100" height="40" fill="#fff" stroke="#000"/>
+  <rect x="200" y="100" width="100" height="40" fill="#fff" stroke="#000"/>
+  <text x="180" y="45" font-family="Arial" font-size="12" text-anchor="middle">App</text>
+  <text x="110" y="125" font-family="Arial" font-size="12" text-anchor="middle">Editor</text>
+  <text x="250" y="125" font-family="Arial" font-size="12" text-anchor="middle">Transport</text>
+  <line x1="180" y1="60" x2="110" y2="100" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="180" y1="60" x2="250" y2="100" stroke="#000" stroke-width="2" marker-end="url(#arrow)"/>
+</svg>

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -3,3 +3,7 @@
 This package contains the web-based user interface for the OpenDAW project.
 
 For a guided overview of the interface, see the [UI tour](../../docs/docs-user/ui-tour.md).
+
+## Component Hierarchy
+
+![Component hierarchy](../../../assets/ui/component-hierarchy.svg)

--- a/packages/docs/docs-dev/architecture/audio-path.md
+++ b/packages/docs/docs-dev/architecture/audio-path.md
@@ -48,6 +48,7 @@ stateDiagram-v2
     active --> terminated
     terminated --> [*]
 ```
+![Worker flow diagram](../../../../assets/architecture/worker-flow.svg)
 
 The shared worker is installed during application startup, becomes active while
 providing services to the audio engine and is terminated when the session ends.

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -83,6 +83,7 @@ sequenceDiagram
     Main->>Worker: invoke protocols
     Main-->>Worker: terminate
 ```
+![Worker flow diagram](../../../../assets/architecture/worker-flow.svg)
 
 Workers are installed once at application startup and provide services such as
 file access and waveform analysis before being terminated when no longer

--- a/packages/lib/box/README.md
+++ b/packages/lib/box/README.md
@@ -41,6 +41,7 @@ sequenceDiagram
     M->>ST: deliver tasks
     ST->>G2: apply updates
 ```
+![Box sync diagram](../../../assets/architecture/box-sync.svg)
 
 This flow keeps graphs in different threads or machines consistent while allowing transactions to batch multiple changes.
 


### PR DESCRIPTION
## Summary
- add architecture and UI diagrams as SVG only
- document asset purpose and licensing
- reference diagrams throughout docs and package READMEs

## Testing
- `npm test` *(fails: @opendaw/lib-dsp build exited with code 2)*
- `npm run lint` *(fails: @opendaw/studio-boxes lint exited with code 2)*

------
https://chatgpt.com/codex/tasks/task_b_68aea3d3f1ac8321a0427314cf2a71da