### PR TITLE
docs: add debugging docs and comments

### DIFF
--- a/packages/app/studio/src/errors/ErrorHandler.ts
+++ b/packages/app/studio/src/errors/ErrorHandler.ts
@@ -1,14 +1,14 @@
 /**
  * Captures global errors and reports them to the logging service.
  */
-import {EmptyExec, Terminable, Terminator, Warning} from "@opendaw/lib-std"
-import {AnimationFrame, Browser, Events} from "@opendaw/lib-dom"
-import {LogBuffer} from "@/errors/LogBuffer.ts"
-import {ErrorLog} from "@/errors/ErrorLog.ts"
-import {ErrorInfo} from "@/errors/ErrorInfo.ts"
-import {Surface} from "@/ui/surface/Surface.tsx"
-import {StudioService} from "@/service/StudioService.ts"
-import {showErrorDialog, showInfoDialog} from "@/ui/components/dialogs.tsx"
+import { EmptyExec, Terminable, Terminator, Warning } from "@opendaw/lib-std";
+import { AnimationFrame, Browser, Events } from "@opendaw/lib-dom";
+import { LogBuffer } from "@/errors/LogBuffer.ts";
+import { ErrorLog } from "@/errors/ErrorLog.ts";
+import { ErrorInfo } from "@/errors/ErrorInfo.ts";
+import { Surface } from "@/ui/surface/Surface.tsx";
+import { StudioService } from "@/service/StudioService.ts";
+import { showErrorDialog, showInfoDialog } from "@/ui/components/dialogs.tsx";
 
 /**
  * Global error handler for the Studio. Captures unexpected errors and
@@ -25,6 +25,13 @@ export class ErrorHandler {
     this.#service = service;
   }
 
+  /**
+   * Handles an error event by reporting it and showing a dialog.
+   *
+   * @param scope - Human-readable scope of the failing component.
+   * @param event - The captured error event.
+   * @returns `true` if the handler considers the error handled.
+   */
   processError(scope: string, event: Event): boolean {
     if ("reason" in event && event.reason instanceof Warning) {
       showInfoDialog({
@@ -75,6 +82,12 @@ export class ErrorHandler {
     return true;
   }
 
+  /**
+   * Installs global listeners on the given owner to catch uncaught errors.
+   *
+   * @param owner - Window or worker to attach listeners to.
+   * @param scope - Descriptive name of the owner for reporting.
+   */
   install(
     owner: WindowProxy | Worker | AudioWorkletNode,
     scope: string,

--- a/packages/app/studio/src/errors/ErrorInfo.ts
+++ b/packages/app/studio/src/errors/ErrorInfo.ts
@@ -1,7 +1,7 @@
 /**
  * Helpers to normalize error information from various event types.
  */
-import {isDefined} from "@opendaw/lib-std"
+import { isDefined } from "@opendaw/lib-std";
 
 /** Normalized representation of diverse error events. */
 export type ErrorInfo = {
@@ -11,6 +11,11 @@ export type ErrorInfo = {
 };
 
 export namespace ErrorInfo {
+  /**
+   * Derives a normalized {@link ErrorInfo} from a variety of error event types.
+   *
+   * @param event - The raw event raised by the platform.
+   */
   export const extract = (event: Event): ErrorInfo => {
     if (event instanceof ErrorEvent && event.error instanceof Error) {
       return {

--- a/packages/app/studio/src/errors/ErrorLog.ts
+++ b/packages/app/studio/src/errors/ErrorLog.ts
@@ -1,17 +1,23 @@
 /**
  * Structured payload sent when reporting an error.
  */
-import {int} from "@opendaw/lib-std"
-import {BuildInfo} from "@/BuildInfo.ts"
-import {LogBuffer} from "@/errors/LogBuffer.ts"
-import {ErrorInfo} from "@/errors/ErrorInfo.ts"
+import { int } from "@opendaw/lib-std";
+import { BuildInfo } from "@/BuildInfo.ts";
+import { LogBuffer } from "@/errors/LogBuffer.ts";
+import { ErrorInfo } from "@/errors/ErrorInfo.ts";
 
 /** Payload sent when reporting runtime errors from the Studio. */
 export type ErrorLog = {
+  /** ISO timestamp when the error was captured. */
   date: string;
+  /** Browser user agent of the reporter. */
   agent: string;
+  /** Build information for the running application. */
   build: BuildInfo;
+  /** Number of script tags present on the page. */
   scripts: int;
+  /** Normalized error information. */
   error: ErrorInfo;
+  /** Recent console log entries captured before the error. */
   logs: Array<LogBuffer.Entry>;
 };

--- a/packages/app/studio/src/errors/LogBuffer.ts
+++ b/packages/app/studio/src/errors/LogBuffer.ts
@@ -1,13 +1,14 @@
 /**
  * Captures recent console output for inclusion in error reports.
  */
-import {int} from "@opendaw/lib-std"
+import { int } from "@opendaw/lib-std";
 
 /**
  * Captures a bounded history of console messages in production so they can be
  * sent along with error reports.
  */
 export namespace LogBuffer {
+  /** Single console log entry preserved for debugging. */
   export type Entry = {
     time: number;
     level: "debug" | "info" | "warn";
@@ -90,5 +91,6 @@ export namespace LogBuffer {
       original.warn.apply(console, args);
     };
   }
+  /** Retrieves the buffered log entries. */
   export const get = () => logBuffer;
 }

--- a/packages/app/studio/src/ui/menu/debug.ts
+++ b/packages/app/studio/src/ui/menu/debug.ts
@@ -1,8 +1,21 @@
-import {Box} from "@opendaw/lib-box"
-import {MenuItem} from "@/ui/model/menu-item.ts"
-import {showDebugBoxDialog} from "@/ui/components/dialogs.tsx"
+import { Box } from "@opendaw/lib-box";
+import { MenuItem } from "@/ui/model/menu-item.ts";
+import { showDebugBoxDialog } from "@/ui/components/dialogs.tsx";
 
+/**
+ * Menu helpers exposing development diagnostics.
+ */
 export namespace DebugMenus {
-    export const debugBox = (box: Box, separatorBefore: boolean = true) =>
-        MenuItem.default({label: "Debug Box", separatorBefore}).setTriggerProcedure(() => showDebugBoxDialog(box))
+  /**
+   * Creates a menu item that opens a dialog showing detailed information
+   * about a given box.
+   *
+   * @param box - The box to inspect.
+   * @param separatorBefore - Whether to insert a separator before the item.
+   */
+  export const debugBox = (box: Box, separatorBefore: boolean = true) =>
+    MenuItem.default({
+      label: "Debug Box",
+      separatorBefore,
+    }).setTriggerProcedure(() => showDebugBoxDialog(box));
 }

--- a/packages/app/studio/src/ui/pages/ErrorsPage.sass
+++ b/packages/app/studio/src/ui/pages/ErrorsPage.sass
@@ -1,4 +1,4 @@
-// Styles for the error diagnostics page.
+// Styles for the error diagnostics page that lists server-reported issues.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/pages/ErrorsPage.tsx
+++ b/packages/app/studio/src/ui/pages/ErrorsPage.tsx
@@ -1,99 +1,146 @@
 /**
  * Displays aggregated error reports and associated logs.
  */
-import css from "./ErrorsPage.sass?inline"
-import {Await, createElement, Group, PageContext, PageFactory} from "@opendaw/lib-jsx"
-import {StudioService} from "@/service/StudioService.ts"
-import {Html} from "@opendaw/lib-dom"
-import {EmptyExec, Strings, TimeSpan} from "@opendaw/lib-std"
-import {showDialog} from "@/ui/components/dialogs.tsx"
-import {LogBuffer} from "@/errors/LogBuffer.ts"
-import {Logs} from "@/ui/pages/errors/Logs.tsx"
-import {Stack} from "@/ui/pages/errors/Stack.tsx"
+import css from "./ErrorsPage.sass?inline";
+import {
+  Await,
+  createElement,
+  Group,
+  PageContext,
+  PageFactory,
+} from "@opendaw/lib-jsx";
+import { StudioService } from "@/service/StudioService.ts";
+import { Html } from "@opendaw/lib-dom";
+import { EmptyExec, Strings, TimeSpan } from "@opendaw/lib-std";
+import { showDialog } from "@/ui/components/dialogs.tsx";
+import { LogBuffer } from "@/errors/LogBuffer.ts";
+import { Logs } from "@/ui/pages/errors/Logs.tsx";
+import { Stack } from "@/ui/pages/errors/Stack.tsx";
 
-const className = Html.adoptStyleSheet(css, "ErrorsPage")
+const className = Html.adoptStyleSheet(css, "ErrorsPage");
 
+/** Server-provided record describing a single reported error. */
 type Entry = {
-    id: string
-    date: string
-    user_agent: string
-    build_uuid: string
-    build_env: string
-    build_date: string
-    script_tags: string
-    error_name: string
-    error_message: string
-    error_stack: string
-    logs: string
-    fixed: number
-}
+  id: string;
+  date: string;
+  user_agent: string;
+  build_uuid: string;
+  build_env: string;
+  build_date: string;
+  script_tags: string;
+  error_name: string;
+  error_message: string;
+  error_stack: string;
+  logs: string;
+  fixed: number;
+};
 
-export const ErrorsPage: PageFactory<StudioService> = ({}: PageContext<StudioService>) => {
-    return (
-        <div className={className}>
-            <h1>Errors</h1>
-            <p>This page shows all errors reported from users running openDAW in production, helping us identify and fix
-                issues.</p>
-            <Await factory={() => fetch(`https://logs.opendaw.studio/list.php`).then(x => x.json())}
-                   failure={(error) => `Unknown request (${error.reason})`}
-                   loading={() => <p>loading...</p>}
-                   success={(json: ReadonlyArray<Entry>) => (
-                       <div className="list">
-                           <Group>
-                               <h4>#</h4>
-                               <h4>Time</h4>
-                               <h4>Build</h4>
-                               <h4>Type</h4>
-                               <h4>Message</h4>
-                               <h4>JS</h4>
-                               <h4>Browser</h4>
-                               <h4>Stack</h4>
-                               <h4>Logs</h4>
-                               <h4>Fixed</h4>
-                           </Group>
-                           {json.map((entry: Entry) => {
-                                   const nowTime = new Date().getTime()
-                                   const errorTime = new Date(entry.date).getTime()
-                                   const errorTimeString = TimeSpan.millis(errorTime - nowTime).toUnitString()
-                                   const buildTimeString = TimeSpan.millis(new Date(entry.build_date).getTime() - nowTime).toUnitString()
-                                   const userAgent = entry.user_agent.replace(/^Mozilla\/[\d.]+\s*/, "")
-                                   const errorMessage = Strings.fallback(entry.error_message, "No message")
-                                   return (
-                                       <div className={Html.buildClassList("row", entry.fixed === 1 && "fixed")}>
-                                           <div>{entry.id}</div>
-                                           <div>{errorTimeString}</div>
-                                           <div>{buildTimeString}</div>
-                                           <div>{entry.error_name}</div>
-                                           <div className="error-message" title={errorMessage}>{errorMessage}</div>
-                                           <div>{entry.script_tags}</div>
-                                           <div className="browser" title={userAgent}>{userAgent}</div>
-                                           <div style={{cursor: "pointer"}}
-                                                onclick={() => showDialog({
-                                                    headline: "Error Stack",
-                                                    content: (<Stack stack={entry.error_stack}/>)
-                                                }).catch(EmptyExec)}>
-                                               📂
-                                           </div>
-                                           <div style={{cursor: "pointer"}}
-                                                onclick={() => {
-                                                    const entries = JSON.parse(entry.logs) as Array<LogBuffer.Entry>
-                                                    return showDialog({
-                                                        headline: "Logs",
-                                                        content: (
-                                                            <Logs errorTime={errorTime}
-                                                                  entries={entries.reverse()}/>
-                                                        )
-                                                    }).catch(EmptyExec)
-                                                }}>
-                                               📂
-                                           </div>
-                                           <div>{entry.fixed ? "Yes 👍" : "No 🙄"}</div>
-                                       </div>
-                                   )
-                               }
-                           )}
-                       </div>
-                   )}/>
-        </div>
-    )
-}
+/**
+ * Lists error reports submitted from production builds along with
+ * their associated log buffers.
+ */
+export const ErrorsPage: PageFactory<
+  StudioService
+> = ({}: PageContext<StudioService>) => {
+  return (
+    <div className={className}>
+      <h1>Errors</h1>
+      <p>
+        This page shows all errors reported from users running openDAW in
+        production, helping us identify and fix issues.
+      </p>
+      <Await
+        factory={() =>
+          fetch(`https://logs.opendaw.studio/list.php`).then((x) => x.json())
+        }
+        failure={(error) => `Unknown request (${error.reason})`}
+        loading={() => <p>loading...</p>}
+        success={(json: ReadonlyArray<Entry>) => (
+          <div className="list">
+            <Group>
+              <h4>#</h4>
+              <h4>Time</h4>
+              <h4>Build</h4>
+              <h4>Type</h4>
+              <h4>Message</h4>
+              <h4>JS</h4>
+              <h4>Browser</h4>
+              <h4>Stack</h4>
+              <h4>Logs</h4>
+              <h4>Fixed</h4>
+            </Group>
+            {json.map((entry: Entry) => {
+              const nowTime = new Date().getTime();
+              const errorTime = new Date(entry.date).getTime();
+              const errorTimeString = TimeSpan.millis(
+                errorTime - nowTime,
+              ).toUnitString();
+              const buildTimeString = TimeSpan.millis(
+                new Date(entry.build_date).getTime() - nowTime,
+              ).toUnitString();
+              const userAgent = entry.user_agent.replace(
+                /^Mozilla\/[\d.]+\s*/,
+                "",
+              );
+              const errorMessage = Strings.fallback(
+                entry.error_message,
+                "No message",
+              );
+              return (
+                <div
+                  className={Html.buildClassList(
+                    "row",
+                    entry.fixed === 1 && "fixed",
+                  )}
+                >
+                  <div>{entry.id}</div>
+                  <div>{errorTimeString}</div>
+                  <div>{buildTimeString}</div>
+                  <div>{entry.error_name}</div>
+                  <div className="error-message" title={errorMessage}>
+                    {errorMessage}
+                  </div>
+                  <div>{entry.script_tags}</div>
+                  <div className="browser" title={userAgent}>
+                    {userAgent}
+                  </div>
+                  <div
+                    style={{ cursor: "pointer" }}
+                    onclick={() =>
+                      showDialog({
+                        headline: "Error Stack",
+                        content: <Stack stack={entry.error_stack} />,
+                      }).catch(EmptyExec)
+                    }
+                  >
+                    📂
+                  </div>
+                  <div
+                    style={{ cursor: "pointer" }}
+                    onclick={() => {
+                      const entries = JSON.parse(
+                        entry.logs,
+                      ) as Array<LogBuffer.Entry>;
+                      return showDialog({
+                        headline: "Logs",
+                        content: (
+                          <Logs
+                            errorTime={errorTime}
+                            entries={entries.reverse()}
+                          />
+                        ),
+                      }).catch(EmptyExec);
+                    }}
+                  >
+                    📂
+                  </div>
+                  <div>{entry.fixed ? "Yes 👍" : "No 🙄"}</div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      />
+    </div>
+  );
+};

--- a/packages/app/studio/src/ui/pages/GraphPage.sass
+++ b/packages/app/studio/src/ui/pages/GraphPage.sass
@@ -1,4 +1,4 @@
-// Styles for the project graph visualization page.
+// Styles for the page that visualizes the project's box graph.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/pages/GraphPage.tsx
+++ b/packages/app/studio/src/ui/pages/GraphPage.tsx
@@ -1,65 +1,91 @@
 /**
  * Visualizes the current project's box graph for diagnostics.
  */
-import css from "./GraphPage.sass?inline"
-import {Await, createElement, DomElement, Frag, PageContext, PageFactory} from "@opendaw/lib-jsx"
-import {Html} from "@opendaw/lib-dom"
-import type {StudioService} from "@/service/StudioService.ts"
-import {GraphData} from "./graph-runtime"
-import {ThreeDots} from "@/ui/spinner/ThreeDots"
-import {UUID} from "@opendaw/lib-std"
-import {Colors} from "@opendaw/studio-core"
-import {RootBox} from "@opendaw/studio-boxes"
+import css from "./GraphPage.sass?inline";
+import {
+  Await,
+  createElement,
+  DomElement,
+  Frag,
+  PageContext,
+  PageFactory,
+} from "@opendaw/lib-jsx";
+import { Html } from "@opendaw/lib-dom";
+import type { StudioService } from "@/service/StudioService.ts";
+import { GraphData } from "./graph-runtime";
+import { ThreeDots } from "@/ui/spinner/ThreeDots";
+import { UUID } from "@opendaw/lib-std";
+import { Colors } from "@opendaw/studio-core";
+import { RootBox } from "@opendaw/studio-boxes";
 
-const className = Html.adoptStyleSheet(css, "GraphPage")
+const className = Html.adoptStyleSheet(css, "GraphPage");
 
-export const GraphPage: PageFactory<StudioService> = ({lifecycle, service}: PageContext<StudioService>) => {
-    const element: DomElement = (
-        <div className={className}>
-            {service.sessionService.getValue().match({
-                none: () => (
-                    <Frag>
-                        <h1>Graph</h1>
-                        <p onclick={() => service.closeProject()}
-                           style={{color: Colors.dark, cursor: "pointer"}}>Open a project first...</p>
-                    </Frag>
+/**
+ * Renders an interactive graph of the current project, exposing box
+ * relationships for diagnostics.
+ */
+export const GraphPage: PageFactory<StudioService> = ({
+  lifecycle,
+  service,
+}: PageContext<StudioService>) => {
+  const element: DomElement = (
+    <div className={className}>
+      {service.sessionService.getValue().match({
+        none: () => (
+          <Frag>
+            <h1>Graph</h1>
+            <p
+              onclick={() => service.closeProject()}
+              style={{ color: Colors.dark, cursor: "pointer" }}
+            >
+              Open a project first...
+            </p>
+          </Frag>
+        ),
+        some: ({ project, meta }) => (
+          <Await
+            factory={() => import("./graph-runtime")}
+            failure={({ reason }) => <p>{reason}</p>}
+            loading={() => <ThreeDots />}
+            success={({ createGraphPanel, GRAPH_INTERACTION_HINT }) => {
+              const stripBoxSuffix = (label?: string) =>
+                label?.endsWith("Box") ? label.slice(0, -3) : label;
+              const boxes = project.boxGraph.boxes();
+              const data: GraphData = {
+                nodes: boxes.map((box) => ({
+                  id: UUID.toString(box.address.uuid),
+                  label: stripBoxSuffix(box.name),
+                  root: box instanceof RootBox,
+                })),
+                edges: boxes.flatMap((box) =>
+                  box.outgoingEdges().map(([pointer, address]) => ({
+                    source: UUID.toString(pointer.box.address.uuid),
+                    target: UUID.toString(address.uuid),
+                  })),
                 ),
-                some: ({project, meta}) => (
-                    <Await factory={() => import("./graph-runtime")}
-                           failure={({reason}) => (<p>{reason}</p>)}
-                           loading={() => (<ThreeDots/>)}
-                           success={({createGraphPanel, GRAPH_INTERACTION_HINT}) => {
-                               const stripBoxSuffix = (label?: string) =>
-                                   label?.endsWith("Box")
-                                       ? label.slice(0, -3)
-                                       : label
-                               const boxes = project.boxGraph.boxes()
-                               const data: GraphData = {
-                                   nodes: boxes.map(box => ({
-                                       id: UUID.toString(box.address.uuid),
-                                       label: stripBoxSuffix(box.name),
-                                       root: box instanceof RootBox
-                                   })),
-                                   edges: boxes.flatMap(box => box.outgoingEdges().map(([pointer, address]) => ({
-                                       source: UUID.toString(pointer.box.address.uuid),
-                                       target: UUID.toString(address.uuid)
-                                   })))
-                               }
-                               const container = (<div className="wrapper"/>)
-                               const controller = createGraphPanel(container, data, {dark: true})
-                               lifecycle.own(controller)
-                               lifecycle.own(Html.watchResize(element, () => controller.resize()))
-                               return (
-                                   <Frag>
-                                       <h1>Graph '{meta.name}'</h1>
-                                       <p style={{fontSize: "0.75em", color: Colors.dark}}>{GRAPH_INTERACTION_HINT}</p>
-                                       {container}
-                                   </Frag>
-                               )
-                           }}/>
-                )
-            })}
-        </div>
-    )
-    return element
-}
+              };
+              const container = <div className="wrapper" />;
+              const controller = createGraphPanel(container, data, {
+                dark: true,
+              });
+              lifecycle.own(controller);
+              lifecycle.own(
+                Html.watchResize(element, () => controller.resize()),
+              );
+              return (
+                <Frag>
+                  <h1>Graph '{meta.name}'</h1>
+                  <p style={{ fontSize: "0.75em", color: Colors.dark }}>
+                    {GRAPH_INTERACTION_HINT}
+                  </p>
+                  {container}
+                </Frag>
+              );
+            }}
+          />
+        ),
+      })}
+    </div>
+  );
+  return element;
+};

--- a/packages/docs/docs-dev/debugging/error-logging.md
+++ b/packages/docs/docs-dev/debugging/error-logging.md
@@ -1,0 +1,5 @@
+# Error Logging
+
+The Studio installs a global `ErrorHandler` that listens for uncaught errors and rejected promises. When triggered it gathers a normalized `ErrorInfo`, the current `BuildInfo`, and recent console output from the `LogBuffer`.
+
+In production these details are serialized into an `ErrorLog` payload and sent to the logging service. The report can then be reviewed on the dedicated errors page inside the Studio.

--- a/packages/docs/docs-dev/debugging/graph-runtime.md
+++ b/packages/docs/docs-dev/debugging/graph-runtime.md
@@ -1,0 +1,3 @@
+# Graph Runtime
+
+An optional debugging page renders the current project's box graph using a runtime module. It loads `graph-runtime` on demand and visualizes boxes as nodes and their connections as edges. The view helps track signal flow and spot unexpected wiring.

--- a/packages/docs/docs-dev/debugging/overview.md
+++ b/packages/docs/docs-dev/debugging/overview.md
@@ -1,0 +1,6 @@
+# Debugging Overview
+
+openDAW provides a set of utilities to help developers diagnose problems during development and in production.
+
+- [Error logging](error-logging.md) describes how runtime issues are captured and reported.
+- [Graph runtime](graph-runtime.md) explains the interactive graph view used to inspect box connections.

--- a/packages/docs/docs-user/troubleshooting.md
+++ b/packages/docs/docs-user/troubleshooting.md
@@ -40,3 +40,6 @@
 
 - When an unexpected error dialog appears, note the steps that led to the
   issue and send them to support using the built-in error report template.
+
+- Developers looking to diagnose issues in depth can consult the
+  [debugging guide](/dev/debugging/overview).

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -12,6 +12,15 @@ module.exports = {
     { type: "doc", id: "browser-support" },
     {
       type: "category",
+      label: "Debugging",
+      items: [
+        "debugging/overview",
+        "debugging/error-logging",
+        "debugging/graph-runtime",
+      ],
+    },
+    {
+      type: "category",
       label: "Configuration",
       items: ["configuration/eslint"],
     },
@@ -92,7 +101,7 @@ module.exports = {
             "ui/timeline/performance",
           ],
         },
-        "ui/browse"
+        "ui/browse",
       ],
     },
     {
@@ -119,8 +128,10 @@ module.exports = {
             { type: "doc", id: "ui/piano-roll/faq" },
           ],
         },
-  "ui/mixer"
-},{
+        "ui/mixer",
+      ],
+    },
+    {
       type: "category",
       label: "Services",
       items: [


### PR DESCRIPTION
## Summary
- document debugging utilities for developers
- improve error handling comments and docs
- link user troubleshooting to new debugging guides

## Testing
- `npm test` *(fails: command exited (2))*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2d5abb883219af59e1b997587ac