### PR TITLE
docs: document canvas utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Accessibility Guide](packages/docs/docs-user/accessibility.md)
 - [Developer i18n Notes](packages/docs/docs-dev/i18n.md)
 - [Documentation Site Guide](packages/docs/docs-dev/documentation-site/overview.md)
+- [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/src/ui/canvas/README.md
+++ b/packages/app/studio/src/ui/canvas/README.md
@@ -1,0 +1,19 @@
+## Canvas Utilities
+
+Helpers in this folder abstract common canvas tasks used across the studio.
+
+### Coordinate Systems
+
+Rendering works with three coordinate spaces:
+
+- **Pixel** – actual device pixels used by the `2d` context.
+- **CSS** – logical pixel size of the canvas element.
+- **Unit** – domain values such as time or amplitude mapped through a `Scale`.
+
+`CanvasPainter` exposes the canvas size in both CSS and device pixels and
+handles resize events. `CanvasUnitPainter` builds on top by converting between
+unit values and pixels using separate scales for each axis. `Capturing` helpers
+translate mouse or pointer positions to these local coordinates.
+
+Together these utilities provide a consistent way to map application data to
+the canvas and react to user interaction.

--- a/packages/app/studio/src/ui/canvas/capturing.ts
+++ b/packages/app/studio/src/ui/canvas/capturing.ts
@@ -1,27 +1,61 @@
 import {Nullable} from "@opendaw/lib-std"
 
+/**
+ * Converts local coordinates into a captured value.
+ *
+ * Implementations typically perform hit testing and return either a value
+ * describing the hit target or `null` if nothing was captured.
+ */
 export interface Capturing<T> {capture(localX: number, localY: number): Nullable<T>}
 
+/**
+ * Associates a {@link Capturing} implementation with a DOM element and
+ * provides helpers to translate various pointer inputs into local coordinates.
+ */
 export class ElementCapturing<T> {
     readonly #element: Element
     readonly #capturing: Capturing<T>
 
+    /**
+     * @param element - The element whose bounds define the local coordinate
+     * system.
+     * @param capturing - Implementation performing the actual capture.
+     */
     constructor(element: Element, capturing: Capturing<T>) {
         this.#element = element
         this.#capturing = capturing
     }
 
+    /** DOM element associated with this capture helper. */
     get element(): Element {return this.#element}
+    /** Capture implementation. */
     get capturing(): Capturing<T> {return this.#capturing}
 
+    /**
+     * Captures a pointer event using its client coordinates.
+     *
+     * @param event - Event carrying `clientX`/`clientY` in viewport space.
+     */
     captureEvent(event: { clientX: number, clientY: number }): Nullable<T> {
         return this.capturePoint(event.clientX, event.clientY)
     }
 
+    /**
+     * Captures an arbitrary client‑space coordinate.
+     *
+     * @param clientX - X position in viewport space.
+     * @param clientY - Y position in viewport space.
+     */
     capturePoint(clientX: number, clientY: number): Nullable<T> {
         const {left, top} = this.#element.getBoundingClientRect()
         return this.captureLocalPoint(clientX - left, clientY - top)
     }
 
+    /**
+     * Captures a point in the element's local coordinate system.
+     *
+     * @param x - X position relative to the element's top‑left corner.
+     * @param y - Y position relative to the element's top‑left corner.
+     */
     captureLocalPoint(x: number, y: number): Nullable<T> {return this.#capturing.capture(x, y)}
 }

--- a/packages/app/studio/src/ui/canvas/painter.ts
+++ b/packages/app/studio/src/ui/canvas/painter.ts
@@ -2,31 +2,60 @@ import {asDefined, Exec, Procedure, Terminable, Terminator} from "@opendaw/lib-s
 import {Scale} from "@/ui/canvas/scale"
 import {AnimationFrame, Html} from "@opendaw/lib-dom"
 
+/**
+ * Paints to a canvas element and tracks its resize state.
+ *
+ * The caller supplies a render callback which is executed whenever an update
+ * is requested or the canvas size changes. Pixel dimensions are exposed for
+ * convenience.
+ */
 export class CanvasPainter implements Terminable {
     readonly #rendering: CanvasRenderer
 
+    /**
+     * @param canvas - Target canvas element.
+     * @param render - Function invoked to draw onto the canvas.
+     */
     constructor(canvas: HTMLCanvasElement, render: Procedure<CanvasPainter>) {
         this.#rendering = new CanvasRenderer(canvas, () => render(this))
     }
 
+    /** Queues a render pass on the next animation frame. */
     readonly requestUpdate = (): void => {this.#rendering.requestUpdate()}
 
+    /** Indicates whether the canvas size changed since the last render. */
     get isResized(): boolean {return this.#rendering.isResized}
+    /** Device pixel ratio used for rendering. */
     get devicePixelRatio(): number {return this.#rendering.devicePixelRatio}
+    /** CSS width of the canvas. */
     get width(): number {return this.#rendering.width}
+    /** CSS height of the canvas. */
     get height(): number {return this.#rendering.height}
+    /** Physical width in pixels. */
     get actualWidth(): number {return this.#rendering.actualWidth}
+    /** Physical height in pixels. */
     get actualHeight(): number {return this.#rendering.actualHeight}
+    /** 2D drawing context. */
     get context(): CanvasRenderingContext2D {return this.#rendering.context}
     terminate(): void {this.#rendering.terminate()}
 }
 
+/**
+ * Extension of {@link CanvasPainter} that maps between pixel and unit
+ * coordinates using {@link Scale} instances for each axis.
+ */
 export class CanvasUnitPainter implements Terminable {
     readonly #rendering: CanvasRenderer
 
     readonly #xAxis: Scale
     readonly #yAxis: Scale
 
+    /**
+     * @param canvas - Target canvas element.
+     * @param xAxis - Scale converting horizontal units to normalized values.
+     * @param yAxis - Scale converting vertical units to normalized values.
+     * @param render - Function invoked to draw using unit coordinates.
+     */
     constructor(canvas: HTMLCanvasElement,
                 xAxis: Scale,
                 yAxis: Scale,
@@ -36,11 +65,16 @@ export class CanvasUnitPainter implements Terminable {
         this.#yAxis = yAxis
     }
 
+    /** Queues a render pass on the next animation frame. */
     readonly requestUpdate = (): void => {this.#rendering.requestUpdate()}
 
+    /** Converts an X pixel coordinate to the corresponding unit value. */
     xToUnit(x: number): number {return this.#xAxis.normToUnit(x / this.#rendering.actualWidth)}
+    /** Converts a unit value to an X pixel coordinate. */
     unitToX(value: number): number {return this.#xAxis.unitToNorm(value) * this.#rendering.actualWidth}
+    /** Converts a Y pixel coordinate to the corresponding unit value. */
     yToUnit(y: number): number {return this.#yAxis.normToUnit(1.0 - y / this.#rendering.actualHeight)}
+    /** Converts a unit value to a Y pixel coordinate. */
     unitToY(value: number): number {return (1.0 - this.#yAxis.unitToNorm(value)) * this.#rendering.actualHeight}
     get context(): CanvasRenderingContext2D {return this.#rendering.context}
     get isResized(): boolean {return this.#rendering.isResized}
@@ -51,6 +85,7 @@ export class CanvasUnitPainter implements Terminable {
     terminate(): void {this.#rendering.terminate()}
 }
 
+/** Internal helper managing canvas resizing and render scheduling. */
 class CanvasRenderer implements Terminable {
     readonly #lifecycle = new Terminator()
 
@@ -89,13 +124,21 @@ class CanvasRenderer implements Terminable {
         )
     }
 
+    /** True if a size change triggered a new render. */
     get isResized(): boolean {return this.#isResized}
+    /** Device pixel ratio used for the last render. */
     get devicePixelRatio(): number {return this.#devicePixelRatio}
+    /** CSS width of the canvas. */
     get width(): number {return this.#width}
+    /** CSS height of the canvas. */
     get height(): number {return this.#height}
+    /** Physical width in pixels. */
     get actualWidth(): number {return this.#width * this.#devicePixelRatio}
+    /** Physical height in pixels. */
     get actualHeight(): number {return this.#height * this.#devicePixelRatio}
+    /** 2D drawing context. */
     get context(): CanvasRenderingContext2D {return this.#context}
+    /** Requests an update on the next animation frame. */
     requestUpdate(): void {this.#needsUpdate = true}
     terminate(): void {this.#lifecycle.terminate()}
 }

--- a/packages/app/studio/src/ui/canvas/scale.ts
+++ b/packages/app/studio/src/ui/canvas/scale.ts
@@ -1,16 +1,41 @@
 import {unitValue} from "@opendaw/lib-std"
 
+/**
+ * Maps between domain specific "unit" values and normalized `[0,1]` values.
+ *
+ * A {@link Scale} is used whenever drawing on a canvas requires translating
+ * arbitrary units—such as seconds or decibels—to a normalized coordinate
+ * system. Implementations must provide the forward and inverse conversion.
+ */
 export interface Scale {
+    /**
+     * Converts a unit value to its normalized representation.
+     *
+     * @param unit - Value in domain specific units.
+     * @returns The corresponding normalized value in the range `[0,1]`.
+     */
     unitToNorm(unit: number): unitValue
+
+    /**
+     * Converts a normalized value back into domain units.
+     *
+     * @param norm - Normalized value in the range `[0,1]`.
+     * @returns The value expressed in domain units.
+     */
     normToUnit(norm: unitValue): number
 }
 
+/** Linear mapping between unit and normalized coordinates. */
 export class LinearScale implements Scale {
     readonly #min: number
     readonly #max: number
     readonly #range: number
     readonly #rangeInv: number
 
+    /**
+     * @param min - Minimum unit value represented by `0`.
+     * @param max - Maximum unit value represented by `1`.
+     */
     constructor(min: number, max: number) {
         this.#min = min
         this.#max = max
@@ -18,13 +43,28 @@ export class LinearScale implements Scale {
         this.#rangeInv = 1.0 / this.#range
     }
 
+    /** Minimum unit value covered by this scale. */
     get min(): number {return this.#min}
+
+    /** Maximum unit value covered by this scale. */
     get max(): number {return this.#max}
 
+    /**
+     * Converts a normalized value to the corresponding unit value.
+     *
+     * @param norm - Normalized value in the range `[0,1]`.
+     */
     normToUnit(norm: number): number {return this.#min + norm * this.#range}
+
+    /**
+     * Converts a unit value into its normalized representation.
+     *
+     * @param unit - Value in domain specific units.
+     */
     unitToNorm(unit: number): number {return (unit - this.#min) * this.#rangeInv}
 }
 
+/** Logarithmic mapping between unit and normalized coordinates. */
 export class LogScale implements Scale {
     readonly #min: number
     readonly #max: number
@@ -32,6 +72,10 @@ export class LogScale implements Scale {
     readonly #logMin: number
     readonly #logRangeInv: number
 
+    /**
+     * @param min - Minimum unit value (>0) represented by `0`.
+     * @param max - Maximum unit value represented by `1`.
+     */
     constructor(min: number, max: number) {
         this.#min = min
         this.#max = max
@@ -40,9 +84,24 @@ export class LogScale implements Scale {
         this.#logRangeInv = 1.0 / (Math.log(max) - this.#logMin)
     }
 
+    /** Minimum unit value covered by this scale. */
     get min(): number {return this.#min}
+
+    /** Maximum unit value covered by this scale. */
     get max(): number {return this.#max}
 
+    /**
+     * Converts a normalized value to a unit value using a logarithmic curve.
+     *
+     * @param norm - Normalized value in the range `[0,1]`.
+     */
     normToUnit(norm: unitValue): number {return this.#min * Math.exp(norm * this.#range)}
+
+    /**
+     * Converts a unit value to its normalized representation on a logarithmic
+     * scale.
+     *
+     * @param unit - Value in domain specific units (>0).
+     */
     unitToNorm(unit: number): unitValue {return (Math.log(unit) - this.#logMin) * this.#logRangeInv}
 }

--- a/packages/docs/docs-dev/ui/canvas/capturing.md
+++ b/packages/docs/docs-dev/ui/canvas/capturing.md
@@ -1,0 +1,6 @@
+# Capturing
+
+The `Capturing` interface translates local coordinates into optional values.
+
+`ElementCapturing` couples a capturer with a DOM element, providing helpers to
+convert client or local points before invoking `capture`.

--- a/packages/docs/docs-dev/ui/canvas/overview.md
+++ b/packages/docs/docs-dev/ui/canvas/overview.md
@@ -1,0 +1,9 @@
+# Canvas Utilities
+
+Shared helpers for drawing and hit testing on HTML canvas elements.
+
+## Guides
+
+- [Scale](./scale.md)
+- [Painter](./painter.md)
+- [Capturing](./capturing.md)

--- a/packages/docs/docs-dev/ui/canvas/painter.md
+++ b/packages/docs/docs-dev/ui/canvas/painter.md
@@ -1,0 +1,7 @@
+# Painter
+
+`CanvasPainter` schedules rendering and tracks canvas size. Use its
+`requestUpdate` method to redraw on resize or state changes.
+
+`CanvasUnitPainter` adds unit-to-pixel conversion via separate `Scale`
+instances for each axis, enabling direct drawing in application units.

--- a/packages/docs/docs-dev/ui/canvas/scale.md
+++ b/packages/docs/docs-dev/ui/canvas/scale.md
@@ -1,0 +1,7 @@
+# Scale
+
+Translate between domain units and normalized `[0,1]` values.
+
+`LinearScale` maps units linearly while `LogScale` maps exponentially for
+values like frequency. Both implement the `Scale` interface with `unitToNorm`
+and `normToUnit` methods.

--- a/packages/docs/docs-dev/ui/overview.md
+++ b/packages/docs/docs-dev/ui/overview.md
@@ -1,4 +1,5 @@
 # User Interface
 
 - [Components](./components/overview.md)
+- [Canvas](./canvas/overview.md)
 

--- a/packages/docs/docs-user/features/timeline.md
+++ b/packages/docs/docs-user/features/timeline.md
@@ -15,3 +15,20 @@ Use the loop brace and time axis to scroll or set the play range.
 Enable snapping to align edits to the musical grid.
 
 ![Timeline snapping menu](./img/timeline-snapping.png)
+
+## Example Integration
+
+```ts
+import {CanvasUnitPainter, LinearScale} from "@opendaw/app-studio/ui/canvas";
+
+const painter = new CanvasUnitPainter(
+    canvas,
+    new LinearScale(0, timeline.length),
+    new LinearScale(0, 1),
+    p => {
+        const ctx = p.context;
+        ctx.clearRect(0, 0, p.actualWidth, p.actualHeight);
+        // draw custom timeline markers here
+    }
+);
+```


### PR DESCRIPTION
## Summary
- add TSDoc for canvas scale, painter, and capturing helpers
- document canvas coordinate systems and utilities in dev docs
- link canvas docs from overview and add timeline integration example

## Testing
- `npm test` *(fails: Could not resolve workspaces / build failed)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2c9d59083218b05af332a6aa3d5