### PR TITLE
docs: document project management

### DIFF
--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -3,6 +3,8 @@
 This package contains the web-based user interface for the OpenDAW project.
 
 For a guided overview of the interface, see the [UI tour](../../docs/docs-user/ui-tour.md).
+Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md).
+Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
 ## Component Hierarchy
 

--- a/packages/app/studio/src/project/ProjectBrowser.sass
+++ b/packages/app/studio/src/project/ProjectBrowser.sass
@@ -1,3 +1,9 @@
+// Styles for the project list displayed in {@link ProjectBrowser}.
+//
+// Example markup:
+// <div class="ProjectBrowser">
+//   <div class="list">...</div>
+// </div>
 component
   font-size: 0.75rem
   display: grid

--- a/packages/app/studio/src/project/ProjectBrowser.tsx
+++ b/packages/app/studio/src/project/ProjectBrowser.tsx
@@ -18,6 +18,14 @@ type Construct = {
 
 /**
  * List of saved projects allowing the user to select or delete entries.
+ *
+ * @example
+ * ```tsx
+ * const handleSelect = ([id, meta]: [UUID.Format, ProjectMeta]) => {
+ *   console.log(meta.name)
+ * }
+ * <ProjectBrowser service={service} select={handleSelect}/>
+ * ```
  */
 export const ProjectBrowser = ({service, select}: Construct) => {
     const now = new Date().getTime()

--- a/packages/app/studio/src/project/ProjectDialogs.tsx
+++ b/packages/app/studio/src/project/ProjectDialogs.tsx
@@ -15,6 +15,12 @@ export namespace ProjectDialogs {
 
     /**
      * Prompt the user to save a project by entering a name and meta data.
+     *
+     * @example
+     * ```ts
+     * const meta = await ProjectDialogs.showSaveDialog({headline: "Save"})
+     * console.log(meta.name)
+     * ```
      */
     export const showSaveDialog = async ({headline, meta}: {
         headline: string,
@@ -70,6 +76,11 @@ export namespace ProjectDialogs {
     /**
      * Display a dialog containing the {@link ProjectBrowser} component and
      * resolve with the selected project.
+     *
+     * @example
+     * ```ts
+     * const [id, meta] = await ProjectDialogs.showBrowseDialog(service)
+     * ```
      */
     export const showBrowseDialog = async (service: StudioService): Promise<[UUID.Format, ProjectMeta]> => {
         const {resolve, reject, promise} = Promise.withResolvers<[UUID.Format, ProjectMeta]>()
@@ -95,6 +106,11 @@ export namespace ProjectDialogs {
     /**
      * Ask the user which stems should be exported for the given project and
      * return the chosen configuration.
+     *
+     * @example
+     * ```ts
+     * const config = await ProjectDialogs.showExportStemsDialog(project)
+     * ```
      */
     export const showExportStemsDialog = async (project: Project): Promise<ExportStemsConfiguration> => {
         const {resolve, reject, promise} = Promise.withResolvers<ExportStemsConfiguration>()

--- a/packages/app/studio/src/project/ProjectMeta.ts
+++ b/packages/app/studio/src/project/ProjectMeta.ts
@@ -1,16 +1,34 @@
 import {JSONValue} from "@opendaw/lib-std"
 
+/**
+ * Metadata describing a project such as name and tags.
+ */
 export type ProjectMeta = {
+    /** Project title displayed in the UI. */
     name: string
+    /** Free form description for the project. */
     description: string
+    /** Tags used for categorization. */
     tags: Array<string>
+    /** Creation timestamp in ISO format. */
     created: Readonly<string>
+    /** Last modification timestamp in ISO format. */
     modified: string
+    /** Optional text notes saved with the project. */
     notepad?: string
 } & JSONValue
 
 export namespace ProjectMeta {
     const created = new Date().toISOString()
+
+    /**
+     * Create a new {@link ProjectMeta} object with sensible defaults.
+     *
+     * @example
+     * ```ts
+     * const meta = ProjectMeta.init("My Song")
+     * ```
+     */
     export const init = (name: string = "Untitled"): ProjectMeta => ({
         name,
         description: "",
@@ -19,5 +37,8 @@ export namespace ProjectMeta {
         modified: created
     })
 
+    /**
+     * Create a shallow copy of the given metadata object.
+     */
     export const copy = (meta: ProjectMeta): ProjectMeta => Object.assign({}, meta)
 }

--- a/packages/app/studio/src/project/ProjectSession.ts
+++ b/packages/app/studio/src/project/ProjectSession.ts
@@ -7,6 +7,15 @@ import {MidiDeviceAccess} from "@/midi/devices/MidiDeviceAccess"
 import {StudioService} from "@/service/StudioService"
 import {Project} from "@opendaw/studio-core"
 
+/**
+ * Wraps a loaded project together with its metadata and persistence helpers.
+ *
+ * @example
+ * ```ts
+ * const session = new ProjectSession(service, uuid, project, meta, Option.None, true)
+ * await session.save()
+ * ```
+ */
 export class ProjectSession {
     readonly #service: StudioService
     readonly #uuid: UUID.Format
@@ -41,6 +50,9 @@ export class ProjectSession {
     get meta(): ProjectMeta {return this.#meta}
     get cover(): Option<ArrayBuffer> {return this.#cover}
 
+    /**
+     * Persist the current project state to storage.
+     */
     async save(): Promise<void> {
         this.updateModifyDate()
         this.saveMidiConfiguration()
@@ -49,6 +61,14 @@ export class ProjectSession {
             : Promise.reject("Project has not been saved")
     }
 
+    /**
+     * Save the project under a new name.
+     *
+     * @example
+     * ```ts
+     * await session.saveAs({name: "copy", description: "", tags: [], created: date, modified: date})
+     * ```
+     */
     async saveAs(meta: ProjectMeta): Promise<Option<ProjectSession>> {
         Object.assign(this.meta, meta)
         this.updateModifyDate()
@@ -86,11 +106,17 @@ export class ProjectSession {
         return this.subscribeMetaData(observer)
     }
 
+    /**
+     * Update the session's cover image.
+     */
     updateCover(cover: Option<ArrayBuffer>): void {
         this.#cover = cover
         this.#hasChanges = true
     }
 
+    /**
+     * Modify a metadata field and notify subscribers.
+     */
     updateMetaData<KEY extends keyof ProjectMeta>(key: KEY, value: ProjectMeta[KEY]): void {
         if (this.meta[key] === value) {return}
         this.meta[key] = value

--- a/packages/app/studio/src/project/SampleImporter.ts
+++ b/packages/app/studio/src/project/SampleImporter.ts
@@ -1,6 +1,14 @@
 import {Progress, UUID} from "@opendaw/lib-std"
 import {Sample} from "@opendaw/studio-adapters"
 
+/**
+ * Interface for importing audio samples into a project.
+ *
+ * @example
+ * ```ts
+ * await importer.importSample({uuid, name: "kick", arrayBuffer})
+ * ```
+ */
 export type SampleImporter = {
     importSample(sample: {
         uuid: UUID.Format,

--- a/packages/app/studio/src/project/SampleUtils.ts
+++ b/packages/app/studio/src/project/SampleUtils.ts
@@ -10,7 +10,17 @@ import {showInfoDialog} from "@/ui/components/dialogs"
 import {SampleImporter} from "@/project/SampleImporter"
 import {SampleApi} from "@/service/SampleApi"
 
+/** Utility functions for working with audio samples. */
 export namespace SampleUtils {
+    /**
+     * Ensure all audio file boxes reference existing samples and prompt the
+     * user to replace missing ones.
+     *
+     * @example
+     * ```ts
+     * await SampleUtils.verify(project.boxGraph, importer, manager)
+     * ```
+     */
     export const verify = async (boxGraph: BoxGraph, importer: SampleImporter, audioManager: SampleManager) => {
         const boxes = boxGraph.boxes().filter((box) => box instanceof AudioFileBox)
         if (boxes.length > 0) {

--- a/packages/app/studio/src/ui/info-panel/Cover.sass
+++ b/packages/app/studio/src/ui/info-panel/Cover.sass
@@ -1,5 +1,8 @@
 @use "@/mixins"
 
+// Styling for the project cover image with edit overlay.
+// Example:
+// <div class="Cover"><img/><span class="edit-icon"/></div>
 component
   width: 100%
   aspect-ratio: 1 / 1

--- a/packages/app/studio/src/ui/info-panel/Cover.tsx
+++ b/packages/app/studio/src/ui/info-panel/Cover.tsx
@@ -14,6 +14,14 @@ type Construct = {
     model: MutableObservableOption<ArrayBuffer>
 }
 
+/**
+ * Displays and lets the user replace a project cover image.
+ *
+ * @example
+ * ```tsx
+ * <Cover lifecycle={lifecycle} model={coverModel}/>
+ * ```
+ */
 export const Cover = ({lifecycle, model}: Construct) => {
     const placeholder = "/cover.png"
     const editIcon: Element = <Icon symbol={IconSymbol.EditBox} className="edit-icon"/>

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
@@ -1,5 +1,8 @@
 @use "@/colors"
 
+// Styles for the project metadata panel.
+// Example markup:
+// <div class="ProjectInfo"><div class="form">...</div></div>
 component
   flex: 1
   display: flex

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
@@ -12,6 +12,14 @@ type Construct = {
     service: StudioService
 }
 
+/**
+ * Form component for editing project metadata and cover image.
+ *
+ * @example
+ * ```tsx
+ * <ProjectInfo lifecycle={lifecycle} service={service}/>
+ * ```
+ */
 export const ProjectInfo = ({lifecycle, service}: Construct) => {
     if (!service.hasProjectSession) {return "No session."}
     const {session} = service

--- a/packages/docs/docs-dev/projects/importing.md
+++ b/packages/docs/docs-dev/projects/importing.md
@@ -1,0 +1,10 @@
+# Importing and Exporting
+
+Projects can be bundled into a single `.odb` file that includes all referenced samples.
+
+```ts
+const data = await Projects.exportBundle(session, progress)
+const session = await Projects.importBundle(service, data)
+```
+
+`SampleUtils.verify` checks that all referenced samples exist and lets the user replace missing ones during import.

--- a/packages/docs/docs-dev/projects/overview.md
+++ b/packages/docs/docs-dev/projects/overview.md
@@ -1,0 +1,15 @@
+# Project System Overview
+
+openDAW stores songs as projects containing a serialized graph, metadata and optional cover image. Files are written beneath the `projects/v1` folder using the helpers from [`ProjectPaths`](../../../app/studio/src/project/Projects.ts).
+
+## Saving
+
+Use [`Projects.saveProject`](../../../app/studio/src/project/Projects.ts) to write a session to disk.
+
+```ts
+await Projects.saveProject(session)
+```
+
+## Metadata
+
+Project metadata like name and tags is represented by [`ProjectMeta`](../../../app/studio/src/project/ProjectMeta.ts).

--- a/packages/docs/docs-dev/projects/sessions.md
+++ b/packages/docs/docs-dev/projects/sessions.md
@@ -1,0 +1,10 @@
+# Working with Sessions
+
+A `ProjectSession` combines a project, its metadata and runtime state. It exposes helpers for saving and updating metadata.
+
+```ts
+const session = new ProjectSession(service, uuid, project, meta, Option.None, true)
+await session.save()
+```
+
+Use `saveAs` to duplicate the project under a new identifier and metadata.

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -1,6 +1,6 @@
 # File Management
 
-Import, export, and organize project files.
+Import, export, and organize project files. Developers can dive deeper in the [project docs](../../docs-dev/projects/overview.md).
 
 ## Save Projects
 


### PR DESCRIPTION
## Summary
- add TSDoc with examples to project management components
- document project storage, sessions and importing
- link studio README to new project documentation

## Testing
- `npm run lint` *(fails: command exited with error)*
- `npm test` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabe65594832197ba0301c00e0ad7