### PR TITLE
docs: document versioning policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,11 @@ Thank you for your interest in contributing to openDAW! This guide outlines the 
 
 ## Pipeline Overview
 
-The monorepo uses **Turbo** to run build, test, and lint tasks across all packages. **Lerna** manages package versioning and publishing, while API docs are generated with **Typedoc**. Deployment configuration files for Vercel and Netlify describe how docs and apps would be deployed when enabled.
+The monorepo uses **Turbo** to run build, test, and lint tasks across all
+packages. **Lerna** manages package versioning and publishing; see the
+[versioning policy](packages/docs/docs-dev/build-and-run/versioning.md). API
+docs are generated with **Typedoc**. Deployment configuration files for Vercel
+and Netlify describe how docs and apps would be deployed when enabled.
 
 GitHub Actions provides continuous integration. Workflows handle deployment,
 documentation builds, quality checks, Discord notifications, and SFTP tests.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,8 +3,10 @@
 ## Pipeline Overview
 
 Turbo coordinates workspace tasks such as builds, tests, and documentation
-generation, while Lerna handles package versioning and publishing. Deployment
-configs for Vercel and Netlify document how releases will be delivered.
+generation, while Lerna handles package versioning and publishing; see the
+[versioning policy](packages/docs/docs-dev/build-and-run/versioning.md).
+Deployment configs for Vercel and Netlify document how releases will be
+delivered.
 
 ## Near term
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,7 @@
 {
   "//": "Lerna manages versioning and publishing for workspace packages",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "independent",
   "npmClient": "npm",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "//": "Root package manifest for the openDAW monorepo",
   "name": "opendaw",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.0",
   "private": true,
   "license": "MIT",

--- a/packages/app/headless/package.json
+++ b/packages/app/headless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opendaw/app-headless",
   "private": true,
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "type": "module",
   "license": "MIT",

--- a/packages/app/studio/package.json
+++ b/packages/app/studio/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@opendaw/app-studio",
   "private": true,
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "description": "Web-based digital audio workstation UI for OpenDAW",
   "type": "module",

--- a/packages/docs/docs-dev/build-and-run/release.md
+++ b/packages/docs/docs-dev/build-and-run/release.md
@@ -1,9 +1,10 @@
 # Release
 
-Package releases rely on **Lerna**. The root script `npm run publish-sdk`
-executes `lerna publish`, which uses conventional commits to determine version
-bumps and publishes packages to npm. Before running the release command, ensure
-that:
+Package releases rely on **Lerna**. Version numbers across the repository are
+managed according to the [versioning policy](./versioning.md). The root script
+`npm run publish-sdk` executes `lerna publish`, which uses conventional commits
+to determine version bumps and publishes packages to npm. Before running the
+release command, ensure that:
 
 - `turbo run build` has produced fresh builds.
 - `turbo run test` passes for all packages.

--- a/packages/docs/docs-dev/build-and-run/versioning.md
+++ b/packages/docs/docs-dev/build-and-run/versioning.md
@@ -1,0 +1,12 @@
+# Versioning
+
+openDAW uses **Lerna** to manage versions for all workspace packages. Each
+package manifest includes a `version` field with an accompanying `version//`
+comment pointing back to this policy.
+
+- Do not edit version numbers manually. Run `npm run publish-sdk` to bump and
+  publish packages.
+- Packages use independent semantic versions. The root manifest and other
+  private packages stay at `0.0.0` to avoid accidental releases.
+
+See the [release guide](./release.md) for publishing steps.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,7 @@
 {
   "//": "Docs site package manifest; see docs-dev/documentation-site/overview.md and tsconfig.json",
   "name": "packages-docs",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/packages/lib/box-forge/package.json
+++ b/packages/lib/box-forge/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-box-forge",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "private": true,
   "license": "MIT",

--- a/packages/lib/box/package.json
+++ b/packages/lib/box/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-box",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/dawproject/package.json
+++ b/packages/lib/dawproject/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-dawproject",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/dom/package.json
+++ b/packages/lib/dom/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-dom",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/dsp/package.json
+++ b/packages/lib/dsp/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-dsp",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/fusion/package.json
+++ b/packages/lib/fusion/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-fusion",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/jsx/package.json
+++ b/packages/lib/jsx/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-jsx",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/lib/midi/package.json
+++ b/packages/lib/midi/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-midi",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/lib/runtime/package.json
+++ b/packages/lib/runtime/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-runtime",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {

--- a/packages/lib/std/package.json
+++ b/packages/lib/std/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-std",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {

--- a/packages/lib/xml/package.json
+++ b/packages/lib/xml/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/lib-xml",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/studio/adapters/package.json
+++ b/packages/studio/adapters/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-adapters",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {

--- a/packages/studio/boxes/package.json
+++ b/packages/studio/boxes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-boxes",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {

--- a/packages/studio/core-processors/package.json
+++ b/packages/studio/core-processors/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-core-processors",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "private": true,

--- a/packages/studio/core-workers/package.json
+++ b/packages/studio/core-workers/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-core-workers",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.14",
   "license": "LGPL-3.0-or-later",
   "private": true,

--- a/packages/studio/core/package.json
+++ b/packages/studio/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-core",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {

--- a/packages/studio/enums/package.json
+++ b/packages/studio/enums/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-enums",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "LGPL-3.0-or-later",
   "publishConfig": {

--- a/packages/studio/forge-boxes/package.json
+++ b/packages/studio/forge-boxes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-forge-boxes",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "private": true,

--- a/packages/studio/sdk/package.json
+++ b/packages/studio/sdk/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@opendaw/studio-sdk",
+  "version//": "Version is managed by openDAW versioning policy; see packages/docs/docs-dev/build-and-run/versioning.md",
   "version": "0.0.20",
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- annotate version fields across package manifests
- add versioning policy doc and link from release instructions
- reference versioning policy from contributing guide and roadmap

## Testing
- `npm test` *(fails: command /workspace/openDAW/packages/studio/enums npm run build exited with code 2)*
- `npm run lint` *(fails: command /workspace/openDAW/packages/lib/runtime npm run lint exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2d90548832189e566b2377eb699