### PR TITLE
docs: document design tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 
 - [Style Guidelines](styles/OpenDAW/style-guidelines.md)
 - [Developer Style Guide](packages/docs/docs-dev/style-guide.md)
+- [Design Tokens](packages/docs/docs-dev/style/design-tokens.md)
 - [User Style Customization](packages/docs/docs-user/style-customization.md)
 - [Writing Guide](packages/docs/docs-dev/style/writing-guide.md)
 

--- a/packages/app/studio/src/colors.sass
+++ b/packages/app/studio/src/colors.sass
@@ -1,39 +1,43 @@
 // Color palette variables; see styles/OpenDAW/style-guidelines.md
 \:root
   color-scheme: dark
-  --color-blue: hsl(189, 100%, 65%)
-  --color-green: hsl(150, 77%, 69%)
-  --color-yellow: hsl(60, 100%, 84%)
-  --color-cream: hsl(65, 27%, 83%)
-  --color-red: hsl(354, 100%, 73%)
-  --color-orange: hsl(31, 100%, 73%)
-  --color-purple: hsl(314, 100%, 78%)
-  --color-bright: hsl(197, 0%, 100%)
-  --color-gray: hsl(197, 31%, 85%)
-  --color-dark: hsl(197, 17%, 62%)
-  --color-shadow: hsl(197, 10%, 39%)
-  --color-black: hsl(197, 10%, 14%)
-  --background: hsl(197, 6%, 8%)
-  --panel-background-bright: hsl(197, 14%, 14%)
-  --panel-background: hsl(197, 14%, 11%)
-  --panel-background-dark: hsl(197, 14%, 8%)
-  --color: var(--color-gray)
-  --lane-height: 3rem
-  --timeline-header-width: 18rem
+  --color-blue: hsl(189, 100%, 65%) // Accent blue used for links and active states
+  --color-green: hsl(150, 77%, 69%) // Confirmation and success highlight
+  --color-yellow: hsl(60, 100%, 84%) // Warning and caution tone
+  --color-cream: hsl(65, 27%, 83%) // Neutral cream for subtle surfaces
+  --color-red: hsl(354, 100%, 73%) // Error and destructive action color
+  --color-orange: hsl(31, 100%, 73%) // Secondary accent orange
+  --color-purple: hsl(314, 100%, 78%) // Decorative purple accent
+  --color-bright: hsl(197, 0%, 100%) // Brightest text color
+  --color-gray: hsl(197, 31%, 85%) // Default interface text color
+  --color-dark: hsl(197, 17%, 62%) // Muted text or disabled elements
+  --color-shadow: hsl(197, 10%, 39%) // Shadow and border color
+  --color-black: hsl(197, 10%, 14%) // Deepest shadow tone
+  --background: hsl(197, 6%, 8%) // Global application background
+  --panel-background-bright: hsl(197, 14%, 14%) // Elevated panel surface
+  --panel-background: hsl(197, 14%, 11%) // Default panel surface
+  --panel-background-dark: hsl(197, 14%, 8%) // Sunken panel surface
+  --color: var(--color-gray) // Fallback text color token
+  --lane-height: 3rem // Standard height of sequencer lanes
+  --timeline-header-width: 18rem // Width of timeline header area
 
-$BRIGHTENER: rgba(white, 0.02)
-$DARKENER: rgba(black, 0.04)
+$BRIGHTENER: rgba(white, 0.02) // Overlay to slightly increase brightness
+$DARKENER: rgba(black, 0.04) // Overlay to slightly decrease brightness
 
 @mixin panel-background-bright
+  // Applies the bright panel background color
   background-color: var(--panel-background-bright) !important
 
 @mixin panel-background
+  // Applies the default panel background color
   background-color: var(--panel-background)
 
 @mixin panel-background-dark
+  // Applies the dark panel background color
   background-color: var(--panel-background-dark) !important
 
 @mixin panel-background-chess
+  // Checkerboard pattern used for transparency indicators
   background-image: linear-gradient(45deg, var(--panel-background-bright) 25%, var(--panel-background) 25%, var(--panel-background) 50%, var(--panel-background-bright) 50%, var(--panel-background-bright) 75%, var(--panel-background) 75%, var(--panel-background) 100%)
   background-size: 5.66px 5.66px
   background-color: var(--panel-background-bright)

--- a/packages/app/studio/src/main.sass
+++ b/packages/app/studio/src/main.sass
@@ -17,8 +17,8 @@ html, body
   flex-direction: column
   row-gap: 1px
   fill: white
-  color: var(--color-bright)
-  background-color: var(--background)
+  color: var(--color-bright) // Default text colour
+  background-color: var(--background) // Global background colour
   touch-action: none
 
 h1, h2, h3, h4, h5
@@ -70,7 +70,7 @@ table
 
   th
     font-size: 1em
-    color: var(--color-green)
+    color: var(--color-green) // Header text colour
 
 input.default, textarea.default
   appearance: none
@@ -101,7 +101,7 @@ input[type="range"]
     -webkit-appearance: none
     width: 12px
     height: 12px
-    background: var(--color-shadow)
+    background: var(--color-shadow) // Slider thumb colour
     border-radius: 50%
     cursor: pointer
     margin-top: -4px
@@ -116,7 +116,7 @@ input[type="range"]
   &::-moz-range-thumb
     width: 12px
     height: 12px
-    background: var(--color-shadow)
+    background: var(--color-shadow) // Slider thumb colour
     border-radius: 50%
     border: none
     cursor: pointer
@@ -137,12 +137,12 @@ input[type="range"]
   &::-ms-thumb
     width: 12px
     height: 12px
-    background: var(--color-shadow)
+    background: var(--color-shadow) // Slider thumb colour
     border-radius: 50%
     cursor: pointer
 
 .spinner_GuJz
-  fill: var(--color-green)
+  fill: var(--color-green) // Spinner accent colour
   transform-origin: center
   animation: spinner_STY6 3s linear infinite
 

--- a/packages/app/studio/src/mixins.sass
+++ b/packages/app/studio/src/mixins.sass
@@ -2,14 +2,17 @@
 @use "@/colors"
 
 @mixin width-available
+  // Expands the element to the available width in the container
   width: -moz-available
   width: -webkit-fill-available
 
 @mixin height-available
+  // Expands the element to the available height in the container
   height: -moz-available
   height: -webkit-fill-available
 
 @mixin controllable
+  // Visual indication for automated controls
   &.automated, .automated &
     border-radius: 1px
     outline-offset: 1px
@@ -17,10 +20,12 @@
     background-color: rgba(white, 0.02)
 
 @mixin clips-aware
+  // Adds margin when clips are hidden
   &:not(.clips-visible *)
     margin-left: 1px
 
 @mixin form-element
+  // Default styling for editable form controls
   color: var(--color-gray)
   background-color: rgba(black, 0.08)
   box-shadow: 0 0 0 1px rgba(white, 0.02)
@@ -34,10 +39,12 @@
     opacity: 0.5
 
 @mixin dragging
+  // Reduces opacity while an element is dragged
   &.dragging
     opacity: 0.1
 
 @mixin unit-type-colors
+  // Sets track colours based on unit type
   &
     --color: var(--color-green)
 
@@ -51,6 +58,7 @@
     --color: var(--color-blue)
 
 @mixin markdown
+  // Basic styles for markdown-rendered content
   color: var(--color-gray)
 
   h1, h2, h3, h4, h5, h6, p
@@ -90,17 +98,20 @@
     background-color: rgba(white, 0.1)
 
 @mixin Control()
+  // Base layout sizing for control grids
   padding: 0.5em 0.25em
   height: 192px
   width: min-content
 
 @mixin ControlLayout($numColumns)
+  // Grid layout for controls with configurable column count
   display: grid
   grid-template: repeat(3, 3.5em) / repeat($numColumns, 3.5em)
   row-gap: 0.25em
   @include Control
 
 @mixin Input($ident: right)
+  // Standard numeric input with optional alignment
   display: flex
   flex-direction: row
   column-gap: 2px
@@ -150,6 +161,7 @@
       color: var(--color-gray)
 
 @mixin floating($semitransparent: true)
+  // Floating panel used for context menus and tooltips
   font-size: 0.75rem
   font-weight: inherit
   font-family: inherit
@@ -169,6 +181,7 @@
     background-color: hsl(200, 12%, 11%)
 
 @mixin corner-frame($color: rgba(white, 0.06))
+  // Draws small corner markers around an element
   position: relative
 
   &::before,

--- a/packages/app/studio/src/ui/components/Button.sass
+++ b/packages/app/studio/src/ui/components/Button.sass
@@ -1,0 +1,10 @@
+component
+  // Base styling for generic buttons
+  --color: var(--color-shadow) // Default button colour
+  --color-active: var(--color-blue) // Colour when the button is active
+  display: inline-flex
+  align-items: center
+  justify-content: center
+  cursor: pointer
+  pointer-events: all
+

--- a/packages/app/studio/src/ui/components/Button.tsx
+++ b/packages/app/studio/src/ui/components/Button.tsx
@@ -1,7 +1,10 @@
+import css from "./Button.sass?inline"
 import {Lifecycle, Procedure} from "@opendaw/lib-std"
 import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {Appearance, ButtonCheckboxRadio} from "@/ui/components/ButtonCheckboxRadio"
 import {Html} from "@opendaw/lib-dom"
+
+const className = Html.adoptStyleSheet(css, "Button")
 
 /**
  * Props for {@link Button}.
@@ -27,7 +30,11 @@ export const Button = ({lifecycle, onClick, style, appearance}: ButtonProps, chi
     const id = Html.nextID()
     const input: HTMLInputElement = <input type="button" id={id} onclick={onClick}/>
     return (
-        <ButtonCheckboxRadio lifecycle={lifecycle} style={style} appearance={appearance} dataClass="button">
+        <ButtonCheckboxRadio lifecycle={lifecycle}
+                             style={style}
+                             appearance={appearance}
+                             dataClass="button"
+                             className={className}>
             {input}
             <label htmlFor={id}>{children}</label>
         </ButtonCheckboxRadio>

--- a/packages/docs/docs-dev/style/design-tokens.md
+++ b/packages/docs/docs-dev/style/design-tokens.md
@@ -1,0 +1,39 @@
+# Design Tokens
+
+These tokens define the visual language for the studio. Values are implemented in [`colors.sass`](../../../app/studio/src/colors.sass).
+
+## Colors
+
+| Token | Description |
+|-------|-------------|
+| `--color-blue` | Accent blue used for links and active states |
+| `--color-green` | Confirmation and success highlight |
+| `--color-yellow` | Warning and caution tone |
+| `--color-cream` | Neutral cream for subtle surfaces |
+| `--color-red` | Error and destructive action color |
+| `--color-orange` | Secondary accent orange |
+| `--color-purple` | Decorative purple accent |
+| `--color-bright` | Brightest text color |
+| `--color-gray` | Default interface text color |
+| `--color-dark` | Muted text or disabled elements |
+| `--color-shadow` | Shadow and border color |
+| `--color-black` | Deepest shadow tone |
+| `--background` | Global application background |
+| `--panel-background-bright` | Elevated panel surface |
+| `--panel-background` | Default panel surface |
+| `--panel-background-dark` | Sunken panel surface |
+
+## Layout
+
+| Token | Description |
+|-------|-------------|
+| `--lane-height` | Standard height of sequencer lanes |
+| `--timeline-header-width` | Width of timeline header area |
+
+## Utility
+
+| Token | Description |
+|-------|-------------|
+| `$BRIGHTENER` | Overlay to slightly increase brightness |
+| `$DARKENER` | Overlay to slightly decrease brightness |
+

--- a/packages/docs/docs-dev/style/writing-guide.md
+++ b/packages/docs/docs-dev/style/writing-guide.md
@@ -10,3 +10,6 @@ Use this guide when contributing documentation.
 - Link to related topics to help navigation.
 
 These practices align with our Markdown linting and Vale configuration.
+
+For naming conventions of colours and other UI variables, refer to the [Design Tokens](./design-tokens.md) guide.
+


### PR DESCRIPTION
## Summary
- document color and layout tokens used by the studio
- style Button component with its own SASS module
- link design tokens doc from writing guide and README

## Testing
- `npm test` *(fails: Cannot find name 'PermissionState')*
- `npm run lint` *(fails: command sh -c eslint "**/*.ts")*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2d8c7b48321865793620eccbcfa