### PR TITLE
docs: add UI component docs and examples

### DIFF
--- a/packages/app/studio/src/ui/components/Button.tsx
+++ b/packages/app/studio/src/ui/components/Button.tsx
@@ -3,14 +3,27 @@ import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {Appearance, ButtonCheckboxRadio} from "@/ui/components/ButtonCheckboxRadio"
 import {Html} from "@opendaw/lib-dom"
 
-export type ButtonParameters = {
+/**
+ * Props for {@link Button}.
+ */
+export interface ButtonProps {
+    /** Manages subscriptions to allow proper cleanup. */
     lifecycle: Lifecycle
+    /** Callback executed when the button is clicked. */
     onClick: Procedure<MouseEvent>
+    /** Optional inline style applied to the wrapper element. */
     style?: Partial<CSSStyleDeclaration>
+    /** Visual customisation forwarded to {@link ButtonCheckboxRadio}. */
     appearance?: Appearance
 }
 
-export const Button = ({lifecycle, onClick, style, appearance}: ButtonParameters, children: JsxValue) => {
+/**
+ * Renders a clickable button using {@link ButtonCheckboxRadio} styling.
+ *
+ * @param lifecycle - {@link Lifecycle} owner of event subscriptions
+ * @param onClick - called when the button is activated
+ */
+export const Button = ({lifecycle, onClick, style, appearance}: ButtonProps, children: JsxValue) => {
     const id = Html.nextID()
     const input: HTMLInputElement = <input type="button" id={id} onclick={onClick}/>
     return (
@@ -20,3 +33,13 @@ export const Button = ({lifecycle, onClick, style, appearance}: ButtonParameters
         </ButtonCheckboxRadio>
     )
 }
+
+/**
+ * Property table for {@link Button}.
+ */
+export const ButtonPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Manages subscriptions for cleanup."},
+    {prop: "onClick", type: "Procedure<MouseEvent>", description: "Invoked when the button is clicked."},
+    {prop: "style", type: "Partial<CSSStyleDeclaration>", description: "Inline style for the wrapper element."},
+    {prop: "appearance", type: "Appearance", description: "Visual customisation of the control."}
+] as const

--- a/packages/app/studio/src/ui/components/ButtonCheckboxRadio.tsx
+++ b/packages/app/studio/src/ui/components/ButtonCheckboxRadio.tsx
@@ -6,25 +6,43 @@ import {CssUtils, Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "ButtonCheckboxRadio")
 
-export type Appearance = {
+/** Visual appearance options shared by button-like controls. */
+export interface Appearance {
+    /** Base color of the control. */
     color?: string
+    /** Color used when the control is active. */
     activeColor?: string
+    /** Renders an outline around the control. */
     framed?: boolean
+    /** Layout children in landscape orientation. */
     landscape?: boolean
+    /** Optional tooltip text. */
     tooltip?: string
+    /** Cursor style when hovering. */
     cursor?: CssUtils.Cursor
 }
 
-type Construct = {
+/** Props for {@link ButtonCheckboxRadio}. */
+export interface ButtonCheckboxRadioProps {
+    /** Lifecycle owner used for automatic disposal. */
     lifecycle: Lifecycle
+    /** Data-class attribute used for styling. */
     dataClass: string
+    /** Inline style applied to the wrapper. */
     style?: Partial<CSSStyleDeclaration>
+    /** Additional CSS class name for the wrapper. */
     className?: string
+    /** Visual appearance options. */
     appearance?: Appearance
 }
 
-export const ButtonCheckboxRadio = ({lifecycle, dataClass, style, className: externalClassName, appearance}: Construct,
-                                    children: JsxValue) => {
+/**
+ * Common wrapper around input elements that behave like buttons,
+ * checkboxes or radio buttons.
+ */
+export const ButtonCheckboxRadio = (
+    {lifecycle, dataClass, style, className: externalClassName, appearance}: ButtonCheckboxRadioProps,
+    children: JsxValue) => {
     const wrapper: HTMLElement = (
         <div className={Html.buildClassList(className,
             appearance?.framed && "framed",
@@ -62,3 +80,12 @@ export const ButtonCheckboxRadio = ({lifecycle, dataClass, style, className: ext
     }
     return wrapper
 }
+
+/** Property table for {@link ButtonCheckboxRadio}. */
+export const ButtonCheckboxRadioPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to clean up resources."},
+    {prop: "dataClass", type: "string", description: "Value assigned to the data-class attribute."},
+    {prop: "style", type: "Partial<CSSStyleDeclaration>", description: "Inline style for the wrapper."},
+    {prop: "className", type: "string", description: "Additional CSS class applied to the wrapper."},
+    {prop: "appearance", type: "Appearance", description: "Visual appearance customisation."}
+] as const

--- a/packages/app/studio/src/ui/components/Checkbox.tsx
+++ b/packages/app/studio/src/ui/components/Checkbox.tsx
@@ -3,15 +3,22 @@ import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {Appearance, ButtonCheckboxRadio} from "@/ui/components/ButtonCheckboxRadio.tsx"
 import {Html} from "@opendaw/lib-dom"
 
-type Construct = {
+/** Props for {@link Checkbox}. */
+export interface CheckboxProps {
+    /** Lifecycle owner for event subscriptions. */
     lifecycle: Lifecycle
+    /** Observable model reflecting the checked state. */
     model: MutableObservableValue<boolean>
+    /** Inline style applied to the wrapper. */
     style?: Partial<CSSStyleDeclaration>
+    /** Additional CSS class name for the wrapper. */
     className?: string
+    /** Visual appearance options. */
     appearance?: Appearance
 }
 
-export const Checkbox = ({lifecycle, model, style, className, appearance}: Construct, children: JsxValue) => {
+/** Toggle control wrapping a native checkbox input. */
+export const Checkbox = ({lifecycle, model, style, className, appearance}: CheckboxProps, children: JsxValue) => {
     const id = Html.nextID()
     const input: HTMLInputElement = (
         <input type="checkbox"
@@ -34,3 +41,12 @@ export const Checkbox = ({lifecycle, model, style, className, appearance}: Const
         </ButtonCheckboxRadio>
     )
 }
+
+/** Property table for {@link Checkbox}. */
+export const CheckboxPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "model", type: "MutableObservableValue<boolean>", description: "Observable representing the checked state."},
+    {prop: "style", type: "Partial<CSSStyleDeclaration>", description: "Inline style for the wrapper."},
+    {prop: "className", type: "string", description: "Additional CSS class names."},
+    {prop: "appearance", type: "Appearance", description: "Visual appearance customisation."}
+] as const

--- a/packages/app/studio/src/ui/components/Dialog.tsx
+++ b/packages/app/studio/src/ui/components/Dialog.tsx
@@ -13,24 +13,37 @@ export interface DialogHandler {
     close(): void
 }
 
-export type Button = {
+/** Button descriptor used within a {@link Dialog}. */
+export interface DialogButton {
+    /** Text displayed on the button. */
     text: string
+    /** Handler invoked when the button is clicked. */
     onClick: Procedure<DialogHandler>
+    /** Marks the button as primary action. */
     primary?: boolean
 }
 
-type Construct = {
+/** Props for {@link Dialog}. */
+export interface DialogProps {
+    /** Headline displayed at the top of the dialog. */
     headline: string
+    /** Icon symbol shown next to the headline. */
     icon: IconSymbol
+    /** Callback executed when the dialog is canceled. */
     onCancel?: Exec
+    /** Whether the dialog can be closed with the Escape key. */
     cancelable?: boolean
-    buttons?: ReadonlyArray<Button>
+    /** Optional list of action buttons. */
+    buttons?: ReadonlyArray<DialogButton>
+    /** Inline style applied to the dialog element. */
     style?: Partial<CSSStyleDeclaration>
+    /** Renders the dialog in error style. */
     error?: boolean
 }
 
+/** Modal dialog component rendered using the native `<dialog>` element. */
 export const Dialog = (
-    {headline, icon, onCancel, buttons, cancelable, style, error}: Construct, children: JsxValue) => {
+    {headline, icon, onCancel, buttons, cancelable, style, error}: DialogProps, children: JsxValue) => {
     const lifecycle = new Terminator()
     const dialog: HTMLDialogElement = (
         <dialog className={Html.buildClassList(className, error && "error")} style={style}>
@@ -70,3 +83,14 @@ export const Dialog = (
     }
     return dialog
 }
+
+/** Property table for {@link Dialog}. */
+export const DialogPropTable = [
+    {prop: "headline", type: "string", description: "Headline displayed in the dialog."},
+    {prop: "icon", type: "IconSymbol", description: "Icon shown next to the headline."},
+    {prop: "onCancel", type: "Exec", description: "Callback when the dialog is cancelled."},
+    {prop: "cancelable", type: "boolean", description: "Whether the Escape key closes the dialog."},
+    {prop: "buttons", type: "ReadonlyArray<DialogButton>", description: "Buttons displayed in the footer."},
+    {prop: "style", type: "Partial<CSSStyleDeclaration>", description: "Inline styles for the dialog element."},
+    {prop: "error", type: "boolean", description: "Render dialog with error styling."}
+] as const

--- a/packages/app/studio/src/ui/components/FloatingTextInput.tsx
+++ b/packages/app/studio/src/ui/components/FloatingTextInput.tsx
@@ -5,14 +5,22 @@ import {Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "TextInput")
 
-type Construct = {
+/** Props for {@link FloatingTextInput}. */
+export interface FloatingTextInputProps {
+    /** Promise resolvers used to resolve or reject user input. */
     resolvers?: PromiseWithResolvers<string>
+    /** Absolute screen position to place the input at. */
     position?: Point
+    /** Initial value shown inside the field. */
     value?: boolean | number | string
+    /** Unit string displayed next to the value. */
     unit?: string
 }
 
-export const FloatingTextInput = ({resolvers, position, value, unit}: Construct) => {
+/**
+ * Light-weight text input that floats at an arbitrary screen position.
+ */
+export const FloatingTextInput = ({resolvers, position, value, unit}: FloatingTextInputProps) => {
     const inputField: HTMLInputElement = (<input type="text" value={isDefined(value) ? String(value) : ""}/>)
     requestAnimationFrame(() => {
         inputField.select()
@@ -48,3 +56,11 @@ export const FloatingTextInput = ({resolvers, position, value, unit}: Construct)
     )
     return element
 }
+
+/** Property table for {@link FloatingTextInput}. */
+export const FloatingTextInputPropTable = [
+    {prop: "resolvers", type: "PromiseWithResolvers<string>", description: "Resolvers to resolve or cancel input."},
+    {prop: "position", type: "Point", description: "Absolute screen position."},
+    {prop: "value", type: "boolean | number | string", description: "Initial value shown in the field."},
+    {prop: "unit", type: "string", description: "Unit text displayed next to the value."}
+] as const

--- a/packages/app/studio/src/ui/components/Knob.tsx
+++ b/packages/app/studio/src/ui/components/Knob.tsx
@@ -5,6 +5,21 @@ import {Html, Svg} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "knob")
 
+/** Configuration of the knob design. */
+export interface Design {
+    /** Radius defining the overall size. */
+    readonly radius: number
+    /** Thickness of the track arc. */
+    readonly trackWidth: number
+    /** Offset limiting the rotation range. */
+    readonly angleOffset: number
+    /** Start and end of the indicator as fractions of the radius. */
+    readonly indicator: [unitValue, unitValue]
+    /** Width of the indicator line. */
+    readonly indicatorWidth: number
+}
+
+/** Default design used by {@link Knob}. */
 export const DefaultDesign: Readonly<Design> = Object.freeze({
     radius: 20,
     trackWidth: 1.5,
@@ -13,6 +28,7 @@ export const DefaultDesign: Readonly<Design> = Object.freeze({
     indicatorWidth: 2.5
 } satisfies Design)
 
+/** Compact design variant for small knobs. */
 export const TinyDesign: Readonly<Design> = Object.freeze({
     radius: 20,
     trackWidth: 1.5,
@@ -21,23 +37,22 @@ export const TinyDesign: Readonly<Design> = Object.freeze({
     indicatorWidth: 2.5
 } satisfies Design)
 
-type Design = {
-    readonly radius: number // defines the size
-    readonly trackWidth: number // thickness of the arc
-    readonly angleOffset: number // positive & smaller than PI/2
-    readonly indicator: [unitValue, unitValue] // allows floating indicator
-    readonly indicatorWidth: number
-}
-
-type Construct = {
+/** Props for {@link Knob}. */
+export interface KnobProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Parameter controlling the knob value. */
     value: Parameter
+    /** Anchor position used as reference for the indicator. */
     anchor: unitValue
+    /** Optional color applied to the knob. */
     color?: string
+    /** Custom visual design. */
     design?: Design
 }
 
-export const Knob = ({lifecycle, value, anchor, color, design}: Construct) => {
+/** Circular control representing a continuous parameter value. */
+export const Knob = ({lifecycle, value, anchor, color, design}: KnobProps) => {
     const {radius, trackWidth, angleOffset, indicator: [min, max], indicatorWidth} = design ?? DefaultDesign
 
     const trackRadius = Math.floor(radius - trackWidth * 0.5)
@@ -90,3 +105,12 @@ export const Knob = ({lifecycle, value, anchor, color, design}: Construct) => {
     update(value.getControlledUnitValue())
     return svg
 }
+
+/** Property table for {@link Knob}. */
+export const KnobPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "value", type: "Parameter", description: "Parameter represented by the knob."},
+    {prop: "anchor", type: "unitValue", description: "Reference position for the indicator."},
+    {prop: "color", type: "string", description: "Optional color applied to the knob."},
+    {prop: "design", type: "Design", description: "Custom design configuration."}
+] as const

--- a/packages/app/studio/src/ui/components/Menu.tsx
+++ b/packages/app/studio/src/ui/components/Menu.tsx
@@ -9,8 +9,15 @@ import {AnimationFrame, Events, Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "menu")
 
-export const HeaderMenuDataElement = ({data}: { data: HeaderMenuData }) => (
-    <div className={Html.buildClassList("header")}>
+/** Props for {@link HeaderMenuDataElement}. */
+export interface HeaderMenuDataElementProps {
+    /** Metadata describing the menu header. */
+    data: HeaderMenuData
+}
+
+/** Renders a non-interactive menu header item. */
+export const HeaderMenuDataElement = ({data}: HeaderMenuDataElementProps) => (
+    <div className={Html.buildClassList("header")}> 
         <div className="icon-space"/>
         {data.icon && <Icon symbol={data.icon} style={{margin: "0 0.25em", fontSize: "1.25em"}}/>}
         <div className="label">{data.label}</div>
@@ -18,8 +25,15 @@ export const HeaderMenuDataElement = ({data}: { data: HeaderMenuData }) => (
     </div>
 )
 
-export const DefaultMenuDataElement = ({data}: { data: DefaultMenuData }) => (
-    <div className={Html.buildClassList("default", data.checked && "checked")}>
+/** Props for {@link DefaultMenuDataElement}. */
+export interface DefaultMenuDataElementProps {
+    /** Descriptor for a regular selectable menu item. */
+    data: DefaultMenuData
+}
+
+/** Renders an interactive menu item. */
+export const DefaultMenuDataElement = ({data}: DefaultMenuDataElementProps) => (
+    <div className={Html.buildClassList("default", data.checked && "checked")}> 
         <svg classList="check-icon" viewBox="0 0 12 12">
             <path d="M2 7L5 10L10 3"/>
         </svg>
@@ -32,6 +46,16 @@ export const DefaultMenuDataElement = ({data}: { data: DefaultMenuData }) => (
     </div>
 )
 
+/** Property table for {@link HeaderMenuDataElement}. */
+export const HeaderMenuDataElementPropTable = [
+    {prop: "data", type: "HeaderMenuData", description: "Metadata describing the menu header."}
+] as const
+
+/** Property table for {@link DefaultMenuDataElement}. */
+export const DefaultMenuDataElementPropTable = [
+    {prop: "data", type: "DefaultMenuData", description: "Descriptor of the menu item."}
+] as const
+
 type MenuHtmlStructure = {
     element: HTMLElement
     scrollUp: HTMLElement
@@ -39,6 +63,11 @@ type MenuHtmlStructure = {
     scrollDown: HTMLElement
 }
 
+/**
+ * Floating menu rendered into a {@link Surface} displaying a hierarchy of
+ * {@link MenuItem} entries. Menus can spawn nested sub-menus and handle
+ * keyboard navigation and scrolling.
+ */
 export class Menu implements Terminable, Lifecycle {
     static create(item: MenuItem, groupId?: string): Menu {return new Menu(Option.None, item, groupId ?? "")}
 

--- a/packages/app/studio/src/ui/components/MenuButton.tsx
+++ b/packages/app/studio/src/ui/components/MenuButton.tsx
@@ -8,26 +8,43 @@ import {Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "MenuButton")
 
-type Appearance = {
+/** Appearance options for {@link MenuButton}. */
+export interface MenuButtonAppearance {
+    /** Base color of the button. */
     color?: string
+    /** Color when the button is active. */
     activeColor?: string
+    /** Renders a frame around the button. */
     framed?: boolean
+    /** Draws a tiny triangle indicator instead of the default one. */
     tinyTriangle?: boolean
+    /** Optional tooltip text. */
     tooltip?: string
 }
 
-type Construct = {
+/** Props for {@link MenuButton}. */
+export interface MenuButtonProps {
+    /** Root menu item defining the hierarchy to display. */
     root: MenuItem
+    /** Inline style applied to the button. */
     style?: Partial<CSSStyleDeclaration>
-    appearance?: Appearance
+    /** Visual appearance options. */
+    appearance?: MenuButtonAppearance
+    /** Horizontal alignment of the menu relative to the button. */
     horizontal?: "left" | "right"
+    /** Stretch button to fill available space. */
     stretch?: boolean
+    /** Display pointer cursor when hovering. */
     pointer?: boolean
+    /** Identifier grouping menus so only one is open at a time. */
     groupId?: string
 }
 
+/**
+ * Button that opens a {@link Menu} on pointer interaction.
+ */
 export const MenuButton =
-    ({root, style, appearance, horizontal, stretch, pointer, groupId}: Construct, children: JsxValue) => {
+    ({root, style, appearance, horizontal, stretch, pointer, groupId}: MenuButtonProps, children: JsxValue) => {
         let current: Option<Menu> = Option.None
         const button: HTMLButtonElement = (
             <button
@@ -77,3 +94,14 @@ export const MenuButton =
         }
         return button
     }
+
+/** Property table for {@link MenuButton}. */
+export const MenuButtonPropTable = [
+    {prop: "root", type: "MenuItem", description: "Root menu item defining the hierarchy."},
+    {prop: "style", type: "Partial<CSSStyleDeclaration>", description: "Inline style for the button."},
+    {prop: "appearance", type: "MenuButtonAppearance", description: "Visual appearance options."},
+    {prop: "horizontal", type: '"left" | "right"', description: "Horizontal alignment for the menu."},
+    {prop: "stretch", type: "boolean", description: "Stretch button to fill space."},
+    {prop: "pointer", type: "boolean", description: "Show pointer cursor when hovering."},
+    {prop: "groupId", type: "string", description: "Group identifier for mutually exclusive menus."}
+] as const

--- a/packages/app/studio/src/ui/components/ParameterLabel.tsx
+++ b/packages/app/studio/src/ui/components/ParameterLabel.tsx
@@ -9,18 +9,27 @@ import {MIDILearning} from "@/midi/devices/MIDILearning"
 
 const className = Html.adoptStyleSheet(css, "ParameterLabel")
 
-type Construct = {
+/** Props for {@link ParameterLabel}. */
+export interface ParameterLabelProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Editing context used for undo/redo integration. */
     editing: Editing
+    /** MIDI learning helper. */
     midiLearning: MIDILearning
+    /** Owning device adapter. */
     adapter: DeviceBoxAdapter
+    /** Parameter represented by the label. */
     parameter: AutomatableParameterFieldAdapter
+    /** Draw a frame around the label. */
     framed?: boolean
+    /** Whether to attach a context menu standalone. */
     standalone?: boolean
 }
 
+/** Displays the current value of an automatable parameter. */
 export const ParameterLabel = (
-    {lifecycle, editing, midiLearning, adapter, parameter, framed, standalone}: Construct): HTMLLabelElement => {
+    {lifecycle, editing, midiLearning, adapter, parameter, framed, standalone}: ParameterLabelProps): HTMLLabelElement => {
     const element: HTMLLabelElement = (
         <label className={Html.buildClassList(className, framed && "framed")}/>
     )
@@ -43,3 +52,14 @@ export const ParameterLabel = (
     onValueChange(parameter)
     return element
 }
+
+/** Property table for {@link ParameterLabel}. */
+export const ParameterLabelPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "editing", type: "Editing", description: "Editing context for undo/redo."},
+    {prop: "midiLearning", type: "MIDILearning", description: "MIDI learn helper."},
+    {prop: "adapter", type: "DeviceBoxAdapter", description: "Owning device adapter."},
+    {prop: "parameter", type: "AutomatableParameterFieldAdapter", description: "Parameter displayed by the label."},
+    {prop: "framed", type: "boolean", description: "Draw a frame around the label."},
+    {prop: "standalone", type: "boolean", description: "Attach context menu standalone."}
+] as const

--- a/packages/app/studio/src/ui/components/ScrollModel.ts
+++ b/packages/app/studio/src/ui/components/ScrollModel.ts
@@ -1,5 +1,10 @@
 import {clamp, Notifier, Observer, Subscription, Terminable} from "@opendaw/lib-std"
 
+/**
+ * Model used by scroller components to keep track of content and viewport
+ * sizes and the current scroll position. Changes are observable to update
+ * associated views.
+ */
 export class ScrollModel implements Terminable {
     static readonly #MinThumbSize = 16.0
 
@@ -12,20 +17,23 @@ export class ScrollModel implements Terminable {
 
     constructor() {this.#notifier = new Notifier<ScrollModel>()}
 
+    /** Moves the view to an absolute position within the track. */
     moveTo(value: number): void {
         if (!this.scrollable()) {return}
         this.normalized = value / (this.#trackSize - this.thumbSize)
     }
 
+    /** Moves the view by a delta. */
     moveBy(delta: number): void {
         if (0.0 === delta || !this.scrollable()) {return}
         this.normalized = (this.#normalized + delta / (this.overflow))
     }
 
+    /** Subscribe to changes of the model. */
     subscribe(observer: Observer<ScrollModel>): Subscription {return this.#notifier.subscribe(observer)}
     terminate(): void {this.#notifier.terminate()}
 
-    // The size if the visible area of the underlying content
+    /** Size of the visible area of the underlying content. */
     set visibleSize(value: number) {
         if (this.#visibleSize === value) {return}
         this.#visibleSize = value
@@ -36,7 +44,7 @@ export class ScrollModel implements Terminable {
     }
     get visibleSize(): number {return this.#visibleSize}
 
-    // The size of the scroller's track
+    /** Size of the scroller's track. */
     set trackSize(value: number) {
         if (this.#trackSize === value) {return}
         this.#trackSize = value
@@ -44,7 +52,7 @@ export class ScrollModel implements Terminable {
     }
     get trackSize(): number {return this.#trackSize}
 
-    // The size of the underlying content
+    /** Total size of the underlying content. */
     set contentSize(value: number) {
         if (this.#contentSize === value) {return}
         this.#contentSize = value
@@ -55,7 +63,7 @@ export class ScrollModel implements Terminable {
     }
     get contentSize(): number {return this.#contentSize}
 
-    // the normalized thumb position
+    /** Normalized thumb position in the range [0,1]. */
     set normalized(value: number) {
         const clamped = !this.scrollable() ? 0.0 : clamp(value, 0.0, 1.0)
         if (this.#normalized === clamped) {return}
@@ -64,16 +72,21 @@ export class ScrollModel implements Terminable {
     }
     get normalized(): number {return this.#normalized}
 
+    /** Pixel position within the content. */
     set position(value: number) {
         if (!this.scrollable()) {return}
         this.normalized = value / (this.overflow)
     }
     get position() {return !this.scrollable() ? 0.0 : Math.floor(this.#normalized * this.overflow)}
 
+    /** Amount by which content exceeds the visible area. */
     get overflow() {return this.#contentSize - this.#visibleSize}
+    /** Position of the thumb in pixels. */
     get thumbPosition() {return this.#normalized * (this.#trackSize - this.#minThumbSize())}
+    /** Size of the thumb in pixels. */
     get thumbSize() {return !this.scrollable() ? this.#trackSize : this.#minThumbSize()}
 
+    /** Ensures that a given region is visible. */
     ensureVisibility(top: number, bottom: number): void {
         if (!this.scrollable()) {return}
         let min = this.position
@@ -87,6 +100,7 @@ export class ScrollModel implements Terminable {
         }
     }
 
+    /** Indicates if the content exceeds the visible area. */
     scrollable(): boolean {return this.#contentSize > this.#visibleSize}
 
     #minThumbSize(): number {

--- a/packages/app/studio/src/ui/components/TextInput.tsx
+++ b/packages/app/studio/src/ui/components/TextInput.tsx
@@ -5,14 +5,20 @@ import {createElement} from "@opendaw/lib-jsx"
 
 const defaultClassName = Html.adoptStyleSheet(css, "TextInput")
 
-type Construct = {
+/** Props for {@link TextInput}. */
+export interface TextInputProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Observable string model representing the value. */
     model: MutableObservableValue<string>
+    /** Additional CSS class name for the wrapper. */
     className?: string
+    /** Maximum number of characters allowed. */
     maxChars?: int
 }
 
-export const TextInput = ({lifecycle, model, className, maxChars}: Construct) => {
+/** Editable text field using a `contentEditable` element. */
+export const TextInput = ({lifecycle, model, className, maxChars}: TextInputProps) => {
     maxChars ??= 127
     const input: HTMLElement = (<div contentEditable="true" style={{width: "100%"}}/>)
     const element: HTMLElement = (
@@ -59,3 +65,11 @@ export const TextInput = ({lifecycle, model, className, maxChars}: Construct) =>
     update()
     return element
 }
+
+/** Property table for {@link TextInput}. */
+export const TextInputPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "model", type: "MutableObservableValue<string>", description: "Observable value bound to the input."},
+    {prop: "className", type: "string", description: "Additional CSS classes for the wrapper."},
+    {prop: "maxChars", type: "int", description: "Maximum number of characters allowed."}
+] as const

--- a/packages/app/studio/src/ui/components/TimeCodeInput.tsx
+++ b/packages/app/studio/src/ui/components/TimeCodeInput.tsx
@@ -6,16 +6,26 @@ import {Events, Html} from "@opendaw/lib-dom"
 
 const defaultClassName = Html.adoptStyleSheet(css, "TimeCodeInput")
 
-type Construct = {
+/** Props for {@link TimeCodeInput}. */
+export interface TimeCodeInputProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Observable model containing the time in PPQN. */
     model: MutableObservableValue<ppqn>
+    /** Additional CSS class name for the wrapper. */
     className?: string
+    /** Warn when the value becomes negative. */
     negativeWarning?: boolean
+    /** Optional time signature `[upper, lower]`. */
     signature?: [int, int]
+    /** Use one-based notation instead of zero-based. */
     oneBased?: boolean
 }
 
-export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, signature, oneBased}: Construct) => {
+/**
+ * Editable time-code input represented as bars, beats and ticks.
+ */
+export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, signature, oneBased}: TimeCodeInputProps) => {
     const upper = signature?.at(0) ?? 4
     const lower = signature?.at(1) ?? 4
     const units = [
@@ -134,3 +144,13 @@ export const TimeCodeInput = ({lifecycle, model, className, negativeWarning, sig
     updateDigits()
     return element
 }
+
+/** Property table for {@link TimeCodeInput}. */
+export const TimeCodeInputPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "model", type: "MutableObservableValue<ppqn>", description: "Observable time value."},
+    {prop: "className", type: "string", description: "Additional CSS class for the wrapper."},
+    {prop: "negativeWarning", type: "boolean", description: "Highlight when value is negative."},
+    {prop: "signature", type: "[int,int]", description: "Optional time signature."},
+    {prop: "oneBased", type: "boolean", description: "Use one-based display."}
+] as const

--- a/packages/app/studio/src/ui/components/TrackPeakMeter.tsx
+++ b/packages/app/studio/src/ui/components/TrackPeakMeter.tsx
@@ -7,8 +7,11 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "PeakVolumeSlider")
 
-type Construct = {
+/** Props for {@link TrackPeakMeter}. */
+export interface TrackPeakMeterProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Array of peak values per channel in decibels. */
     peaksInDb: Float32Array
 }
 
@@ -17,7 +20,8 @@ type Peak = {
     value: number
 }
 
-export const TrackPeakMeter = ({lifecycle, peaksInDb}: Construct) => {
+/** Visualises per-track peak levels using a canvas. */
+export const TrackPeakMeter = ({lifecycle, peaksInDb}: TrackPeakMeterProps) => {
     const canvas: HTMLCanvasElement = <canvas/>
     const mapping = ValueMapping.linear(-48, 9)
     const s0 = mapping.x(-12)
@@ -62,3 +66,9 @@ export const TrackPeakMeter = ({lifecycle, peaksInDb}: Construct) => {
     )
     return (<div className={className}>{canvas}</div>)
 }
+
+/** Property table for {@link TrackPeakMeter}. */
+export const TrackPeakMeterPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "peaksInDb", type: "Float32Array", description: "Peak values per channel in decibels."}
+] as const

--- a/packages/app/studio/src/ui/components/VolumeSlider.tsx
+++ b/packages/app/studio/src/ui/components/VolumeSlider.tsx
@@ -52,13 +52,18 @@ const markers: ReadonlyArray<{ length: MarkerLength, decibel: number }> = [
     {length: MarkerLength.Long, decibel: -96.0}
 ] as const
 
-type Construct = {
+/** Props for {@link VolumeSlider}. */
+export interface VolumeSliderProps {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Editing context to integrate with undo/redo. */
     editing: Editing
+    /** Parameter representing volume in decibels. */
     parameter: Parameter<number>
 }
 
-export const VolumeSlider = ({lifecycle, editing, parameter}: Construct) => {
+/** Vertical slider component displaying and controlling a volume parameter. */
+export const VolumeSlider = ({lifecycle, editing, parameter}: VolumeSliderProps) => {
     const strokeWidth = 1.0 / devicePixelRatio
     const guide: SVGRectElement = (
         <rect width="0.125em"
@@ -138,3 +143,10 @@ export const VolumeSlider = ({lifecycle, editing, parameter}: Construct) => {
     observer(parameter)
     return wrapper
 }
+
+/** Property table for {@link VolumeSlider}. */
+export const VolumeSliderPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "editing", type: "Editing", description: "Editing context for undo/redo."},
+    {prop: "parameter", type: "Parameter<number>", description: "Volume parameter controlled by the slider."}
+] as const

--- a/packages/app/studio/src/ui/pages/ComponentsPage.tsx
+++ b/packages/app/studio/src/ui/pages/ComponentsPage.tsx
@@ -2,7 +2,7 @@ import css from "./ComponentsPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"
 import {StudioService} from "@/service/StudioService.ts"
 import {Checkbox} from "@/ui/components/Checkbox.tsx"
-import {DefaultObservableValue, Option, panic, UUID} from "@opendaw/lib-std"
+import {DefaultObservableValue, Option, panic, UUID, DefaultParameter, ValueMapping, StringMapping} from "@opendaw/lib-std"
 import {Icon} from "@/ui/components/Icon.tsx"
 import {RadioGroup} from "@/ui/components/RadioGroup.tsx"
 import {Button} from "@/ui/components/Button.tsx"
@@ -18,13 +18,16 @@ import {VUMeterDesign} from "@/ui/meter/VUMeterDesign.tsx"
 import {IconSymbol} from "@opendaw/studio-adapters"
 import {dbToGain} from "@opendaw/lib-dsp"
 import {RootBox, TimelineBox} from "@opendaw/studio-boxes"
-import {BoxGraph} from "@opendaw/lib-box"
+import {BoxGraph, Editing} from "@opendaw/lib-box"
 import {BoxDebugView} from "../components/BoxDebugView"
 import {ProgressBar} from "@/ui/components/ProgressBar.tsx"
 import {TextInput} from "../components/TextInput"
 import {SearchInput} from "../components/SearchInput"
 import {Html} from "@opendaw/lib-dom"
 import {Colors} from "@opendaw/studio-core"
+import {Knob} from "@/ui/components/Knob.tsx"
+import {VolumeSlider} from "@/ui/components/VolumeSlider.tsx"
+import {TrackPeakMeter} from "@/ui/components/TrackPeakMeter.tsx"
 
 const className = Html.adoptStyleSheet(css, "ComponentsPage")
 
@@ -39,6 +42,15 @@ export const ComponentsPage: PageFactory<StudioService> = ({lifecycle}: PageCont
     })
     rootBox.timeline.refer(timelineBox.root)
     boxGraph.endTransaction()
+    const editing = new Editing(boxGraph)
+    const volumeParameter = new DefaultParameter<number>(
+        ValueMapping.linear(-96, 6),
+        StringMapping.decible,
+        "Volume",
+        -6
+    )
+    const knobParameter = DefaultParameter.percent("Knob", 0.5)
+    const peaks = new Float32Array([-6, -12, -24])
     return (
         <div className={className}>
             <div>
@@ -110,6 +122,10 @@ export const ComponentsPage: PageFactory<StudioService> = ({lifecycle}: PageCont
                     <TextInput lifecycle={lifecycle} model={new DefaultObservableValue("Text")}/>
                     <label>SearchField</label>
                     <SearchInput lifecycle={lifecycle} model={new DefaultObservableValue("")}/>
+                    <label>Knob</label>
+                    <Knob lifecycle={lifecycle} value={knobParameter} anchor={0.5}/>
+                    <label>Volume Slider</label>
+                    <VolumeSlider lifecycle={lifecycle} editing={editing} parameter={volumeParameter}/>
                     <label>Scroller</label>
                     <div style={{
                         width: "128px",
@@ -136,6 +152,7 @@ export const ComponentsPage: PageFactory<StudioService> = ({lifecycle}: PageCont
                     <div>
                         <VUMeterDesign.Default model={new DefaultObservableValue(dbToGain(-6))}/>
                         <VUMeterDesign.Modern model={new DefaultObservableValue(dbToGain(-6))}/>
+                        <TrackPeakMeter lifecycle={lifecycle} peaksInDb={peaks}/>
                     </div>
                 </div>
             </div>

--- a/packages/docs/docs-dev/ui/components/buttons.md
+++ b/packages/docs/docs-dev/ui/components/buttons.md
@@ -1,0 +1,4 @@
+# Buttons
+
+Interactive elements such as `Button` and `MenuButton` allow users to trigger actions or open menus.
+

--- a/packages/docs/docs-dev/ui/components/inputs.md
+++ b/packages/docs/docs-dev/ui/components/inputs.md
@@ -1,0 +1,4 @@
+# Inputs
+
+Input controls like `TextInput`, `NumberInput` and `TimeCodeInput` capture user data within the application.
+

--- a/packages/docs/docs-dev/ui/components/menus.md
+++ b/packages/docs/docs-dev/ui/components/menus.md
@@ -1,0 +1,4 @@
+# Menus
+
+Menu components such as `MenuButton` and `Menu` provide contextual options and navigation paths.
+

--- a/packages/docs/docs-dev/ui/components/meters.md
+++ b/packages/docs/docs-dev/ui/components/meters.md
@@ -1,0 +1,4 @@
+# Meters
+
+Visual feedback elements like `TrackPeakMeter` and the various VU meter designs display audio levels.
+

--- a/packages/docs/docs-dev/ui/components/overview.md
+++ b/packages/docs/docs-dev/ui/components/overview.md
@@ -1,0 +1,11 @@
+# Components Overview
+
+This section groups the UI components used within the studio.
+
+## Categories
+
+- [Buttons](./buttons.md)
+- [Inputs](./inputs.md)
+- [Menus](./menus.md)
+- [Meters](./meters.md)
+

--- a/packages/docs/docs-dev/ui/overview.md
+++ b/packages/docs/docs-dev/ui/overview.md
@@ -1,0 +1,4 @@
+# User Interface
+
+- [Components](./components/overview.md)
+


### PR DESCRIPTION
## Summary
- document UI components with TSDoc and prop tables
- expand ComponentsPage with knob, volume slider and peak meter examples
- add developer docs for UI components

## Testing
- `npm test` *(fails: Cannot find name 'PermissionState')*
- `npm run lint` *(fails: eslint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68aeabd116a48321825f18998d07bfff