### PR TITLE
docs: document cross-origin isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Accessibility Guide](packages/docs/docs-user/accessibility.md)
 - [Developer i18n Notes](packages/docs/docs-dev/i18n.md)
 - [Documentation Site Guide](packages/docs/docs-dev/documentation-site/overview.md)
+- [Cross-Origin Isolation Guide](packages/docs/docs-dev/build-and-run/cross-origin-isolation.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/index.html
+++ b/packages/app/studio/index.html
@@ -1,8 +1,11 @@
 <!doctype html>
 <!-- Entry point for the OpenDAW Studio application -->
-<!-- Security note: COOP and COEP headers below isolate the app from other
-     browsing contexts. Serve this page over HTTPS and avoid untrusted script
-     injections. -->
+<!--
+  Security note: COOP and COEP headers (mirrored here with meta tags) isolate
+  the app from other browsing contexts so `window.crossOriginIsolated` is true.
+  Serve this page over HTTPS and avoid untrusted script injections. See
+  docs-dev/build-and-run/cross-origin-isolation.md for more information.
+-->
 <html lang="en" translate="no">
 <head>
 	<meta charset="UTF-8">

--- a/packages/app/studio/package.json
+++ b/packages/app/studio/package.json
@@ -1,4 +1,5 @@
 {
+  "//": "Package manifest for the Studio app; includes a plugin to enable cross-origin isolation in development.",
   "name": "@opendaw/app-studio",
   "private": true,
   "version": "0.0.20",

--- a/packages/app/studio/src/AppDialogs.tsx
+++ b/packages/app/studio/src/AppDialogs.tsx
@@ -1,3 +1,9 @@
+/**
+ * Dialog helpers shown during application start-up.
+ *
+ * The exported functions are invoked from `main.ts` to request
+ * browser-specific permissions that keep data available across sessions.
+ */
 import {Dialog} from "@/ui/components/Dialog"
 import { IconSymbol } from "@opendaw/studio-adapters"
 import {Surface} from "@/ui/surface/Surface"

--- a/packages/app/studio/src/main.ts
+++ b/packages/app/studio/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * Application bootstrap for the OpenDAW Studio front end.
+ *
+ * The page must be served with cross-origin isolation headers (COOP/COEP)
+ * so that `window.crossOriginIsolated` is true and WebAssembly threads and
+ * AudioWorklets can run. See `docs-dev/build-and-run/cross-origin-isolation.md`.
+ */
 import "./main.sass"
 import {App} from "@/ui/App.tsx"
 import {panic, Procedure, unitValue, UUID} from "@opendaw/lib-std"
@@ -30,6 +37,7 @@ window.name = "main"
 const loadBuildInfo = async () => fetch(`/build-info.json?v=${Date.now()}`).then(x => x.json().then(x => x as BuildInfo))
 
 requestAnimationFrame(async () => {
+        // Abort early if the required COOP/COEP headers are missing.
         if (!window.crossOriginIsolated) {return panic("window must be crossOriginIsolated")}
         console.debug("booting...")
         WorkerAgents.install(WorkersUrl)

--- a/packages/app/studio/src/vite-plugin-cross-origin-isolation.d.ts
+++ b/packages/app/studio/src/vite-plugin-cross-origin-isolation.d.ts
@@ -1,8 +1,12 @@
 /**
  * Type declaration for the `vite-plugin-cross-origin-isolation` package.
  *
- * The plugin enables cross-origin isolation headers during development so
- * that features like WebAssembly threads work as expected.
+ * The plugin injects the `Cross-Origin-Opener-Policy` and
+ * `Cross-Origin-Embedder-Policy` headers into Vite's dev server so the
+ * Studio runs in a `crossOriginIsolated` context. This is required for
+ * advanced Web APIs such as `SharedArrayBuffer` and WebAssembly threads.
+ * See the developer documentation in
+ * `docs-dev/build-and-run/cross-origin-isolation.md` for details.
  */
 declare module 'vite-plugin-cross-origin-isolation' {
     import { Plugin } from 'vite'

--- a/packages/app/studio/vite.config.ts
+++ b/packages/app/studio/vite.config.ts
@@ -9,6 +9,8 @@
 import { readFileSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import { defineConfig } from "vite";
+// Adds the necessary COOP/COEP headers so the app runs in a
+// `crossOriginIsolated` context during development.
 import crossOriginIsolation from "vite-plugin-cross-origin-isolation";
 import viteCompression from "vite-plugin-compression";
 import { BuildInfo } from "./src/BuildInfo";
@@ -58,6 +60,7 @@ export default defineConfig(({ command }) => {
             }
           : undefined,
       headers: {
+        // These headers enable cross-origin isolation in supported browsers.
         "Cross-Origin-Opener-Policy": "same-origin",
         "Cross-Origin-Embedder-Policy": "require-corp",
       },
@@ -67,6 +70,7 @@ export default defineConfig(({ command }) => {
       },
     },
     plugins: [
+      // Apply the cross-origin isolation headers via a dedicated plugin.
       crossOriginIsolation(),
       viteCompression({
         algorithm: "brotliCompress",

--- a/packages/docs/docs-dev/build-and-run/cross-origin-isolation.md
+++ b/packages/docs/docs-dev/build-and-run/cross-origin-isolation.md
@@ -1,0 +1,18 @@
+# Cross-Origin Isolation
+
+openDAW relies on a [cross-origin isolated](https://developer.mozilla.org/docs/Web/API/Window/crossOriginIsolated) environment to unlock advanced Web APIs such as `SharedArrayBuffer`, WebAssembly threads and AudioWorklets. During development this isolation is provided by the `vite-plugin-cross-origin-isolation` package.
+
+## Development
+
+- The Studio's `vite.config.ts` installs the plugin and sets the `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` headers.
+- `index.html` mirrors these headers with matching `<meta>` tags to keep `window.crossOriginIsolated` true.
+- Start the dev server with `npm run dev:studio` and navigate to `https://localhost:8080`.
+- In the browser console, verify that `window.crossOriginIsolated === true` before continuing.
+
+## Why it matters
+
+Without cross-origin isolation the browser blocks features required for real‑time audio processing. If `window.crossOriginIsolated` is `false` the application will terminate early.
+
+## Browser support
+
+Chromium based browsers and Firefox support the required headers. Safari currently lacks full cross-origin isolation support and therefore cannot run the Studio reliably. See the [user browser support guide](../../docs-user/browser-support.md) for up-to-date information.

--- a/packages/docs/docs-user/browser-support.md
+++ b/packages/docs/docs-user/browser-support.md
@@ -1,6 +1,10 @@
 # Browser Support
 
-openDAW runs in current versions of Chrome, Firefox, Safari, and Edge (Chromium).
+openDAW runs in current versions of Chrome, Firefox, and Edge (Chromium).
+Safari currently lacks the cross‑origin isolation features required for
+`SharedArrayBuffer` and WebAssembly threads, so the Studio does not yet run
+there.
+
 For the best experience, keep your browser up to date. Some features—such as
 MIDI access or advanced file APIs—may be limited depending on the browser.
 Refer to the [developer browser support](../docs-dev/browser-support.md) for


### PR DESCRIPTION
## Summary
- explain cross-origin isolation usage in Studio and reference new developer guide
- clarify browser requirement in user docs and add link in README

## Testing
- `npm test` *(fails: command exited 2)*
- `npm run lint` *(fails: command exited 1)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2d527a483218ed7d908bab0a60c