### PR TITLE
docs: document documentation site and add cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Localization Guide](packages/docs/docs-user/localization.md)
 - [Accessibility Guide](packages/docs/docs-user/accessibility.md)
 - [Developer i18n Notes](packages/docs/docs-dev/i18n.md)
+- [Documentation Site Guide](packages/docs/docs-dev/documentation-site/overview.md)
 
 ### Style Documentation
 

--- a/packages/docs/docs-dev/documentation-site/contributing.md
+++ b/packages/docs/docs-dev/documentation-site/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+When updating the documentation site:
+
+1. Review the [overview](overview.md) to understand the setup.
+2. Follow the [structure guide](structure.md) for file placement.
+3. Apply styles as described in the [styling guide](styling.md).
+
+After editing, run `npm test` and `npm run lint` at the repository root before submitting changes.

--- a/packages/docs/docs-dev/documentation-site/overview.md
+++ b/packages/docs/docs-dev/documentation-site/overview.md
@@ -1,0 +1,5 @@
+# Documentation Site Overview
+
+The documentation site is built with Docusaurus. Configuration lives in `packages/docs/docusaurus.config.ts` and sidebars are defined in `packages/docs/sidebarsDev.js`, `sidebarsUser.js`, and `sidebarsLearn.js`.
+
+Use the [structure guide](structure.md) for directory layout details, the [styling guide](styling.md) for CSS and component conventions, and the [contributing guide](contributing.md) for contribution instructions.

--- a/packages/docs/docs-dev/documentation-site/structure.md
+++ b/packages/docs/docs-dev/documentation-site/structure.md
@@ -1,0 +1,9 @@
+# Structure
+
+This guide explains how files are organized.
+
+- The main configuration resides in `packages/docs/docusaurus.config.ts`.
+- Sidebar definitions are in `packages/docs/sidebarsDev.js`, `sidebarsUser.js`, and `sidebarsLearn.js`.
+- Pages live under `packages/docs/src/pages/` and reusable components under `packages/docs/src/components/`.
+
+Refer back to the [overview](overview.md) and consult the [styling guide](styling.md) when editing. Contributions are described in the [contributing guide](contributing.md).

--- a/packages/docs/docs-dev/documentation-site/styling.md
+++ b/packages/docs/docs-dev/documentation-site/styling.md
@@ -1,0 +1,5 @@
+# Styling
+
+Global styles are in `packages/docs/src/css/custom.css` while component-scoped styles accompany their components such as `packages/docs/src/components/HomepageFeatures/styles.module.css`.
+
+See the [overview](overview.md) for context and the [structure guide](structure.md) for file locations. Contributions should follow the [contributing guide](contributing.md).

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -1,3 +1,6 @@
+// Docusaurus configuration for the documentation site.
+// For an overview of the documentation setup see docs-dev/documentation-site/overview.md
+// Sidebars are maintained in sidebarsDev.js, sidebarsUser.js and sidebarsLearn.js
 import type { Config } from "@docusaurus/types";
 import { themes as prismThemes } from "prism-react-renderer";
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,4 +1,5 @@
 {
+  "//": "Docs site package manifest; see docs-dev/documentation-site/overview.md and tsconfig.json",
   "name": "packages-docs",
   "version": "0.0.0",
   "private": true,

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -1,5 +1,8 @@
 import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
+// See docs-dev/documentation-site/structure.md for how sidebars integrate with
+// docusaurus.config.ts and other sidebar definitions.
+
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 /**

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -1,3 +1,6 @@
+/** Sidebar for developer documentation.
+ * Referenced from docusaurus.config.ts; see docs-dev/documentation-site/structure.md
+ */
 module.exports = {
   devSidebar: [
     { type: "doc", id: "intro" },

--- a/packages/docs/sidebarsLearn.js
+++ b/packages/docs/sidebarsLearn.js
@@ -1,3 +1,6 @@
+/** Sidebar for learning resources.
+ * Referenced from docusaurus.config.ts; see docs-dev/documentation-site/structure.md
+ */
 module.exports = {
   learnSidebar: [{ type: 'doc', id: 'intro' }],
 };

--- a/packages/docs/sidebarsUser.js
+++ b/packages/docs/sidebarsUser.js
@@ -1,3 +1,6 @@
+/** Sidebar for user guides.
+ * Referenced from docusaurus.config.ts; see docs-dev/documentation-site/structure.md
+ */
 module.exports = {
   userSidebar: [
     { type: "doc", id: "intro" },

--- a/packages/docs/src/components/HomepageFeatures/index.tsx
+++ b/packages/docs/src/components/HomepageFeatures/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * Features section displayed on the docs home page.
+ * Styling is defined in styles.module.css and global rules live in ../../css/custom.css.
+ * See docs-dev/documentation-site/styling.md for guidelines.
+ */
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Heading from '@theme/Heading';

--- a/packages/docs/src/components/HomepageFeatures/styles.module.css
+++ b/packages/docs/src/components/HomepageFeatures/styles.module.css
@@ -1,3 +1,7 @@
+/* Styles specific to the HomepageFeatures component.
+   See docs-dev/documentation-site/styling.md for guidance and
+   packages/docs/src/pages/index.tsx for usage. */
+
 .features {
   display: flex;
   align-items: center;

--- a/packages/docs/src/css/custom.css
+++ b/packages/docs/src/css/custom.css
@@ -2,6 +2,9 @@
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to
  * work well for content-centric websites.
+ * See docs-dev/documentation-site/styling.md for styling guidelines.
+ * Component specific styles live alongside their components such as
+ * ../components/HomepageFeatures/styles.module.css
  */
 
 /* You can override the default Infima variables here. */

--- a/packages/docs/src/pages/index.tsx
+++ b/packages/docs/src/pages/index.tsx
@@ -1,3 +1,8 @@
+/**
+ * Landing page for the documentation site.
+ * See docs-dev/documentation-site/structure.md for layout guidance.
+ * Uses the HomepageFeatures component.
+ */
 import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';

--- a/packages/docs/src/pages/markdown-page.md
+++ b/packages/docs/src/pages/markdown-page.md
@@ -2,6 +2,9 @@
 title: Markdown page example
 ---
 
+<!-- Standalone markdown page. See docs-dev/documentation-site/overview.md for context
+and contributing.md for editing guidelines. -->
+
 # Markdown page example
 
 You don't need React to write simple standalone pages.

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -1,4 +1,6 @@
 {
+  // TypeScript config for the docs site. See docs-dev/documentation-site/structure.md
+  // Related files: package.json and docusaurus.config.ts
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {


### PR DESCRIPTION
## Summary
- comment and cross-link docs site config, sidebars, pages, and styles
- add documentation site overview, structure, styling, and contributing guides
- link documentation site guide from the README

## Testing
- `npm test` *(fails: '@opendaw/lib-std#build' error TS18028)*
- `npm run lint` *(fails: '@opendaw/studio-core-workers#lint' eslint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabe4732c8321be4d167cb60d91e1