### PR TITLE
docs: document viscious speed assets

### DIFF
--- a/packages/app/studio/public/viscious-speed/README.md
+++ b/packages/app/studio/public/viscious-speed/README.md
@@ -1,0 +1,142 @@
+# Viscious Speed SVGs
+
+This folder contains abstract SVG images used in the studio dashboard.
+
+## Available SVGs
+
+* abstract-000.svg
+* abstract-001.svg
+* abstract-002.svg
+* abstract-003.svg
+* abstract-004.svg
+* abstract-005.svg
+* abstract-006.svg
+* abstract-007.svg
+* abstract-008.svg
+* abstract-009.svg
+* abstract-010.svg
+* abstract-011.svg
+* abstract-012.svg
+* abstract-013.svg
+* abstract-014.svg
+* abstract-015.svg
+* abstract-016.svg
+* abstract-017.svg
+* abstract-018.svg
+* abstract-019.svg
+* abstract-020.svg
+* abstract-021.svg
+* abstract-022.svg
+* abstract-023.svg
+* abstract-024.svg
+* abstract-025.svg
+* abstract-026.svg
+* abstract-027.svg
+* abstract-028.svg
+* abstract-029.svg
+* abstract-030.svg
+* abstract-031.svg
+* abstract-032.svg
+* abstract-033.svg
+* abstract-034.svg
+* abstract-035.svg
+* abstract-036.svg
+* abstract-037.svg
+* abstract-038.svg
+* abstract-039.svg
+* abstract-040.svg
+* abstract-041.svg
+* abstract-042.svg
+* abstract-043.svg
+* abstract-044.svg
+* abstract-045.svg
+* abstract-046.svg
+* abstract-047.svg
+* abstract-048.svg
+* abstract-049.svg
+* abstract-050.svg
+* abstract-051.svg
+* abstract-052.svg
+* abstract-053.svg
+* abstract-054.svg
+* abstract-055.svg
+* abstract-056.svg
+* abstract-057.svg
+* abstract-058.svg
+* abstract-059.svg
+* abstract-060.svg
+* abstract-061.svg
+* abstract-062.svg
+* abstract-063.svg
+* abstract-064.svg
+* abstract-065.svg
+* abstract-066.svg
+* abstract-067.svg
+* abstract-068.svg
+* abstract-069.svg
+* abstract-070.svg
+* abstract-071.svg
+* abstract-072.svg
+* abstract-073.svg
+* abstract-074.svg
+* abstract-075.svg
+* abstract-076.svg
+* abstract-077.svg
+* abstract-078.svg
+* abstract-079.svg
+* abstract-080.svg
+* abstract-081.svg
+* abstract-082.svg
+* abstract-083.svg
+* abstract-084.svg
+* abstract-085.svg
+* abstract-086.svg
+* abstract-087.svg
+* abstract-088.svg
+* abstract-089.svg
+* abstract-090.svg
+* abstract-091.svg
+* abstract-092.svg
+* abstract-093.svg
+* abstract-094.svg
+* abstract-095.svg
+* abstract-096.svg
+* abstract-097.svg
+* abstract-098.svg
+* abstract-099.svg
+* abstract-100.svg
+* abstract-101.svg
+* abstract-102.svg
+* abstract-103.svg
+* abstract-104.svg
+* abstract-105.svg
+* abstract-106.svg
+* abstract-107.svg
+* abstract-108.svg
+* abstract-109.svg
+* abstract-110.svg
+* abstract-111.svg
+* abstract-112.svg
+* abstract-113.svg
+* abstract-114.svg
+* abstract-115.svg
+* abstract-116.svg
+* abstract-117.svg
+* abstract-118.svg
+* abstract-119.svg
+* abstract-120.svg
+* abstract-121.svg
+
+## Source diagrams
+
+Draw.io source files are provided for selected assets:
+
+* abstract-000.drawio
+* abstract-036.drawio
+* abstract-072.drawio
+* abstract-108.drawio
+* abstract-120.drawio
+
+## License
+
+The SVG images and source diagrams are distributed under the [MIT License](../../../LICENSE).

--- a/packages/app/studio/public/viscious-speed/abstract-000.drawio
+++ b/packages/app/studio/public/viscious-speed/abstract-000.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="abstract-000">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" parent="1" vertex="1" style="shape=image;html=1;image=abstract-000.svg">
+          <mxGeometry width="256" height="256" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/packages/app/studio/public/viscious-speed/abstract-036.drawio
+++ b/packages/app/studio/public/viscious-speed/abstract-036.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="abstract-036">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" parent="1" vertex="1" style="shape=image;html=1;image=abstract-036.svg">
+          <mxGeometry width="256" height="256" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/packages/app/studio/public/viscious-speed/abstract-072.drawio
+++ b/packages/app/studio/public/viscious-speed/abstract-072.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="abstract-072">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" parent="1" vertex="1" style="shape=image;html=1;image=abstract-072.svg">
+          <mxGeometry width="256" height="256" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/packages/app/studio/public/viscious-speed/abstract-108.drawio
+++ b/packages/app/studio/public/viscious-speed/abstract-108.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="abstract-108">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" parent="1" vertex="1" style="shape=image;html=1;image=abstract-108.svg">
+          <mxGeometry width="256" height="256" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/packages/app/studio/public/viscious-speed/abstract-120.drawio
+++ b/packages/app/studio/public/viscious-speed/abstract-120.drawio
@@ -1,0 +1,13 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="abstract-120">
+    <mxGraphModel>
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+        <mxCell id="2" parent="1" vertex="1" style="shape=image;html=1;image=abstract-120.svg">
+          <mxGeometry width="256" height="256" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/packages/app/studio/src/main.sass
+++ b/packages/app/studio/src/main.sass
@@ -149,3 +149,9 @@ input[type="range"]
 @keyframes spinner_STY6
   100%
     transform: rotate(360deg)
+
+// Example background using Viscious Speed art
+.viscious-speed-sample
+  width: 64px
+  height: 64px
+  background: url("/viscious-speed/abstract-000.svg") no-repeat center/cover

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -5,6 +5,10 @@ openDAW is composed of several packages such as
 [`@opendaw/studio-core`](../package-inventory.md#studio). The architecture is
 described using the C4 model.
 
+Static assets like the abstract SVG set in
+`packages/app/studio/public/viscious-speed` are bundled with the app; see that
+folder's README for a complete list and licensing details.
+
 ## Context
 
 ```mermaid

--- a/packages/docs/docs-user/ui-tour.md
+++ b/packages/docs/docs-user/ui-tour.md
@@ -7,6 +7,10 @@ open additional tooling such as the mixer or project browser.
 The tour walks through the default layout and highlights common entry points
 for editing audio, managing devices and browsing samples.
 
+The interface uses abstract SVG art from the
+`packages/app/studio/public/viscious-speed` collection; see that folder's
+README for the full catalogue and licensing terms.
+
 Get oriented with the main areas of the interface.
 
 ## Transport


### PR DESCRIPTION
## Summary
- document viscious speed SVG set and licensing
- add draw.io sources for selected icons
- reference assets in docs and example SASS usage

## Testing
- `npm test` *(fails: File '@opendaw/typescript-config/base.json' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2cd8d108321a89b5d6f0728ac4e