### PR TITLE
docs: add service layer docs

### DIFF
--- a/packages/app/studio/src/service/ExportStemsConfigurator.sass
+++ b/packages/app/studio/src/service/ExportStemsConfigurator.sass
@@ -1,3 +1,10 @@
+// Styles for the ExportStemsConfigurator component.
+//
+// ```mermaid
+// flowchart LR
+//   header --> list
+// ```
+
 component
   padding: 1em 0
   display: grid

--- a/packages/app/studio/src/service/ExportStemsConfigurator.tsx
+++ b/packages/app/studio/src/service/ExportStemsConfigurator.tsx
@@ -23,6 +23,16 @@ type Construct = {
     configuration: EditableExportStemsConfiguration
 }
 
+/**
+ * Configurator dialog for selecting and naming stems during export.
+ *
+ * ```mermaid
+ * flowchart TB
+ *   includeAll --> stem
+ *   includeAudioEffectsAll --> stem
+ *   includeSendsAll --> stem
+ * ```
+ */
 export const ExportStemsConfigurator = ({lifecycle, configuration}: Construct) => {
     const includeAll = new DefaultObservableValue(true)
     const includeAudioEffectsAll = new DefaultObservableValue(true)

--- a/packages/app/studio/src/service/FooterLabel.ts
+++ b/packages/app/studio/src/service/FooterLabel.ts
@@ -1,5 +1,13 @@
 import {Terminable} from "@opendaw/lib-std"
 
+/**
+ * Minimal interface for labels shown in the application's footer.
+ *
+ * ```mermaid
+ * classDiagram
+ *   class FooterLabel
+ * ```
+ */
 export interface FooterLabel extends Terminable {
     setTitle(value: string): void
     setValue(value: string): void

--- a/packages/app/studio/src/service/SampleApi.ts
+++ b/packages/app/studio/src/service/SampleApi.ts
@@ -12,6 +12,17 @@ const headers: RequestInit = {
     credentials: "include"
 }
 
+/**
+ * REST API helpers for retrieving and uploading sample files.
+ *
+ * ```mermaid
+ * sequenceDiagram
+ *   participant U as Client
+ *   participant A as ApiRoot
+ *   U->>A: list.php
+ *   U->>A: get.php
+ * ```
+ */
 export namespace SampleApi {
     export const ApiRoot = "https://api.opendaw.studio/samples"
     export const FileRoot = "https://assets.opendaw.studio/samples"

--- a/packages/app/studio/src/service/SamplePlayback.ts
+++ b/packages/app/studio/src/service/SamplePlayback.ts
@@ -22,6 +22,18 @@ export type PlaybackEvent = {
     reason: string
 }
 
+/**
+ * Lightweight preview player for samples. It handles buffering, playback and
+ * emits state changes to subscribed UI components.
+ *
+ * ```mermaid
+ * stateDiagram-v2
+ *   [*] --> idle
+ *   idle --> buffering
+ *   buffering --> playing
+ *   playing --> idle
+ * ```
+ */
 export class SamplePlayback {
     readonly #context: AudioContext
     readonly #audio: HTMLAudioElement

--- a/packages/app/studio/src/service/SessionService.ts
+++ b/packages/app/studio/src/service/SessionService.ts
@@ -18,6 +18,16 @@ import {FilePickerAcceptTypes} from "@/ui/FilePickerAcceptTypes.ts"
 import {Errors, Files} from "@opendaw/lib-dom"
 import {Project} from "@opendaw/studio-core"
 
+/**
+ * Handles the lifecycle of a project session, including loading, saving and
+ * exporting bundles.
+ *
+ * ```mermaid
+ * flowchart LR
+ *   SessionService -->|creates| ProjectSession
+ *   SessionService -->|uses| Projects
+ * ```
+ */
 export class SessionService implements MutableObservableValue<Option<ProjectSession>> {
     readonly #service: StudioService
     readonly #session: DefaultObservableValue<Option<ProjectSession>>

--- a/packages/app/studio/src/service/Shortcuts.ts
+++ b/packages/app/studio/src/service/Shortcuts.ts
@@ -5,6 +5,15 @@ import {DefaultWorkspace} from "@/ui/workspace/Default"
 import {Arrays, isUndefined} from "@opendaw/lib-std"
 import {Workspace} from "@/ui/workspace/Workspace"
 
+/**
+ * Registers global keyboard listeners and routes actions to the
+ * {@link StudioService}.
+ *
+ * ```mermaid
+ * flowchart LR
+ *   Keypress --> Shortcuts --> StudioService
+ * ```
+ */
 export class Shortcuts {
     constructor(service: StudioService) {
         window.addEventListener("keydown", async (event: KeyboardEvent) => {

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -64,11 +64,6 @@ import {ProjectDialogs} from "@/project/ProjectDialogs"
 import {AudioImporter} from "@/audio/AudioImport"
 import {FilePickerAcceptTypes} from "@/ui/FilePickerAcceptTypes"
 
-/**
- * I am just piling stuff after stuff in here to boot the environment.
- * I suppose this gets cleaned up sooner or later.
- */
-
 const range = new TimelineRange({padding: 12})
 range.minimum = PPQN.fromSignature(3, 8)
 range.maxUnits = PPQN.fromSignature(128, 1)
@@ -82,6 +77,17 @@ export type Session = {
     readonly meta: ProjectMeta
 }
 
+/**
+ * Central service orchestrating workspace screens, project handling and the
+ * audio engine.
+ *
+ * ```mermaid
+ * flowchart LR
+ *   StudioService --> SessionService
+ *   StudioService --> SamplePlayback
+ *   StudioService --> Shortcuts
+ * ```
+ */
 export class StudioService implements ProjectEnv {
     readonly layout = {
         systemOpen: new DefaultObservableValue<boolean>(false),

--- a/packages/app/studio/src/service/StudioSignal.ts
+++ b/packages/app/studio/src/service/StudioSignal.ts
@@ -1,6 +1,17 @@
 import {ProjectMeta} from "@/project/ProjectMeta"
 import {Sample} from "@opendaw/studio-adapters"
 
+/**
+ * Events broadcast by {@link StudioService} to update various UI elements.
+ *
+ * ```mermaid
+ * classDiagram
+ *   class StudioSignal
+ *   StudioSignal <|-- reset-peaks
+ *   StudioSignal <|-- import-sample
+ *   StudioSignal <|-- delete-project
+ * ```
+ */
 export type StudioSignal =
     | {
     type: "reset-peaks"

--- a/packages/app/studio/src/service/SyncLogService.ts
+++ b/packages/app/studio/src/service/SyncLogService.ts
@@ -5,6 +5,15 @@ import {Promises} from "@opendaw/lib-runtime"
 import {StudioService} from "@/service/StudioService"
 import {Commit, SyncLogReader, SyncLogWriter} from "@opendaw/studio-core"
 
+/**
+ * Service helpers for writing and appending project SyncLog files.
+ *
+ * ```mermaid
+ * flowchart LR
+ *   A[start] -->|start| B[New SyncLog]
+ *   A2[existing] -->|append| B
+ * ```
+ */
 export namespace SyncLogService {
     export const start = async (service: StudioService) => {
         if (!isDefined(window.showSaveFilePicker)) {return}

--- a/packages/app/studio/src/service/app-menu.ts
+++ b/packages/app/studio/src/service/app-menu.ts
@@ -8,6 +8,16 @@ import {AudioDevices} from "@opendaw/studio-core"
 import {SyncLogService} from "@/service/SyncLogService"
 import {IconSymbol} from "@opendaw/studio-adapters"
 
+/**
+ * Builds the dynamic application menu and wires entries to the
+ * {@link StudioService}.
+ *
+ * ```mermaid
+ * graph TD
+ *   A[Menu] --> B[File]
+ *   A --> C[Debug]
+ * ```
+ */
 export const initAppMenu = (service: StudioService) => {
     return MenuItem.root()
         .setRuntimeChildrenProcedure(parent => {

--- a/packages/docs/docs-dev/services/overview.md
+++ b/packages/docs/docs-dev/services/overview.md
@@ -1,0 +1,11 @@
+# Service Layer Overview
+
+The studio app exposes several services to coordinate complex tasks.
+
+```mermaid
+flowchart LR
+  StudioService --> SessionService
+  StudioService --> Shortcuts
+  StudioService --> SyncLogService
+  StudioService --> ExportStemsConfigurator
+```

--- a/packages/docs/docs-dev/services/sessions.md
+++ b/packages/docs/docs-dev/services/sessions.md
@@ -1,0 +1,8 @@
+# Session Service
+
+Manages the current project session including saving, loading and templates.
+
+```mermaid
+flowchart LR
+  User --> SessionService --> ProjectSession
+```

--- a/packages/docs/docs-dev/services/shortcuts.md
+++ b/packages/docs/docs-dev/services/shortcuts.md
@@ -1,0 +1,12 @@
+# Shortcuts Service
+
+Global key bindings translate user input into Studio actions.
+
+```mermaid
+sequenceDiagram
+  participant K as Keyboard
+  participant S as Shortcuts
+  participant SS as StudioService
+  K->>S: keydown
+  S->>SS: invoke
+```

--- a/packages/docs/docs-dev/services/stems.md
+++ b/packages/docs/docs-dev/services/stems.md
@@ -1,0 +1,10 @@
+# Stems Configurator
+
+UI component used when exporting individual track stems.
+
+```mermaid
+flowchart LR
+  includeAll --> Track
+  includeAudioEffectsAll --> Track
+  includeSendsAll --> Track
+```

--- a/packages/docs/docs-dev/services/sync.md
+++ b/packages/docs/docs-dev/services/sync.md
@@ -1,0 +1,9 @@
+# SyncLog Service
+
+Records project changes to a SyncLog file for auditing or collaboration.
+
+```mermaid
+flowchart TD
+  start --> write --> file
+  file --> append
+```

--- a/packages/docs/docs-user/workflows/exporting-and-sharing.md
+++ b/packages/docs/docs-user/workflows/exporting-and-sharing.md
@@ -1,0 +1,21 @@
+# Exporting and Sharing Workflow
+
+Share your music outside of openDAW by rendering audio or packaging the project.
+
+```mermaid
+flowchart TD
+    A[Finalize mix] --> B[Open export dialog]
+    B --> C{Choose type}
+    C --> D[Set range & quality]
+    D --> E[Start export]
+    E --> F[Download or share]
+```
+
+1. **Finalize your mix.** Balance tracks and stop playback where you want the export to end.
+2. **Open the export dialog.** From the main menu choose _File → Export_.
+3. **Pick an option.** Select _Audio Mixdown_ to render a WAV/MP3, _Stems_ for individual tracks, or _Project Bundle_ to create an `.odb` file.
+4. **Set the range and quality.** Export the entire song or define markers, then choose sample rate and format.
+5. **Start the export.** Click _Export_ and wait for processing to complete.
+6. **Download or share.** Save the resulting file to your computer or send the bundle to a collaborator.
+
+Use this workflow whenever you need to back up a project or deliver a finished track. For collaboration tips see the [Collaboration workflow](collaboration.md). For technical details on stem export see the [Stems Configurator](../../docs-dev/services/stems.md).

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -70,5 +70,16 @@ module.exports = {
         { type: "doc", id: "boxes/faq" },
       ],
     },
+    {
+      type: "category",
+      label: "Services",
+      items: [
+        "services/overview",
+        "services/sessions",
+        "services/shortcuts",
+        "services/sync",
+        "services/stems",
+      ],
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- add TSDoc comments with mermaid diagrams for studio service modules
- document session, shortcut, sync, and stem services
- add exporting and sharing workflow page linking to stem configurator

## Testing
- `npm test` (fails: TS configuration missing)
- `npm run lint` (fails: run failed)


------
https://chatgpt.com/codex/tasks/task_b_68aeabdb636c8321aa97b91135540a93