### PR TITLE
docs: document device editors and panel workflow

### DIFF
--- a/packages/app/studio/src/ui/devices/AudioBusEditor.sass
+++ b/packages/app/studio/src/ui/devices/AudioBusEditor.sass
@@ -1,3 +1,4 @@
+// Layout styling for the minimal audio bus editor.
 component
   height: 100%
   display: flex

--- a/packages/app/studio/src/ui/devices/AudioBusEditor.tsx
+++ b/packages/app/studio/src/ui/devices/AudioBusEditor.tsx
@@ -1,3 +1,9 @@
+/**
+ * UI wrapper for audio bus devices.
+ *
+ * Utilises the generic DeviceEditor while showing a peak meter for the bus
+ * output and exposing the input routing menu.
+ */
 import css from "./AudioBusEditor.sass?inline"
 import {Lifecycle} from "@opendaw/lib-std"
 import {createElement} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/devices/DeviceEditor.sass
+++ b/packages/app/studio/src/ui/devices/DeviceEditor.sass
@@ -1,3 +1,4 @@
+// Styles for the generic device editor wrapper, including header and content grid.
 @use "@/mixins"
 @use "@/colors"
 

--- a/packages/app/studio/src/ui/devices/DeviceEditor.tsx
+++ b/packages/app/studio/src/ui/devices/DeviceEditor.tsx
@@ -1,3 +1,9 @@
+/**
+ * Provides a generic wrapper around device editors.
+ *
+ * The component renders a device header, delegates menu and control creation,
+ * and wires up drag-and-drop reordering for effect devices.
+ */
 import css from "./DeviceEditor.sass?inline"
 import {Lifecycle, ObservableValue, Procedure, Provider} from "@opendaw/lib-std"
 import {createElement, Group, JsxValue} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/devices/DeviceEditorFactory.tsx
+++ b/packages/app/studio/src/ui/devices/DeviceEditorFactory.tsx
@@ -1,3 +1,9 @@
+/**
+ * Maps device boxes to their respective editor components.
+ *
+ * The factory hides the visitor pattern used by boxes and allows callers to
+ * obtain the correct editor for midi, instrument, or audio effects.
+ */
 import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {
     ArpeggioDeviceBox,

--- a/packages/app/studio/src/ui/devices/DevicePanelDragAndDrop.ts
+++ b/packages/app/studio/src/ui/devices/DevicePanelDragAndDrop.ts
@@ -1,3 +1,9 @@
+/**
+ * Drag-and-drop helpers for the device panel.
+ *
+ * This module manages inserting, reordering and swapping devices when the user
+ * drags elements within the panel.
+ */
 import {asDefined, panic, Terminable} from "@opendaw/lib-std"
 import {DragAndDrop} from "@/ui/DragAndDrop"
 import {AnyDragData} from "@/ui/AnyDragData"

--- a/packages/app/studio/src/ui/devices/ParameterLabelKnob.sass
+++ b/packages/app/studio/src/ui/devices/ParameterLabelKnob.sass
@@ -1,2 +1,3 @@
+// Minimal container for a parameter knob with label.
 component
   display: contents

--- a/packages/app/studio/src/ui/devices/ParameterLabelKnob.tsx
+++ b/packages/app/studio/src/ui/devices/ParameterLabelKnob.tsx
@@ -1,3 +1,9 @@
+/**
+ * Combines a labelled knob with automation and MIDI learn support.
+ *
+ * The component wraps the generic LabelKnob and adds relative dragging as well
+ * as parameter context menus.
+ */
 import css from "./ParameterLabelKnob.sass?inline"
 import {Lifecycle, unitValue, ValueGuide} from "@opendaw/lib-std"
 import {createElement} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/devices/README.md
+++ b/packages/app/studio/src/ui/devices/README.md
@@ -1,0 +1,15 @@
+## Device UI Module
+
+Components in this folder provide the user interface for editing devices in
+openDAW. The module contains:
+
+- **DeviceEditor** – generic wrapper used by individual device editors.
+- **DevicePanel** – container that displays the currently selected device
+  chain and enables drag‑and‑drop reordering.
+- **ParameterLabelKnob**, **SampleSelector** and various helpers used across
+  instrument and effect editors.
+
+These pieces work together to offer a consistent experience for all device
+types, allowing developers to compose new editors by reusing the building
+blocks found here.
+

--- a/packages/app/studio/src/ui/devices/SampleSelector.ts
+++ b/packages/app/studio/src/ui/devices/SampleSelector.ts
@@ -1,3 +1,9 @@
+/**
+ * Handles selecting and importing audio samples for devices.
+ *
+ * The selector coordinates drag-and-drop, browsing dialogs and pointer field
+ * updates so that devices can reference new or existing samples.
+ */
 import {AudioFileBox} from "@opendaw/studio-boxes"
 import {isDefined, Option, Terminable, UUID} from "@opendaw/lib-std"
 import {showProcessMonolog} from "@/ui/components/dialogs"

--- a/packages/app/studio/src/ui/devices/menu-items.ts
+++ b/packages/app/studio/src/ui/devices/menu-items.ts
@@ -1,3 +1,9 @@
+/**
+ * Helper functions to build context menus for devices.
+ *
+ * The namespace exposes menu item builders used throughout device editors and
+ * the panel for actions such as renaming, adding or moving effects.
+ */
 import {DeviceHost, Devices, EffectDeviceBoxAdapter} from "@opendaw/studio-adapters"
 import {MenuItem} from "@/ui/model/menu-item.ts"
 import {Editing, PrimitiveField, PrimitiveValues, StringField} from "@opendaw/lib-box"
@@ -151,3 +157,4 @@ export namespace MenuItems {
                 }
             )
 }
+

--- a/packages/app/studio/src/ui/devices/panel/DevicePanel.sass
+++ b/packages/app/studio/src/ui/devices/panel/DevicePanel.sass
@@ -1,3 +1,4 @@
+// Styling for the device panel hosting editors and channel strip.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
@@ -1,3 +1,9 @@
+/**
+ * Visual container displaying the currently edited device chain.
+ *
+ * The panel hosts individual device editors, meters and the channel strip
+ * while supporting scrolling and drag-and-drop reordering of devices.
+ */
 import css from "./DevicePanel.sass?inline"
 import {asDefined, Lifecycle, ObservableValue, Option, Terminable, Terminator, UUID} from "@opendaw/lib-std"
 import {appendChildren, createElement} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.sass
+++ b/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.sass
@@ -1,3 +1,4 @@
+// Presentation for the small peak meter shown in device headers.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
@@ -1,3 +1,9 @@
+/**
+ * Simple peak level meter used inside device editors.
+ *
+ * Subscribes to the live audio stream and renders SVG bars representing peak
+ * values for the addressed bus or channel.
+ */
 import css from "./DevicePeakMeter.sass?inline"
 import {Arrays, int, Lifecycle, Terminator, ValueMapping} from "@opendaw/lib-std"
 import {createElement} from "@opendaw/lib-jsx"

--- a/packages/docs/docs-dev/ui/devices/effects.md
+++ b/packages/docs/docs-dev/ui/devices/effects.md
@@ -1,0 +1,9 @@
+## Effect editors
+
+Effect devices share a common set of context menu items for enabling,
+reordering and inserting new effects. The `MenuItems` helpers provide these
+actions and are used by every effect editor.
+
+Each specific effect (delay, reverb, etc.) implements its own set of controls
+while being wrapped by `DeviceEditor` to obtain the standard header and meter.
+

--- a/packages/docs/docs-dev/ui/devices/faq.md
+++ b/packages/docs/docs-dev/ui/devices/faq.md
@@ -1,0 +1,12 @@
+## Device UI FAQ
+
+### Why does my effect not appear in the panel?
+
+Ensure the device is wrapped by `DeviceEditor` and that the host adds the
+adapter to the correct effect collection so the panel can mount it.
+
+### How do I add custom menu actions?
+
+Extend the `MenuItems` helpers or provide a `populateMenu` callback when using
+`DeviceEditor` to append additional `MenuItem` entries.
+

--- a/packages/docs/docs-dev/ui/devices/instruments.md
+++ b/packages/docs/docs-dev/ui/devices/instruments.md
@@ -1,0 +1,9 @@
+## Instrument editors
+
+Instrument editors often expose sample selection and parameter knobs. Utilities
+such as `SampleSelector` and `ParameterLabelKnob` are reused across many
+instruments to provide consistent behaviour and MIDI learn integration.
+
+Like effects, instrument editors are hosted inside `DeviceEditor` so they share
+the same header, menu structure and metering.
+

--- a/packages/docs/docs-dev/ui/devices/overview.md
+++ b/packages/docs/docs-dev/ui/devices/overview.md
@@ -1,0 +1,11 @@
+## Device editing overview
+
+The device UI exposes editors for instruments, audio effects and utility
+modules. Each editor is built on top of a common `DeviceEditor` wrapper and is
+hosted inside the device panel. This document provides pointers to the
+specialised topics below.
+
+* [Device panel](./panel.md) – how editors are mounted and reordered.
+* [Effects](./effects.md) – implementation details for audio and midi effects.
+* [Instruments](./instruments.md) – instrument specific editors and helpers.
+

--- a/packages/docs/docs-dev/ui/devices/panel.md
+++ b/packages/docs/docs-dev/ui/devices/panel.md
@@ -1,0 +1,10 @@
+## Device panel
+
+The panel displays the device chain of the currently selected track or bus.
+Editors are mounted in three sections: MIDI effects, instrument, and audio
+effects. Users can reorder devices via drag and drop; the `DevicePanelDragAndDrop`
+module coordinates the movement and creation of devices.
+
+The panel also embeds a compact channel strip and meters so that the user can
+monitor levels while editing devices.
+


### PR DESCRIPTION
## Summary
- annotate device editor components and utilities
- add module overview for device UI
- document device panel workflow in developer docs

## Testing
- `npm test` *(fails: Private identifiers are only available when targeting ECMAScript 2015 and higher)*
- `npm run lint` *(fails: run failed: command  exited (1))*

------
https://chatgpt.com/codex/tasks/task_b_68aeabcfdbac8321ab3f66fef621b130