### PR TITLE
docs: add writing guide and style tips

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,1 +1,2 @@
+# Disable all markdownlint rules by default; enable only the ones we need
 default: false

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,9 @@
+# Path to custom Vale styles
 StylesPath = styles
+
+# Report suggestions at or above the warning level
 MinAlertLevel = warning
 
 [*.md]
+# Apply our OpenDAW style rules to all Markdown files
 BasedOnStyles = OpenDAW

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ The monorepo uses **Turbo** to run build, test, and lint tasks across all packag
 - Write Markdown documentation using ATX headings (`#`, `##`, etc.) and keep line length reasonable.
 - Include tests or documentation updates alongside code changes when appropriate.
 - Review our [error handling notes](packages/docs/docs-dev/error-handling.md) when working with runtime failures.
+- Refer to the [Writing Guide](packages/docs/docs-dev/style/writing-guide.md) for tone and formatting tips when updating documentation.
 
 Following these steps helps maintain a clean git history and a stable codebase. We appreciate every contribution—thank you for helping improve openDAW!
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Style Guidelines](styles/OpenDAW/style-guidelines.md)
 - [Developer Style Guide](packages/docs/docs-dev/style-guide.md)
 - [User Style Customization](packages/docs/docs-user/style-customization.md)
+- [Writing Guide](packages/docs/docs-dev/style/writing-guide.md)
 
 ### Prepare, Clone, Installation, and Run
 

--- a/packages/docs/docs-dev/api-coverage.md
+++ b/packages/docs/docs-dev/api-coverage.md
@@ -58,4 +58,5 @@ A typical `coverage.json` looks like:
   `notDocumented` list shrinks.
 
 Contributions to improve coverage are welcome—see
-[Contributing](./contributing.md) for guidelines.
+[Contributing](./contributing.md) for guidelines. For doc style, consult the
+[Writing Guide](./style/writing-guide.md).

--- a/packages/docs/docs-dev/contributing.md
+++ b/packages/docs/docs-dev/contributing.md
@@ -14,6 +14,8 @@ please:
 4. Run tests with `npm test` (see [Tests](./build-and-run/tests.md)).
 5. Commit with clear messages and open a pull request against `main`.
 
+For documentation changes, follow the [Writing Guide](./style/writing-guide.md).
+
 For profiling advice, read the [Profiling guide](./build-and-run/profiling.md).
 See [Licensing](./licensing.md) for information on the dual license. For more
 detail, see the root [CONTRIBUTING.md](../../../../CONTRIBUTING.md).

--- a/packages/docs/docs-dev/intro.md
+++ b/packages/docs/docs-dev/intro.md
@@ -6,6 +6,8 @@ to [build and run](./build-and-run/setup.md) the project, explore its
 [architecture](./architecture/overview.md), and ensure quality with
 [testing and QA](./testing-and-qa/index.md).
 
+For writing and formatting conventions, see the [Writing Guide](./style/writing-guide.md).
+
 ## Table of Contents
 
 - [Build and Run](./build-and-run/setup.md)

--- a/packages/docs/docs-dev/style/writing-guide.md
+++ b/packages/docs/docs-dev/style/writing-guide.md
@@ -1,0 +1,12 @@
+# Writing Guide
+
+Use this guide when contributing documentation.
+
+## Tips
+- Write in the second person and use active voice.
+- Keep sentences short—aim for 20 words or fewer.
+- Use the present tense and plain language.
+- Provide code fences for commands or snippets.
+- Link to related topics to help navigation.
+
+These practices align with our Markdown linting and Vale configuration.

--- a/packages/docs/docs-learn/daw-basics-101.md
+++ b/packages/docs/docs-learn/daw-basics-101.md
@@ -7,7 +7,7 @@ A Digital Audio Workstation (DAW) is software for recording, editing, and mixing
 - **Tracks** – containers for audio or MIDI data that you can record, edit, and process.
 - **Timeline** – the horizontal workspace where clips are arranged in time.
 - **Mixer** – combines tracks, sets their levels, and routes them to outputs.
-- **Plug-ins** – processors or instruments inserted on tracks to modify or generate sound.
+- **Plugins** – processors or instruments inserted on tracks to modify or generate sound.
 - **Automation** – recorded changes to parameters such as volume or effect settings over time.
 
 ## Signal Flow
@@ -26,6 +26,9 @@ flowchart LR
 ## Next Steps
 
 Continue to the next lesson to learn how to create tracks, record audio, and use basic effects.
+
+For writing guidance or to suggest edits, see the
+[Writing Guide](../docs-dev/style/writing-guide.md).
 
 ## Quiz
 

--- a/packages/docs/docs-learn/intro.md
+++ b/packages/docs/docs-learn/intro.md
@@ -5,6 +5,9 @@ Start with **[DAW Basics 101](./daw-basics-101.md)** to learn core concepts
 like tracks, the mixer, and automation. Lessons build on each other, so work
 through them in order or jump to topics using the sidebar.
 
+Interested in contributing lessons? Check the
+[Writing Guide](../docs-dev/style/writing-guide.md) for style tips.
+
 ```mermaid
 graph LR
     Basics["DAW Basics"] --> Arrangement["Arrangement Basics"]

--- a/packages/docs/docs-user/intro.md
+++ b/packages/docs/docs-user/intro.md
@@ -1,6 +1,8 @@
 # User Guide
 
-This guide helps you get started with openDAW and deepen your skills.
+This guide helps you get started with openDAW and deepen your skills. If you
+want to contribute documentation, read the
+[Writing Guide](../docs-dev/style/writing-guide.md).
 
 - [Quick Start](quick-start.md) — set up the project and begin making music in minutes.
 - [UI Tour](ui-tour.md) — explore the interface and learn where everything lives.

--- a/packages/docs/docs-user/quick-start.md
+++ b/packages/docs/docs-user/quick-start.md
@@ -8,3 +8,6 @@
 6. **Explore further.** Continue with the [Beat Making](workflows/beat.md) or [Recording and Effects](workflows/record-and-fx.md) workflows to learn more.
 
 For language options see the [Localization guide](localization.md). Accessibility features are outlined in the [Accessibility guide](accessibility.md).
+
+For writing or editing tips, consult the
+[Writing Guide](../docs-dev/style/writing-guide.md).


### PR DESCRIPTION
## Summary
- document Vale and markdownlint configs
- add writing guide and link from all doc entry points
- fix plugin terminology and doc inconsistencies

## Testing
- `npm test` *(fails: File '@opendaw/typescript-config/base.json' not found)*
- `npm run lint` *(fails: eslint "**/*.ts" exited with 1)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabe49e308321bcd6bdcaa2d030b2