### PR TITLE
docs: document persistence and session utilities

### DIFF
--- a/docs-user/features/file-management.md
+++ b/docs-user/features/file-management.md
@@ -1,0 +1,20 @@
+# File Management
+
+openDAW stores projects and audio samples in the browser's origin private file system (OPFS). Projects can be saved under custom names, exported as portable bundles and re‑imported later.
+
+## Saving projects
+
+Use **Save** to persist the current project, or **Save As** to create a copy under a new name. Each project consists of a `.od` file containing the arrangement plus a metadata file and optional cover image.
+
+## Exporting bundles
+
+Bundles package a project together with all referenced samples into a single `.odb` archive. This makes it easy to move projects between machines. Choose **Export Bundle** to create the archive and download it to disk.
+
+## Importing bundles
+
+Select **Import Bundle** to load an `.odb` archive. Samples and project data are written into OPFS and a new session is created.
+
+## Removing samples
+
+Unused samples can be deleted from storage via the sample browser. openDAW will warn when a sample is still referenced by a project.
+

--- a/packages/app/studio/src/project/ProjectMeta.ts
+++ b/packages/app/studio/src/project/ProjectMeta.ts
@@ -18,6 +18,7 @@ export type ProjectMeta = {
     notepad?: string
 } & JSONValue
 
+/** Utilities for working with {@link ProjectMeta} objects. */
 export namespace ProjectMeta {
     const created = new Date().toISOString()
 

--- a/packages/app/studio/src/project/ProjectSession.ts
+++ b/packages/app/studio/src/project/ProjectSession.ts
@@ -94,13 +94,17 @@ export class ProjectSession {
         }
     }
 
+    /** Whether the session has been written to persistent storage. */
     saved(): boolean {return this.#saved}
+    /** Indicates if project or metadata changes are pending. */
     hasChanges(): boolean {return this.#hasChanges}
 
+    /** Subscribe to metadata updates. */
     subscribeMetaData(observer: Observer<ProjectMeta>): Subscription {
         return this.#metaUpdated.subscribe(observer)
     }
 
+    /** Subscribe to metadata updates and immediately receive the current value. */
     catchSubscribeMetaData(observer: Observer<ProjectMeta>): Subscription {
         observer(this.meta)
         return this.subscribeMetaData(observer)
@@ -124,14 +128,20 @@ export class ProjectSession {
         this.#metaUpdated.notify(this.meta)
     }
 
+    /** Update the modification timestamp. */
     updateModifyDate(): void {this.meta.modified = new Date().toISOString()}
 
+    /** Persist the current MIDI learn configuration to local storage. */
     saveMidiConfiguration(): void {
         const key = UUID.toString(this.#uuid)
         console.debug(`saveMidiConfiguration(${key})`)
         this.#service.midiLearning.saveToLocalStorage(key)
     }
 
+    /**
+     * Load the MIDI learn configuration and optionally prompt to connect
+     * a device if mappings are present.
+     */
     async loadMidiConfiguration(): Promise<void> {
         const key = UUID.toString(this.#uuid)
         const hasMidi = this.#service.midiLearning.loadFromLocalStorage(key)
@@ -149,6 +159,7 @@ export class ProjectSession {
         }
     }
 
+    /** String representation for debugging. */
     toString(): string {
         return `{uuid: ${UUID.toString(this.uuid)}, meta: ${JSON.stringify(this.meta)}}`
     }

--- a/packages/app/studio/src/project/Projects.ts
+++ b/packages/app/studio/src/project/Projects.ts
@@ -36,6 +36,7 @@ export namespace ProjectPaths {
     export const projectFolder = (uuid: UUID.Format): string => `${Folder}/${UUID.toString(uuid)}`
 }
 
+/** Functions for persisting and transferring projects. */
 export namespace Projects {
     /**
      * Store the given project and its metadata.

--- a/packages/app/studio/src/project/SampleUtils.ts
+++ b/packages/app/studio/src/project/SampleUtils.ts
@@ -16,6 +16,10 @@ export namespace SampleUtils {
      * Ensure all audio file boxes reference existing samples and prompt the
      * user to replace missing ones.
      *
+     * @param boxGraph Graph containing the boxes to inspect.
+     * @param importer Utility used to load replacement samples.
+     * @param audioManager Manager responsible for caching sample data.
+     *
      * @example
      * ```ts
      * await SampleUtils.verify(project.boxGraph, importer, manager)

--- a/packages/app/studio/src/ui/browse/SampleService.ts
+++ b/packages/app/studio/src/ui/browse/SampleService.ts
@@ -26,7 +26,12 @@ export class SampleService {
   readonly #service: StudioService;
   readonly #selection: HTMLSelection;
 
-  /** Create a new SampleService bound to a studio service and selection. */
+  /**
+   * Create a new SampleService bound to a studio service and selection.
+   *
+   * @param service underlying studio service.
+   * @param selection helper exposing the current DOM selection.
+   */
   constructor(service: StudioService, selection: HTMLSelection) {
     this.#service = service;
     this.#selection = selection;
@@ -79,12 +84,17 @@ export class SampleService {
   }
 
   /** Delete all currently selected samples. */
-  async deleteSelected() {
+  async deleteSelected(): Promise<void> {
     return this.deleteSamples(...this.#samples());
   }
 
-  /** Delete the given samples after checking their usage and confirmation. */
-  async deleteSamples(...samples: ReadonlyArray<Sample>) {
+  /**
+   * Delete the given samples after checking their usage and asking for
+   * confirmation.
+   *
+   * @param samples samples to remove from local storage.
+   */
+  async deleteSamples(...samples: ReadonlyArray<Sample>): Promise<void> {
     const processDialog = showProcessDialog(
       "Checking Sample Usages",
       new DefaultObservableValue(0.5),

--- a/packages/docs/docs-dev/architecture/persistence.md
+++ b/packages/docs/docs-dev/architecture/persistence.md
@@ -1,0 +1,22 @@
+# Persistence
+
+openDAW stores project data and samples in the browser using the Origin Private File System (OPFS). Each project resides in its own folder under `projects/v1/<uuid>` containing:
+
+- `project.od` – serialized project graph
+- `meta.json` – metadata such as title and tags
+- `image.bin` – optional cover image
+
+Sample files referenced by projects are managed via `SampleStorage` and can be packaged together with a project into a distributable bundle. Bundles are standard ZIP archives with a `uuid` marker and a `samples/` folder holding audio data.
+
+The `Projects` utility provides functions for reading and writing these artifacts as well as creating and importing bundles.
+
+```mermaid
+flowchart TD
+    subgraph OPFS
+      P[project.od]
+      M[meta.json]
+      I[image.bin]
+    end
+    P -->|references| S[SampleStorage]
+```
+

--- a/packages/docs/docs-dev/testing/test-files.md
+++ b/packages/docs/docs-dev/testing/test-files.md
@@ -11,3 +11,7 @@ cover common scenarios and are used across packages for development and regressi
 | `automation.dawproject` | Includes parameter automation curves. |
 | `audio-regions.dawproject` | Contains audio regions with linked media. |
 | `bitwig.example.xml` | Minimal Bitwig project used for parser tests. |
+
+See the [persistence overview](../architecture/persistence.md) for how project files
+are stored and the [file management guide](../../../../docs-user/features/file-management.md)
+for user-level instructions.

--- a/packages/lib/std/src/cache.ts
+++ b/packages/lib/std/src/cache.ts
@@ -1,22 +1,35 @@
 import {Exec, Nullable, Provider} from "./lang"
 import {Terminable} from "./terminable"
 
-/** Simple lazy-initialising cache backed by a provider function. */
+/**
+ * Lazily caches the result of a provider function.
+ *
+ * The provider is invoked on the first call to {@link get} and the
+ * resulting value is stored until {@link invalidate} or {@link terminate}
+ * is called. The class implements {@link Terminable} so it can be
+ * integrated into larger lifecycles.
+ *
+ * @typeParam T – Type of value produced by the provider.
+ */
 export class Cache<T> implements Terminable {
     readonly #provider: Provider<T>
 
     #value: Nullable<T> = null
 
+    /** Create a cache backed by the given provider. */
     constructor(provider: Provider<T>) {this.#provider = provider}
 
-    /** Clears the cached value. */
+    /** Clears the cached value so the provider will be invoked again. */
     readonly invalidate: Exec = () => this.#value = null
 
-    /** Returns the cached value, invoking the provider on first access. */
+    /**
+     * Retrieve the cached value, invoking the provider on first access.
+     */
     get(): T {
         if (this.#value === null) {this.#value = this.#provider()}
         return this.#value
     }
 
+    /** @inheritDoc */
     terminate(): void {this.invalidate()}
 }


### PR DESCRIPTION
## Summary
- add persistence architecture notes and user file management guide
- document project/session helpers and sample management
- cross-link testing docs to new guides

## Testing
- `npm test` (fails: TS18028 private identifiers only available when targeting ES2015)
- `npm run lint` (fails: command sh -c eslint "**/*.ts")


------
https://chatgpt.com/codex/tasks/task_b_68aeb2d4c1488321b78ebd32705ca2d5