### PR TITLE
docs: document timeline clips and regions

### DIFF
--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -8,3 +8,7 @@ For a guided overview of the interface, see the [UI tour](../../docs/docs-user/u
 
 ![Component hierarchy](../../../assets/ui/component-hierarchy.svg)
 Developers can extend the Studio with custom devices and user interfaces. Learn how to build and test plugins in the [developer docs](../../docs/docs-dev/extending/plugin-guide.md).
+
+For implementation details on the timeline, see the developer docs for
+[clips](../../docs/docs-dev/ui/timeline/clips.md) and
+[regions](../../docs/docs-dev/ui/timeline/regions.md).

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/Clip.sass
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/Clip.sass
@@ -1,3 +1,4 @@
+// Styles for the Clip component displayed in the timeline.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/Clip.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/Clip.tsx
@@ -20,16 +20,31 @@ import {Project} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "Clip")
 
+/**
+ * Construction parameters for {@link Clip}.
+ */
 type Construct = {
+    /** Studio level services providing engine access. */
     service: StudioService
+    /** Lifecycle used to manage subscriptions. */
     lifecycle: Lifecycle
+    /** The current project instance. */
     project: Project
+    /** Adapter describing the clip to render. */
     adapter: AnyClipBoxAdapter
+    /** CSS grid column where the clip should be placed. */
     gridColumn: string
 }
 
+/**
+ * Playback state of a clip.
+ */
 export enum ClipState {Idle, Waiting, Playing}
 
+/**
+ * Renders a timeline clip and keeps its visual state in sync with playback
+ * notifications and selection changes.
+ */
 export const Clip = ({lifecycle, service, project, adapter, gridColumn}: Construct) => {
     const canvas: HTMLCanvasElement = (<canvas/>)
     const progress: HTMLElement = (<div className="progress"/>)

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipCapturing.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipCapturing.ts
@@ -6,11 +6,19 @@ import {ClipWidth} from "@/ui/timeline/tracks/audio-unit/clips/constants.ts"
 import {TrackContext} from "@/ui/timeline/tracks/audio-unit/TrackContext.ts"
 import {ExtraSpace} from "@/ui/timeline/tracks/audio-unit/Constants"
 
+/**
+ * Result returned by {@link ClipCapturing} indicating the clip or track
+ * located at the given coordinates.
+ */
 export type ClipCaptureTarget =
     | { type: "clip", clip: AnyClipBoxAdapter }
     | { type: "track", track: TrackContext, clipIndex: int }
 
 export namespace ClipCapturing {
+    /**
+     * Creates an {@link ElementCapturing} instance that resolves timeline clips
+     * and tracks based on pointer coordinates.
+     */
     export const create = (element: Element, manager: TracksManager) =>
         new ElementCapturing<ClipCaptureTarget>(element, {
             capture: (x: number, y: number): Nullable<ClipCaptureTarget> => {

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipContextMenu.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipContextMenu.ts
@@ -12,13 +12,24 @@ import {AudioRegionBox, NoteRegionBox, ValueRegionBox} from "@opendaw/studio-box
 import {ColorMenu} from "@/ui/timeline/ColorMenu"
 import {Project} from "@opendaw/studio-core"
 
+/**
+ * Parameters required to install the clip context menu.
+ */
 type Creation = {
+    /** Element that receives the context menu. */
     element: HTMLElement
+    /** Current project to apply mutations to. */
     project: Project
+    /** Helper used to resolve what clip or track is under the cursor. */
     capturing: ElementCapturing<ClipCaptureTarget>
+    /** Selection containing currently highlighted clips. */
     selection: Selection<AnyClipBoxAdapter>
 }
 
+/**
+ * Installs a context menu for timeline clips handling edit actions such as
+ * rename, delete or color adjustments.
+ */
 export const installClipContextMenu = ({element, project, selection, capturing}: Creation) =>
     ContextMenu.subscribe(element, collector => {
         const client = collector.client

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipLane.sass
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipLane.sass
@@ -1,3 +1,4 @@
+// Styles for the clip lane hosting multiple clip placeholders.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipLane.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipLane.tsx
@@ -21,19 +21,32 @@ import {deferNextFrame, Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "ClipLane")
 
+/**
+ * Placeholder cell that hosts a clip instance.
+ */
 type Cell = {
     readonly terminator: Terminator
     readonly placeholder: HTMLElement
     readonly adapter: MutableObservableValue<Nullable<AnyClipBoxAdapter>>
 }
 
+/**
+ * Construction options for {@link ClipLane}.
+ */
 type Construct = {
+    /** Lifecycle of the lane. */
     lifecycle: Lifecycle
+    /** Studio service for editing operations. */
     service: StudioService
+    /** Track manager providing track lookups. */
     trackManager: TracksManager
+    /** Adapter of the track represented by this lane. */
     adapter: TrackBoxAdapter
 }
 
+/**
+ * Displays clips for a single track by managing a pool of placeholder cells.
+ */
 export const ClipLane = ({lifecycle, service, trackManager, adapter}: Construct) => {
     const placeholderContainer: HTMLElement = <Group/>
     const container: HTMLElement = (<div className={className}>{placeholderContainer}</div>)

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipModifyStrategy.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipModifyStrategy.ts
@@ -1,13 +1,20 @@
 import {AnyClipBoxAdapter} from "@opendaw/studio-adapters"
 import {int} from "@opendaw/lib-std"
 
+/**
+ * Bundles strategies to visualize and transform clips during editing.
+ */
 export interface ClipModifyStrategies {
+    /** Whether the original clips should remain visible. */
     showOrigin(): boolean
+    /** Strategy applied to selected clips. */
     selectedModifyStrategy(): ClipModifyStrategy
+    /** Strategy applied to unselected clips. */
     unselectedModifyStrategy(): ClipModifyStrategy
 }
 
 export namespace ClipModifyStrategies {
+    /** Identity strategy performing no modifications. */
     export const Identity: ClipModifyStrategies = Object.freeze({
         showOrigin: (): boolean => false,
         selectedModifyStrategy: (): ClipModifyStrategy => ClipModifyStrategy.Identity,
@@ -15,13 +22,23 @@ export namespace ClipModifyStrategies {
     })
 }
 
+/**
+ * Describes how a clip should be read or transformed for temporary preview.
+ */
 export interface ClipModifyStrategy {
+    /** Returns the index where the clip should appear. */
     readClipIndex(clip: AnyClipBoxAdapter): int
+    /** Whether the clip should be rendered mirrored. */
     readMirror(clip: AnyClipBoxAdapter): boolean
+    /**
+     * Translates the track index used to look up clips. It allows previews
+     * to show clips on different tracks than the original ones.
+     */
     translateTrackIndex(index: int): int
 }
 
 export namespace ClipModifyStrategy {
+    /** Identity strategy leaving clips untouched. */
     export const Identity: ClipModifyStrategy = Object.freeze({
         readClipIndex: (clip: AnyClipBoxAdapter): number => clip.indexField.getValue(),
         readMirror: (clip: AnyClipBoxAdapter): boolean => clip.canMirror && clip.isMirrowed,

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipPlaybackButton.sass
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipPlaybackButton.sass
@@ -1,3 +1,4 @@
+// Styles for the clip playback button overlay.
 component
   pointer-events: all
   opacity: 0

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipPlaybackButton.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipPlaybackButton.tsx
@@ -10,13 +10,23 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "ClipPlaybackButton")
 
+/**
+ * Construction options for {@link ClipPlaybackButton}.
+ */
 type Construct = {
+    /** Lifecycle controlling subscriptions. */
     lifecycle: Lifecycle
+    /** Studio service used to schedule playback. */
     service: StudioService
+    /** Clip associated with the button. */
     adapter: AnyClipBoxAdapter
+    /** Observable state of the clip. */
     state: DefaultObservableValue<ClipState>
 }
 
+/**
+ * Small play/stop button rendered on top of a clip.
+ */
 export const ClipPlaybackButton = ({lifecycle, service, adapter, state}: Construct) => {
     const iconModel = new DefaultObservableValue(IconSymbol.Play)
     const element: HTMLElement = (

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsArea.sass
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsArea.sass
@@ -1,3 +1,4 @@
+// Container styles for the timeline clips area.
 component
   grid-row: 1 / -1
   grid-column: 2 / calc(var(--clips-count) + 2)

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsArea.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/clips/ClipsArea.tsx
@@ -23,14 +23,26 @@ import {showProcessMonolog} from "@/ui/components/dialogs"
 
 const className = Html.adoptStyleSheet(css, "ClipsArea")
 
+/**
+ * Construction options for {@link ClipsArea}.
+ */
 type Construct = {
+    /** Lifecycle for the area. */
     lifecycle: Lifecycle
+    /** Access to project services. */
     service: StudioService
+    /** Manager providing track information. */
     manager: TracksManager
+    /** Scroll model synced with the timeline. */
     scrollModel: ScrollModel
+    /** Scroll container element. */
     scrollContainer: HTMLElement
 }
 
+/**
+ * Top level container hosting clip lanes and managing selection,
+ * dragging and context menus for clips.
+ */
 export const ClipsArea = ({lifecycle, service, manager, scrollModel, scrollContainer}: Construct) => {
     const {project} = service
     const {selection, boxAdapters, editing, userEditingManager} = project

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionContextMenu.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionContextMenu.ts
@@ -17,15 +17,28 @@ import {Browser} from "@opendaw/lib-dom"
 import {showInfoDialog} from "@/ui/components/dialogs.tsx"
 import {StudioService} from "@/service/StudioService"
 
+/**
+ * Parameters required to install the region context menu.
+ */
 type Construct = {
+    /** Element to attach the menu to. */
     element: Element
+    /** Studio service providing project access. */
     service: StudioService
+    /** Capturing helper resolving the region under the cursor. */
     capturing: ElementCapturing<RegionCaptureTarget>
+    /** Region selection used for menu actions. */
     selection: Selection<AnyRegionBoxAdapter>
+    /** Timeline box for loop/zoom operations. */
     timelineBox: TimelineBox
+    /** Range controlling the visible portion of the timeline. */
     range: TimelineRange
 }
 
+/**
+ * Installs the context menu for timeline regions, enabling rename,
+ * color, conversion and other region related actions.
+ */
 export const installRegionContextMenu =
     ({element, service, capturing, selection, timelineBox, range}: Construct): Terminable => {
         const {project} = service

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionLane.sass
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionLane.sass
@@ -1,3 +1,4 @@
+// Styles for the region lane canvas renderer.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionLane.tsx
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionLane.tsx
@@ -11,13 +11,23 @@ import {TrackType} from "@opendaw/studio-adapters"
 
 const className = Html.adoptStyleSheet(css, "RegionLane")
 
+/**
+ * Construction parameters for {@link RegionLane}.
+ */
 type Construct = {
+    /** Lifecycle managing subscriptions. */
     lifecycle: Lifecycle
+    /** Track manager used to resolve region data. */
     trackManager: TracksManager
+    /** Visible range of the timeline. */
     range: TimelineRange
+    /** Adapter of the track whose regions are rendered. */
     adapter: TrackBoxAdapter
 }
 
+/**
+ * Displays region previews for a single track using a canvas renderer.
+ */
 export const RegionLane = ({lifecycle, trackManager, range, adapter}: Construct) => {
     if (adapter.type === TrackType.Undefined) {
         return <div className={Html.buildClassList(className, "deactive")}/>

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionMoveModifier.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionMoveModifier.ts
@@ -45,15 +45,29 @@ class UnselectedStrategy implements RegionModifyStrategy {
     }
 }
 
+/**
+ * Construction data used when starting a region move operation.
+ */
 type Construct = Readonly<{
+    /** Element representing the timeline area. */
     element: Element
+    /** Snapping configuration for movement. */
     snapping: Snapping
+    /** Pulse position where the drag started. */
     pointerPulse: ppqn
+    /** Track index where the drag started. */
     pointerIndex: int
+    /** Region under the pointer when the drag started. */
     reference: AnyRegionBoxAdapter
 }>
 
+/**
+ * Handles moving (and optionally copying) of regions across the timeline.
+ */
 export class RegionMoveModifier implements RegionModifyStrategies {
+    /**
+     * Creates a move modifier when a selection exists.
+     */
     static create(trackManager: TracksManager, selection: Selection<AnyRegionBoxAdapter>, construct: Construct): Option<RegionMoveModifier> {
         return selection.isEmpty()
             ? Option.None

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionRenderer.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionRenderer.ts
@@ -13,6 +13,11 @@ import {renderValueStream} from "@/ui/timeline/renderer/value.ts"
 import {TimelineRange} from "@/ui/timeline/TimelineRange.ts"
 import {Context2d} from "@opendaw/lib-dom"
 
+/**
+ * Renders the regions of a given track into a canvas context.
+ * It respects the provided range and modification strategies from the
+ * {@link TracksManager}.
+ */
 export const renderRegions = (context: CanvasRenderingContext2D,
                               tracks: TracksManager,
                               range: TimelineRange,

--- a/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionTransformer.ts
+++ b/packages/app/studio/src/ui/timeline/tracks/audio-unit/regions/RegionTransformer.ts
@@ -7,6 +7,10 @@ import {asDefined, UUID} from "@opendaw/lib-std"
 import {AnyClipBox} from "@opendaw/studio-adapters"
 
 export namespace RegionTransformer {
+    /**
+     * Converts a region into a standalone clip. Optionally copies associated
+     * event collections instead of reusing the original ones.
+     */
     export const toClip = (region: AnyRegionBoxAdapter, copyEvents: boolean = true): AnyClipBox => {
         const trackBoxAdapter = region.trackBoxAdapter.unwrap()
         const index = trackBoxAdapter.clips.collection.getMinFreeIndex()

--- a/packages/docs/docs-dev/ui/timeline/clips.md
+++ b/packages/docs/docs-dev/ui/timeline/clips.md
@@ -1,0 +1,16 @@
+# Timeline Clips
+
+The clip components render and control individual clip instances on the timeline.
+
+```mermaid
+flowchart LR
+  ClipsArea --> ClipLane
+  ClipLane --> Clip
+  Clip --> ClipPlaybackButton
+```
+
+- **ClipsArea** manages selection, drag and drop and context menus for clips.
+- **ClipLane** hosts placeholder cells for a track's clips.
+- **Clip** paints the clip preview and tracks playback state.
+- **ClipPlaybackButton** provides a play/stop overlay on the clip.
+

--- a/packages/docs/docs-dev/ui/timeline/regions.md
+++ b/packages/docs/docs-dev/ui/timeline/regions.md
@@ -1,0 +1,18 @@
+# Timeline Regions
+
+Regions are drawn on a canvas and support rich editing operations.
+
+```mermaid
+flowchart LR
+  RegionsArea --> RegionLane
+  RegionLane --> RegionRenderer
+  RegionLane --> RegionContextMenu
+  RegionMoveModifier -.-> RegionLane
+```
+
+- **RegionsArea** contains the region lanes for each track.
+- **RegionLane** renders a track's regions and handles visibility.
+- **RegionRenderer** draws the region content on the canvas.
+- **RegionContextMenu** exposes actions such as rename or convert.
+- **RegionMoveModifier** updates previews while regions are moved.
+


### PR DESCRIPTION
## Summary
- add TSDoc comments to timeline clip components and modifiers
- add developer docs for timeline clips and regions with diagrams
- link new docs from Studio README

## Testing
- `npm test` *(fails: Could not find name 'PermissionState')*

------
https://chatgpt.com/codex/tasks/task_b_68aeabd207b48321ba8f0ab5d7dba34f