### PR TITLE
docs: document info panel components

### DIFF
--- a/packages/app/studio/src/ui/info-panel/Cover.sass
+++ b/packages/app/studio/src/ui/info-panel/Cover.sass
@@ -1,8 +1,11 @@
 @use "@/mixins"
 
-// Styling for the project cover image with edit overlay.
-// Example:
-// <div class="Cover"><img/><span class="edit-icon"/></div>
+/**
+ * Styling for the project cover image with edit overlay.
+ *
+ * @example
+ * <div class="Cover"><img/><span class="edit-icon"/></div>
+ */
 component
   width: 100%
   aspect-ratio: 1 / 1

--- a/packages/app/studio/src/ui/info-panel/Cover.tsx
+++ b/packages/app/studio/src/ui/info-panel/Cover.tsx
@@ -1,18 +1,29 @@
-import css from "./Cover.sass?inline"
-import {EmptyExec, isDefined, Lifecycle, MutableObservableOption, panic} from "@opendaw/lib-std"
-import {createElement} from "@opendaw/lib-jsx"
-import {Icon} from "../components/Icon"
-import {IconSymbol} from "@opendaw/studio-adapters"
-import {showInfoDialog} from "@/ui/components/dialogs"
-import {Errors, Events, Files, Html} from "@opendaw/lib-dom"
-import {Promises} from "@opendaw/lib-runtime"
+import css from "./Cover.sass?inline";
+import {
+  EmptyExec,
+  isDefined,
+  Lifecycle,
+  MutableObservableOption,
+  panic,
+} from "@opendaw/lib-std";
+import { createElement } from "@opendaw/lib-jsx";
+import { Icon } from "../components/Icon";
+import { IconSymbol } from "@opendaw/studio-adapters";
+import { showInfoDialog } from "@/ui/components/dialogs";
+import { Errors, Events, Files, Html } from "@opendaw/lib-dom";
+import { Promises } from "@opendaw/lib-runtime";
 
-const className = Html.adoptStyleSheet(css, "Cover")
+const className = Html.adoptStyleSheet(css, "Cover");
 
+/**
+ * Construction options for {@link Cover}.
+ */
 type Construct = {
-    lifecycle: Lifecycle
-    model: MutableObservableOption<ArrayBuffer>
-}
+  /** Lifecycle manager for automatic cleanup. */
+  lifecycle: Lifecycle;
+  /** Observable image data for the cover art. */
+  model: MutableObservableOption<ArrayBuffer>;
+};
 
 /**
  * Displays and lets the user replace a project cover image.
@@ -22,42 +33,57 @@ type Construct = {
  * <Cover lifecycle={lifecycle} model={coverModel}/>
  * ```
  */
-export const Cover = ({lifecycle, model}: Construct) => {
-    const placeholder = "/cover.png"
-    const editIcon: Element = <Icon symbol={IconSymbol.EditBox} className="edit-icon"/>
-    const image: HTMLImageElement = (<img src={placeholder} alt="Cover"/>)
-    lifecycle.ownAll(
-        model.catchupAndSubscribe(owner => {
-            image.src = owner.match({
-                none: () => placeholder,
-                some: buffer => buffer.byteLength === 0 ? placeholder : URL.createObjectURL(new Blob([buffer]))
-            })
-        }),
-        Events.subscribe(editIcon, "click", async () => {
-            const {status, value, error} = await Promises.tryCatch(Files.open())
-            if (status === "rejected") {
-                if (!Errors.isAbort(error)) {return panic(String(error))}
-                return
-            }
-            const file = value?.at(0)
-            if (!isDefined(file)) {return}
-            if (file.size > (1 << 20) * 4) {
-                showInfoDialog({headline: "Cover", message: "Image is too large. Keep it below 4mb."}).catch(EmptyExec)
-                return
-            }
-            const fallback = image.src
-            image.onerror = () => {
-                image.onerror = null
-                image.src = fallback
-                showInfoDialog({headline: "Cover", message: `Unknown image format (${file.type}).`}).catch(EmptyExec)
-            }
-            model.wrap(await file.arrayBuffer())
-        })
-    )
-    return (
-        <div className={className}>
-            {editIcon}
-            {image}
-        </div>
-    )
-}
+export const Cover = ({ lifecycle, model }: Construct) => {
+  const placeholder = "/cover.png";
+  const editIcon: Element = (
+    <Icon symbol={IconSymbol.EditBox} className="edit-icon" />
+  );
+  const image: HTMLImageElement = <img src={placeholder} alt="Cover" />;
+  lifecycle.ownAll(
+    model.catchupAndSubscribe((owner) => {
+      image.src = owner.match({
+        none: () => placeholder,
+        some: (buffer) =>
+          buffer.byteLength === 0
+            ? placeholder
+            : URL.createObjectURL(new Blob([buffer])),
+      });
+    }),
+    Events.subscribe(editIcon, "click", async () => {
+      const { status, value, error } = await Promises.tryCatch(Files.open());
+      if (status === "rejected") {
+        if (!Errors.isAbort(error)) {
+          return panic(String(error));
+        }
+        return;
+      }
+      const file = value?.at(0);
+      if (!isDefined(file)) {
+        return;
+      }
+      if (file.size > (1 << 20) * 4) {
+        showInfoDialog({
+          headline: "Cover",
+          message: "Image is too large. Keep it below 4mb.",
+        }).catch(EmptyExec);
+        return;
+      }
+      const fallback = image.src;
+      image.onerror = () => {
+        image.onerror = null;
+        image.src = fallback;
+        showInfoDialog({
+          headline: "Cover",
+          message: `Unknown image format (${file.type}).`,
+        }).catch(EmptyExec);
+      };
+      model.wrap(await file.arrayBuffer());
+    }),
+  );
+  return (
+    <div className={className}>
+      {editIcon}
+      {image}
+    </div>
+  );
+};

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
@@ -1,8 +1,11 @@
 @use "@/colors"
 
-// Styles for the project metadata panel.
-// Example markup:
-// <div class="ProjectInfo"><div class="form">...</div></div>
+/**
+ * Styles for the project metadata panel.
+ *
+ * @example
+ * <div class="ProjectInfo"><div class="form">...</div></div>
+ */
 component
   flex: 1
   display: flex

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
@@ -1,16 +1,21 @@
-import css from "./ProjectInfo.sass?inline"
-import {Lifecycle, MutableObservableOption} from "@opendaw/lib-std"
-import {createElement} from "@opendaw/lib-jsx"
-import {StudioService} from "@/service/StudioService.ts"
-import {Cover} from "./Cover"
-import {Events, Html} from "@opendaw/lib-dom"
+import css from "./ProjectInfo.sass?inline";
+import { Lifecycle, MutableObservableOption } from "@opendaw/lib-std";
+import { createElement } from "@opendaw/lib-jsx";
+import { StudioService } from "@/service/StudioService.ts";
+import { Cover } from "./Cover";
+import { Events, Html } from "@opendaw/lib-dom";
 
-const className = Html.adoptStyleSheet(css, "ProjectInfo")
+const className = Html.adoptStyleSheet(css, "ProjectInfo");
 
+/**
+ * Construction options for {@link ProjectInfo}.
+ */
 type Construct = {
-    lifecycle: Lifecycle
-    service: StudioService
-}
+  /** Lifecycle manager for automatic cleanup. */
+  lifecycle: Lifecycle;
+  /** Service exposing the current project session. */
+  service: StudioService;
+};
 
 /**
  * Form component for editing project metadata and cover image.
@@ -20,55 +25,75 @@ type Construct = {
  * <ProjectInfo lifecycle={lifecycle} service={service}/>
  * ```
  */
-export const ProjectInfo = ({lifecycle, service}: Construct) => {
-    if (!service.hasProjectSession) {return "No session."}
-    const {session} = service
-    const {meta, cover} = session
-    const inputName: HTMLInputElement = (
-        <input type="text" className="default"
-               placeholder="Type in your's project name"
-               value={meta.name}/>
-    )
-    const inputTags: HTMLInputElement = (
-        <input type="text" className="default"
-               placeholder="Type in your's project tags"
-               value={meta.tags.join(", ")}/>
-    )
-    const inputDescription: HTMLTextAreaElement = (
-        <textarea className="default"
-                  placeholder="Type in your's project description"
-                  value={meta.description}/>
-    )
-    const coverModel = new MutableObservableOption<ArrayBuffer>(cover.unwrapOrUndefined())
-    const form: HTMLElement = (
-        <div className="form">
-            <div className="label">Name</div>
-            <label info="Maximum 128 characters">{inputName}</label>
-            <div className="label">Tags</div>
-            <label info="Separate tags with commas">{inputTags}</label>
-            <div className="label">Description</div>
-            <label info="Maximum 512 characters">{inputDescription}</label>
-            <div className="label">Cover</div>
-            <Cover lifecycle={lifecycle} model={coverModel}/>
-        </div>
-    )
-    lifecycle.ownAll(
-        Events.subscribe(form, "keydown", (event: KeyboardEvent) => {
-            if (event.code === "Enter" && event.target instanceof HTMLInputElement) {event.target.blur()}
-        }),
-        Events.subscribe(inputName, "blur",
-            () => session.updateMetaData("name", inputName.value)),
-        Events.subscribe(inputDescription, "blur",
-            () => session.updateMetaData("description", inputDescription.value)),
-        Events.subscribe(inputTags, "blur",
-            () => session.updateMetaData("tags", inputTags.value.split(",").map(x => x.trim()))),
-        Events.subscribe(inputName, "input", () => Html.limitChars(inputDescription, "value", 128)),
-        Events.subscribe(inputDescription, "input", () => Html.limitChars(inputDescription, "value", 512)),
-        coverModel.subscribe(owner => session.updateCover(owner))
-    )
-    return (
-        <div className={className}>
-            {form}
-        </div>
-    )
-}
+export const ProjectInfo = ({ lifecycle, service }: Construct) => {
+  if (!service.hasProjectSession) {
+    return "No session.";
+  }
+  const { session } = service;
+  const { meta, cover } = session;
+  const inputName: HTMLInputElement = (
+    <input
+      type="text"
+      className="default"
+      placeholder="Type in your's project name"
+      value={meta.name}
+    />
+  );
+  const inputTags: HTMLInputElement = (
+    <input
+      type="text"
+      className="default"
+      placeholder="Type in your's project tags"
+      value={meta.tags.join(", ")}
+    />
+  );
+  const inputDescription: HTMLTextAreaElement = (
+    <textarea
+      className="default"
+      placeholder="Type in your's project description"
+      value={meta.description}
+    />
+  );
+  const coverModel = new MutableObservableOption<ArrayBuffer>(
+    cover.unwrapOrUndefined(),
+  );
+  const form: HTMLElement = (
+    <div className="form">
+      <div className="label">Name</div>
+      <label info="Maximum 128 characters">{inputName}</label>
+      <div className="label">Tags</div>
+      <label info="Separate tags with commas">{inputTags}</label>
+      <div className="label">Description</div>
+      <label info="Maximum 512 characters">{inputDescription}</label>
+      <div className="label">Cover</div>
+      <Cover lifecycle={lifecycle} model={coverModel} />
+    </div>
+  );
+  lifecycle.ownAll(
+    Events.subscribe(form, "keydown", (event: KeyboardEvent) => {
+      if (event.code === "Enter" && event.target instanceof HTMLInputElement) {
+        event.target.blur();
+      }
+    }),
+    Events.subscribe(inputName, "blur", () =>
+      session.updateMetaData("name", inputName.value),
+    ),
+    Events.subscribe(inputDescription, "blur", () =>
+      session.updateMetaData("description", inputDescription.value),
+    ),
+    Events.subscribe(inputTags, "blur", () =>
+      session.updateMetaData(
+        "tags",
+        inputTags.value.split(",").map((x) => x.trim()),
+      ),
+    ),
+    Events.subscribe(inputName, "input", () =>
+      Html.limitChars(inputDescription, "value", 128),
+    ),
+    Events.subscribe(inputDescription, "input", () =>
+      Html.limitChars(inputDescription, "value", 512),
+    ),
+    coverModel.subscribe((owner) => session.updateCover(owner)),
+  );
+  return <div className={className}>{form}</div>;
+};

--- a/packages/app/studio/src/ui/info-panel/README.md
+++ b/packages/app/studio/src/ui/info-panel/README.md
@@ -1,0 +1,10 @@
+## Info Panel UI Module
+
+Components in this folder handle editing and previewing project metadata in
+openDAW. They include:
+
+- **ProjectInfo** – form for updating a project's name, tags and description.
+- **Cover** – widget that displays the project cover image and lets the user
+  choose a new one.
+
+Together these pieces provide the "Project Info" panel shown in the studio.

--- a/packages/docs/docs-dev/ui/info-panel/cover-art.md
+++ b/packages/docs/docs-dev/ui/info-panel/cover-art.md
@@ -1,0 +1,11 @@
+# Cover Art Component
+
+`Cover` shows the current project cover image and provides an overlay button to
+select a new image from the file system.
+
+## Usage
+
+```tsx
+const model = new MutableObservableOption<ArrayBuffer>(initialCover)
+<Cover lifecycle={lifecycle} model={model} />
+```

--- a/packages/docs/docs-dev/ui/info-panel/overview.md
+++ b/packages/docs/docs-dev/ui/info-panel/overview.md
@@ -1,0 +1,9 @@
+# Info Panel
+
+The info panel exposes basic project metadata such as name, tags and cover
+art.
+
+## Components
+
+- [Project Info](./project-info.md)
+- [Cover Art](./cover-art.md)

--- a/packages/docs/docs-dev/ui/info-panel/project-info.md
+++ b/packages/docs/docs-dev/ui/info-panel/project-info.md
@@ -1,0 +1,10 @@
+# Project Info Component
+
+`ProjectInfo` renders a small form that lets users edit the project's name,
+tags, description and cover image.
+
+## Usage
+
+```tsx
+<ProjectInfo lifecycle={lifecycle} service={service} />
+```

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -1,6 +1,8 @@
 # File Management
 
-Import, export, and organize project files. Developers can dive deeper in the [project docs](../../docs-dev/projects/overview.md).
+Import, export, and organize project files. Developers can dive deeper in the
+[project docs](../../docs-dev/projects/overview.md) and the
+[info panel reference](../../docs-dev/ui/info-panel/overview.md).
 
 ## Save Projects
 


### PR DESCRIPTION
## Summary
- add TSDoc and README for info panel components
- write developer docs for project info and cover art
- cross-link info panel docs from file management guide

## Testing
- `npm run lint` *(fails: command @opendaw/studio-core-workers#lint exited with 1)*
- `npm test` *(fails: @opendaw/studio-enums#build could not find PermissionState)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2c375bc8321a13d9d65a29ca08e