### PR TITLE
docs: document bundled fonts and licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+The font files `rubik.woff2` and `OpenSans-Regular.ttf` located in `packages/app/studio/public/fonts` are licensed under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL). These fonts are distributed under their own licenses and are not covered by the MIT License above. See `packages/app/studio/public/fonts/README.md` for details.

--- a/README.md
+++ b/README.md
@@ -213,3 +213,5 @@ participate, visit our [Contribute](https://opendaw.org/contribute) page.
 
 This project is licensed under the [MIT License](LICENSE)
 
+The bundled fonts (`rubik.woff2` and `OpenSans-Regular.ttf` in packages/app/studio/public/fonts) are provided under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL). See [fonts/README.md](packages/app/studio/public/fonts/README.md) for details.
+

--- a/packages/app/studio/public/fonts/README.md
+++ b/packages/app/studio/public/fonts/README.md
@@ -1,0 +1,10 @@
+# Fonts
+
+This directory contains the font files bundled with openDAW.
+
+- `rubik.woff2` – [Rubik](https://fonts.google.com/specimen/Rubik) distributed under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL).
+- `OpenSans-Regular.ttf` – [Open Sans](https://fonts.google.com/specimen/Open+Sans) distributed under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL).
+
+These files are used by the studio UI and loaded via `src/ui/Fonts.ts`.
+
+If you add or replace fonts, ensure that the license is compatible and update this document accordingly.

--- a/packages/docs/docs-dev/style/fonts.md
+++ b/packages/docs/docs-dev/style/fonts.md
@@ -1,0 +1,14 @@
+# Fonts
+
+The studio bundles its fonts in [`packages/app/studio/public/fonts`](../../../packages/app/studio/public/fonts).
+
+- `rubik.woff2` – Rubik (SIL Open Font License 1.1).
+- `OpenSans-Regular.ttf` – Open Sans (SIL Open Font License 1.1).
+
+Fonts are declared in [`src/ui/Fonts.ts`](../../../packages/app/studio/src/ui/Fonts.ts) and loaded at runtime by `FontLoader`.
+
+When adding or replacing fonts:
+
+1. Add the font file to `public/fonts`.
+2. Register it in `src/ui/Fonts.ts`.
+3. Document its origin and license in [`public/fonts/README.md`](../../../packages/app/studio/public/fonts/README.md).

--- a/packages/docs/docs-user/style-customization.md
+++ b/packages/docs/docs-user/style-customization.md
@@ -4,6 +4,9 @@ openDAW's appearance can be adjusted by overriding the CSS variables defined in
 [`colors.sass`](../../../packages/app/studio/src/colors.sass). Variables and
 class names use kebab-case such as `--color-green` or `.help-section`.
 
+
+The default UI uses the **Rubik** and **Open Sans** typefaces from [`packages/app/studio/public/fonts`](../../../packages/app/studio/public/fonts). These fonts are provided under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL). Replace these files or override the CSS `font-family` to customize text appearance.
+
 To create a custom theme:
 
 1. Fork or clone the repository.


### PR DESCRIPTION
## Summary
- document bundled Rubik and Open Sans fonts with licensing notes
- add developer and user documentation on customizing fonts
- reference font licensing in LICENSE and README

## Testing
- `npm test` *(fails: npm error command sh -c vitest run)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2cc609c832197c9125bd02f3dbb