### PR TITLE
docs: document developer UI pages and add page headers

### DIFF
--- a/packages/app/studio/src/errors/ErrorHandler.ts
+++ b/packages/app/studio/src/errors/ErrorHandler.ts
@@ -1,3 +1,6 @@
+/**
+ * Captures global errors and reports them to the logging service.
+ */
 import {EmptyExec, Terminable, Terminator, Warning} from "@opendaw/lib-std"
 import {AnimationFrame, Browser, Events} from "@opendaw/lib-dom"
 import {LogBuffer} from "@/errors/LogBuffer.ts"

--- a/packages/app/studio/src/errors/ErrorInfo.ts
+++ b/packages/app/studio/src/errors/ErrorInfo.ts
@@ -1,3 +1,6 @@
+/**
+ * Helpers to normalize error information from various event types.
+ */
 import {isDefined} from "@opendaw/lib-std"
 
 export type ErrorInfo = {

--- a/packages/app/studio/src/errors/ErrorLog.ts
+++ b/packages/app/studio/src/errors/ErrorLog.ts
@@ -1,3 +1,6 @@
+/**
+ * Structured payload sent when reporting an error.
+ */
 import {int} from "@opendaw/lib-std"
 import {BuildInfo} from "@/BuildInfo.ts"
 import {LogBuffer} from "@/errors/LogBuffer.ts"

--- a/packages/app/studio/src/errors/LogBuffer.ts
+++ b/packages/app/studio/src/errors/LogBuffer.ts
@@ -1,3 +1,6 @@
+/**
+ * Captures recent console output for inclusion in error reports.
+ */
 import {int} from "@opendaw/lib-std"
 
 export namespace LogBuffer {

--- a/packages/app/studio/src/ui/pages/AutomationPage.sass
+++ b/packages/app/studio/src/ui/pages/AutomationPage.sass
@@ -1,3 +1,4 @@
+// Styles for the automation examples page.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/pages/AutomationPage.tsx
+++ b/packages/app/studio/src/ui/pages/AutomationPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Development page demonstrating value stream rendering and automation edge cases.
+ */
 import css from "./AutomationPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/BackButton.sass
+++ b/packages/app/studio/src/ui/pages/BackButton.sass
@@ -1,3 +1,4 @@
+// Styles for the studio back navigation button.
 component
   display: contents
 

--- a/packages/app/studio/src/ui/pages/BackButton.tsx
+++ b/packages/app/studio/src/ui/pages/BackButton.tsx
@@ -1,3 +1,6 @@
+/**
+ * Navigation button leading back to the studio root.
+ */
 import css from "./BackButton.sass?inline"
 import {Html} from "@opendaw/lib-dom"
 import {Icon} from "@/ui/components/Icon"

--- a/packages/app/studio/src/ui/pages/ComponentsPage.sass
+++ b/packages/app/studio/src/ui/pages/ComponentsPage.sass
@@ -1,3 +1,4 @@
+// Styles for the components showcase page.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/pages/ComponentsPage.tsx
+++ b/packages/app/studio/src/ui/pages/ComponentsPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Interactive showcase of reusable UI components.
+ */
 import css from "./ComponentsPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/ErrorsPage.sass
+++ b/packages/app/studio/src/ui/pages/ErrorsPage.sass
@@ -1,3 +1,4 @@
+// Styles for the error diagnostics page.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/pages/ErrorsPage.tsx
+++ b/packages/app/studio/src/ui/pages/ErrorsPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays aggregated error reports and associated logs.
+ */
 import css from "./ErrorsPage.sass?inline"
 import {Await, createElement, Group, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/GraphPage.sass
+++ b/packages/app/studio/src/ui/pages/GraphPage.sass
@@ -1,3 +1,4 @@
+// Styles for the project graph visualization page.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/pages/GraphPage.tsx
+++ b/packages/app/studio/src/ui/pages/GraphPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Visualizes the current project's box graph for diagnostics.
+ */
 import css from "./GraphPage.sass?inline"
 import {Await, createElement, DomElement, Frag, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {Html} from "@opendaw/lib-dom"

--- a/packages/app/studio/src/ui/pages/IconsPage.sass
+++ b/packages/app/studio/src/ui/pages/IconsPage.sass
@@ -1,3 +1,4 @@
+// Styles for the icon gallery page.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/pages/IconsPage.tsx
+++ b/packages/app/studio/src/ui/pages/IconsPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Lists all available SVG icons in the application.
+ */
 import css from "./IconsPage.sass?inline"
 import {createElement, Frag, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/ManualPage.sass
+++ b/packages/app/studio/src/ui/pages/ManualPage.sass
@@ -1,3 +1,4 @@
+// Layout styles for the manuals page and sidebar.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/pages/ManualPage.tsx
+++ b/packages/app/studio/src/ui/pages/ManualPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Renders documentation manuals and navigation.
+ */
 import css from "./ManualPage.sass?inline"
 import {Await, createElement, LocalLink, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/Manuals.ts
+++ b/packages/app/studio/src/ui/pages/Manuals.ts
@@ -1,3 +1,6 @@
+/**
+ * List of manual links displayed in the ManualPage sidebar.
+ */
 export const Manuals: ReadonlyArray<[string, string]> = [
     ["⇱", "/manuals/"],
     ["Browser Support", "/manuals/browser-support"],

--- a/packages/app/studio/src/ui/pages/SampleUploadPage.sass
+++ b/packages/app/studio/src/ui/pages/SampleUploadPage.sass
@@ -1,3 +1,4 @@
+// Styles for the sample upload utility page.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/pages/SampleUploadPage.tsx
+++ b/packages/app/studio/src/ui/pages/SampleUploadPage.tsx
@@ -1,3 +1,6 @@
+/**
+ * Upload utility for analyzing and submitting audio samples.
+ */
 import css from "./SampleUploadPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/pages/errors/Logs.sass
+++ b/packages/app/studio/src/ui/pages/errors/Logs.sass
@@ -1,3 +1,4 @@
+// Styles for the error log table within diagnostics.
 component
   display: grid
   overflow: auto

--- a/packages/app/studio/src/ui/pages/errors/Logs.tsx
+++ b/packages/app/studio/src/ui/pages/errors/Logs.tsx
@@ -1,3 +1,6 @@
+/**
+ * Displays buffered log entries relative to an error time.
+ */
 import css from "./Logs.sass?inline"
 import {Html} from "@opendaw/lib-dom"
 import {isDefined, TimeSpan} from "@opendaw/lib-std"

--- a/packages/app/studio/src/ui/pages/errors/Stack.sass
+++ b/packages/app/studio/src/ui/pages/errors/Stack.sass
@@ -1,3 +1,4 @@
+// Styles for the error stack trace display.
 component
   display: grid
   overflow: auto

--- a/packages/app/studio/src/ui/pages/errors/Stack.tsx
+++ b/packages/app/studio/src/ui/pages/errors/Stack.tsx
@@ -1,3 +1,6 @@
+/**
+ * Shows the stack trace for an error report.
+ */
 import css from "./Stack.sass?inline"
 import {Html} from "@opendaw/lib-dom"
 import {createElement} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/pages/graph-runtime.ts
+++ b/packages/app/studio/src/ui/pages/graph-runtime.ts
@@ -1,4 +1,6 @@
-// graph-runtime.ts
+/**
+ * Force-directed graph runtime used by GraphPage.
+ */
 import ForceGraph from "force-graph"
 import * as d3 from "d3-force"
 import {SimulationNodeDatum} from "d3-force"

--- a/packages/docs/docs-dev/ui/pages/automation.md
+++ b/packages/docs/docs-dev/ui/pages/automation.md
@@ -1,0 +1,3 @@
+# Automation Page
+
+Demonstrates timeline automation rendering and edge cases used for development.

--- a/packages/docs/docs-dev/ui/pages/components.md
+++ b/packages/docs/docs-dev/ui/pages/components.md
@@ -1,0 +1,3 @@
+# Components Page
+
+Interactive gallery showcasing reusable UI components.

--- a/packages/docs/docs-dev/ui/pages/diagnostics.md
+++ b/packages/docs/docs-dev/ui/pages/diagnostics.md
@@ -1,0 +1,3 @@
+# Diagnostics
+
+Pages for inspecting runtime state such as the project graph and collected error reports.

--- a/packages/docs/docs-dev/ui/pages/icons.md
+++ b/packages/docs/docs-dev/ui/pages/icons.md
@@ -1,0 +1,3 @@
+# Icons Page
+
+Reference gallery listing all SVG icons available in the studio.

--- a/packages/docs/docs-dev/ui/pages/manuals.md
+++ b/packages/docs/docs-dev/ui/pages/manuals.md
@@ -1,0 +1,3 @@
+# Manuals Page
+
+Lists and renders markdown manuals shipped with the studio.

--- a/packages/docs/docs-user/ui-tour.md
+++ b/packages/docs/docs-user/ui-tour.md
@@ -32,3 +32,13 @@ Displays the device chain for the active track, allowing you to add and tweak in
 ## Mixer
 
 Shows channel strips for each track. Toggle the panel with `M` or switch to the dedicated mixer view via `⇧2`.
+
+## Developer Pages
+
+For internal tooling and diagnostics see:
+
+- [Automation](../docs-dev/ui/pages/automation.md)
+- [Components](../docs-dev/ui/pages/components.md)
+- [Diagnostics](../docs-dev/ui/pages/diagnostics.md)
+- [Icons](../docs-dev/ui/pages/icons.md)
+- [Manuals](../docs-dev/ui/pages/manuals.md)


### PR DESCRIPTION
## Summary
- add TSDoc headers for studio pages and error modules
- document developer UI pages and link from user tour
- note new docs for automation, components, diagnostics, icons and manuals

## Testing
- `npm test` *(fails: Could not resolve workspaces; @opendaw/lib-std build failed)*
- `npm run lint` *(fails: run failed)*
- `npm --workspace packages/docs run build` *(fails: missing TypeScript configs and types)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabd88f0883218beba586cacd528a