### PR TITLE
docs: add validator examples and docs

### DIFF
--- a/packages/app/studio/src/ui/validator/README.md
+++ b/packages/app/studio/src/ui/validator/README.md
@@ -1,0 +1,15 @@
+## Validator UI Module
+
+Utilities for validating user input in the Studio.
+
+- **validator.ts** – defines the generic `Validator` and `Result` interfaces.
+- **name.ts** – provides a `NameValidator` enforcing 1–64 character names.
+
+Use these helpers to ensure form components provide immediate feedback.
+
+```ts
+NameValidator.validate("Demo", {
+  success: (value) => console.log(value),
+  failure: () => console.error("Invalid"),
+});
+```

--- a/packages/app/studio/src/ui/validator/name.ts
+++ b/packages/app/studio/src/ui/validator/name.ts
@@ -1,14 +1,28 @@
-import {showInfoDialog} from "@/ui/components/dialogs.tsx"
-import {Result, Validator} from "./validator"
+import { showInfoDialog } from "@/ui/components/dialogs.tsx";
+import { Result, Validator } from "./validator";
 
+/**
+ * Validates that a name contains between 1 and 64 characters.
+ *
+ * @example
+ * ```ts
+ * NameValidator.validate("Project", {
+ *   success: value => console.log(value),
+ *   failure: () => console.error("Invalid name")
+ * })
+ * ```
+ */
 export const NameValidator: Validator<string> = {
-    validate: (value: string, match: Result<string>, origin?: Element): void => {
-        const trimmed = value.trim()
-        if (trimmed.length >= 1 && trimmed.length <= 64) {
-            match.success(trimmed)
-        } else {
-            match.failure?.call(null)
-            showInfoDialog({message: "A name must have one to 64 chararacters.", origin: origin})
-        }
+  validate: (value: string, match: Result<string>, origin?: Element): void => {
+    const trimmed = value.trim();
+    if (trimmed.length >= 1 && trimmed.length <= 64) {
+      match.success(trimmed);
+    } else {
+      match.failure?.();
+      showInfoDialog({
+        message: "A name must have one to 64 characters.",
+        origin,
+      });
     }
-}
+  },
+};

--- a/packages/app/studio/src/ui/validator/validator.ts
+++ b/packages/app/studio/src/ui/validator/validator.ts
@@ -1,10 +1,39 @@
-import {Exec, Procedure} from "@opendaw/lib-std"
+import { Exec, Procedure } from "@opendaw/lib-std";
 
+/**
+ * Result handlers passed to a {@link Validator}.
+ *
+ * @template T The value type.
+ * @example
+ * ```ts
+ * const result: Result<string> = {
+ *   success: value => console.log(value),
+ *   failure: () => console.error("Invalid value")
+ * }
+ * ```
+ */
 export interface Result<T> {
-    success: Procedure<T>
-    failure?: Exec
+  success: Procedure<T>;
+  failure?: Exec;
 }
 
+/**
+ * Validates a value and triggers matching result handlers.
+ *
+ * @template T The type of value to validate.
+ * @example
+ * ```ts
+ * const notEmpty: Validator<string> = {
+ *   validate: (value, match) => {
+ *     if (value) {
+ *       match.success(value)
+ *     } else {
+ *       match.failure?.()
+ *     }
+ *   }
+ * }
+ * ```
+ */
 export interface Validator<T> {
-    validate: (value: T, match: Result<T>, origin?: Element) => void
+  validate: (value: T, match: Result<T>, origin?: Element) => void;
 }

--- a/packages/docs/docs-dev/style/writing-guide.md
+++ b/packages/docs/docs-dev/style/writing-guide.md
@@ -3,10 +3,13 @@
 Use this guide when contributing documentation.
 
 ## Tips
+
 - Write in the second person and use active voice.
 - Keep sentences short—aim for 20 words or fewer.
 - Use the present tense and plain language.
 - Provide code fences for commands or snippets.
 - Link to related topics to help navigation.
+- Call out input constraints where validators apply, such as the name
+  validator used when creating projects.
 
 These practices align with our Markdown linting and Vale configuration.

--- a/packages/docs/docs-dev/ui/overview.md
+++ b/packages/docs/docs-dev/ui/overview.md
@@ -1,4 +1,4 @@
 # User Interface
 
 - [Components](./components/overview.md)
-
+- [Validator](./validator/overview.md)

--- a/packages/docs/docs-dev/ui/validator/overview.md
+++ b/packages/docs/docs-dev/ui/validator/overview.md
@@ -1,0 +1,5 @@
+# Validator
+
+Utilities for validating user input in Studio components.
+
+- [Patterns](./patterns.md)

--- a/packages/docs/docs-dev/ui/validator/patterns.md
+++ b/packages/docs/docs-dev/ui/validator/patterns.md
@@ -1,0 +1,26 @@
+# Validator Patterns
+
+Validators encapsulate form validation logic.
+
+## Basic usage
+
+```ts
+NameValidator.validate(input.value, {
+  success: (value) => console.log(value),
+  failure: () => alert("Invalid name"),
+});
+```
+
+## Creating custom validators
+
+```ts
+const NonEmpty: Validator<string> = {
+  validate: (value, match) => {
+    if (value.trim()) {
+      match.success(value);
+    } else {
+      match.failure?.();
+    }
+  },
+};
+```

--- a/packages/docs/docs-user/workflows/creating-projects.md
+++ b/packages/docs/docs-user/workflows/creating-projects.md
@@ -1,7 +1,9 @@
 # Creating Projects
 
 1. Open the Studio and choose **File → New Project**.
-2. Enter a project name when prompted and confirm to create it.
+2. Enter a project name when prompted and confirm to create it. The name
+   validator accepts 1–64 characters and displays a message if the input is
+   invalid.
 3. Use the **Project Browser** to manage and switch between saved projects.
 
 Projects are stored locally in your browser. Make sure to export regularly if


### PR DESCRIPTION
## Summary
- document Validator interfaces with examples
- add NameValidator README and developer docs
- reference validator usage in existing guides

## Testing
- `npm test` *(fails: Cannot find name 'PermissionState'; missing tsconfig)*
- `npm run lint` *(fails: eslint command failed for @opendaw/studio-core-workers)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2c5772483219f148668585ee9d6