### PR TITLE
docs: document mixer components

### DIFF
--- a/packages/app/studio/src/ui/devices/panel/DevicePanel.sass
+++ b/packages/app/studio/src/ui/devices/panel/DevicePanel.sass
@@ -1,5 +1,6 @@
 @use "@/colors"
 
+// Styles for the device editing panel and its scrollable containers.
 component
   width: 100%
   height: 15rem

--- a/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
@@ -35,6 +35,9 @@ type Construct = {
 
 type Context = { deviceHost: DeviceHost, instrument: ObservableValue<Option<AudioUnitInputAdapter>> }
 
+/**
+ * Hosts device editors and the channel strip for the currently selected track.
+ */
 export const DevicePanel = ({lifecycle, service}: Construct) => {
     const midiEffectsContainer: HTMLElement = <div className="midi-container"/>
     const instrumentContainer: HTMLElement = <div className="source-container"/>

--- a/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.sass
+++ b/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.sass
@@ -1,5 +1,6 @@
 @use "@/colors"
 
+// Styling for the small peak meter inside the device panel.
 component
   display: flex
   justify-content: center

--- a/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
@@ -15,6 +15,9 @@ type Construct = {
     address: Address
 }
 
+/**
+ * Compact peak meter used inside the device panel to visualize output levels.
+ */
 export const DevicePeakMeter = ({lifecycle, receiver, address}: Construct) => {
     const element: HTMLDivElement = (<div className={className}/>)
     const peaks = new Float32Array(2)

--- a/packages/app/studio/src/ui/mixer/AudioOutputDevices.sass
+++ b/packages/app/studio/src/ui/mixer/AudioOutputDevices.sass
@@ -1,3 +1,4 @@
+// Layout for the selectable list of audio output devices.
 component
   padding: 1em 0
   display: flex

--- a/packages/app/studio/src/ui/mixer/AudioOutputDevices.tsx
+++ b/packages/app/studio/src/ui/mixer/AudioOutputDevices.tsx
@@ -12,6 +12,9 @@ type Construct = {
     provider: Procedure<MediaDeviceInfo>
 }
 
+/**
+ * Lists available audio output devices and lets the user choose one.
+ */
 export const AudioOutputDevices = ({output, provider}: Construct) => {
     return (
         <div className={className} style={{padding: "1em 0"}}>

--- a/packages/app/studio/src/ui/mixer/AudioOutputSelector.tsx
+++ b/packages/app/studio/src/ui/mixer/AudioOutputSelector.tsx
@@ -18,6 +18,9 @@ type Construct = {
     output: AudioOutputDevice
 }
 
+/**
+ * Selector used to choose the browser's audio output device if supported.
+ */
 export const AudioOutputSelector = ({lifecycle, output}: Construct) => {
     if (!output.switchable) {
         return (

--- a/packages/app/studio/src/ui/mixer/AuxSend.sass
+++ b/packages/app/studio/src/ui/mixer/AuxSend.sass
@@ -1,3 +1,4 @@
+// Styling for an individual auxiliary send row.
 component
   width: 100%
   height: 2em

--- a/packages/app/studio/src/ui/mixer/AuxSend.tsx
+++ b/packages/app/studio/src/ui/mixer/AuxSend.tsx
@@ -20,6 +20,9 @@ type Construct = {
     adapter: AuxSendBoxAdapter
 }
 
+/**
+ * Control representing a single auxiliary send with pan and gain knobs.
+ */
 export const AuxSend = ({lifecycle, editing, adapter}: Construct) => {
     const tooltip = Inject.attribute(adapter.targetBus.labelField.getValue())
     lifecycle.own(adapter.targetBus.labelField.subscribe(owner => tooltip.value = owner.getValue()))

--- a/packages/app/studio/src/ui/mixer/AuxSendGroup.sass
+++ b/packages/app/studio/src/ui/mixer/AuxSendGroup.sass
@@ -1,3 +1,4 @@
+// Container for all auxiliary sends within a channel strip.
 component
   display: grid
   width: 64px

--- a/packages/app/studio/src/ui/mixer/AuxSendGroup.tsx
+++ b/packages/app/studio/src/ui/mixer/AuxSendGroup.tsx
@@ -26,6 +26,9 @@ type Construct = {
     audioUnitAdapter: AudioUnitBoxAdapter
 }
 
+/**
+ * Renders and manages all auxiliary sends for a given audio unit.
+ */
 export const AuxSendGroup = ({lifecycle, project, audioUnitAdapter}: Construct) => {
     const canHaveAuxSends = !audioUnitAdapter.isOutput
     const groupElement: HTMLDivElement = <div className={className}/>

--- a/packages/app/studio/src/ui/mixer/ChannelOutputSelector.tsx
+++ b/packages/app/studio/src/ui/mixer/ChannelOutputSelector.tsx
@@ -18,6 +18,9 @@ type Construct = {
     adapter: AudioUnitBoxAdapter
 }
 
+/**
+ * Dropdown menu for selecting the output bus of a channel strip.
+ */
 export const ChannelOutputSelector = ({lifecycle, project, adapter}: Construct) => {
     const label: HTMLElement = (<div className="label"/>)
     const symbol = lifecycle.own(new DefaultObservableValue(IconSymbol.NoAudio))

--- a/packages/app/studio/src/ui/mixer/ChannelStrip.sass
+++ b/packages/app/studio/src/ui/mixer/ChannelStrip.sass
@@ -1,6 +1,7 @@
 @use "@/mixins"
 @use "@/colors"
 
+// Styles for an individual channel strip in the mixer.
 component
   min-width: 74px
   max-width: 74px

--- a/packages/app/studio/src/ui/mixer/ChannelStrip.tsx
+++ b/packages/app/studio/src/ui/mixer/ChannelStrip.tsx
@@ -36,6 +36,9 @@ type Construct = {
     compact: boolean
 }
 
+/**
+ * Displays controls for a single track or bus including meters, sends and routing.
+ */
 export const ChannelStrip = ({lifecycle, service, adapter, compact}: Construct) => {
     const {mute, panning, solo, volume} = adapter.namedParameter
     const {project, midiLearning} = service

--- a/packages/app/studio/src/ui/mixer/Mixer.sass
+++ b/packages/app/studio/src/ui/mixer/Mixer.sass
@@ -1,5 +1,6 @@
 @use "@/colors"
 
+// Layout and styling for the mixer view and channel strip container.
 component
   flex: 1 0 0
   width: 100%

--- a/packages/app/studio/src/ui/mixer/Mixer.tsx
+++ b/packages/app/studio/src/ui/mixer/Mixer.tsx
@@ -26,6 +26,10 @@ type Construct = {
     service: StudioService
 }
 
+/**
+ * Renders the main mixer view with channel strips for each audio unit.
+ * Handles scrolling, ordering and selection of channels.
+ */
 export const Mixer = ({lifecycle, service}: Construct) => {
     const project = service.project
     const headers: HTMLElement = (

--- a/packages/docs/docs-dev/ui/mixer.md
+++ b/packages/docs/docs-dev/ui/mixer.md
@@ -1,0 +1,26 @@
+# Mixer UI
+
+Developer overview of mixer-related components.
+
+## Components
+
+- `Mixer` – container that lays out channel strips and manages scrolling.
+- `ChannelStrip` – represents a track or bus with controls for level, pan and routing.
+- `AuxSend` and `AuxSendGroup` – provide send levels to auxiliary busses.
+- `ChannelOutputSelector` and `AudioOutputSelector` – choose output busses or hardware devices.
+- `AudioOutputDevices` – lists available hardware devices for selection.
+- `DevicePanel` and `DevicePeakMeter` – host editors and metering for selected devices.
+
+### Routing diagram
+
+```mermaid
+graph LR
+    Mixer --> ChannelStrip
+    ChannelStrip --> AuxSendGroup
+    AuxSendGroup --> AuxSend
+    ChannelStrip --> ChannelOutputSelector
+    ChannelStrip --> AudioOutputSelector
+    ChannelOutputSelector -->|bus| Master
+```
+
+This structure allows the mixer to manage complex routing between tracks, busses and external devices while keeping components isolated.

--- a/packages/docs/docs-user/features/mixer.md
+++ b/packages/docs/docs-user/features/mixer.md
@@ -35,4 +35,15 @@ You can group tracks together by routing them through a bus:
 This setup lets you process and control multiple tracks as one while preserving
 individual sends and automation.
 
+### Signal routing diagram
+
+```mermaid
+graph LR
+    T1[Track 1] --> B[Drum Bus]
+    T2[Track 2] --> B
+    B --> M[Master]
+    T1 -- Send --> R[Reverb]
+    R --> M
+```
+
 For a practical example see the [Mixing workflow](../workflows/mixing.md).

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -70,5 +70,10 @@ module.exports = {
         { type: "doc", id: "boxes/faq" },
       ],
     },
+    {
+      type: "category",
+      label: "UI",
+      items: ["ui/mixer"],
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- document mixer-related React components with TSDoc
- clarify mixer and device panel styles with comments
- add mixer docs with routing diagrams for users and developers

## Testing
- `npm test` *(fails: @opendaw/lib-std:test npm error command sh -c vitest run)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabd529a483219c0989fff5b45141