### PR TITLE
docs: add template metadata and examples

### DIFF
--- a/packages/app/studio/public/templates/README.md
+++ b/packages/app/studio/public/templates/README.md
@@ -1,0 +1,16 @@
+# Template metadata
+
+The Studio bundles several starter projects. Each template file below has a corresponding SVG thumbnail in `images/`.
+
+<!-- BMX_LiquidDrums.od: images/BMX_LiquidDrums.svg -->
+<!-- BMX_Playfield.od: images/BMX_Playfield.svg -->
+<!-- BMX_Skyence_buryme_Remix.od: images/BMX_Skyence_buryme_Remix.svg -->
+<!-- Breeze.od: images/Breeze.svg -->
+<!-- Dub-Techno.od: images/Dub-Techno.svg -->
+<!-- Fatso.od: images/Fatso.svg -->
+<!-- Release.od: images/Release.svg -->
+<!-- Ben.od: images/Ben.svg -->
+<!-- BuryMe.od: images/BuryMe.svg -->
+<!-- Shafted.od: images/Shafted.svg -->
+<!-- SeekDeeper.od: images/SeekDeeper.svg -->
+<!-- Sunset.od: images/Sunset.svg -->

--- a/packages/app/studio/public/templates/images/BMX_LiquidDrums.svg
+++ b/packages/app/studio/public/templates/images/BMX_LiquidDrums.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">BMX_LiquidDrums</text>
+</svg>

--- a/packages/app/studio/public/templates/images/BMX_Playfield.svg
+++ b/packages/app/studio/public/templates/images/BMX_Playfield.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">BMX_Playfield</text>
+</svg>

--- a/packages/app/studio/public/templates/images/BMX_Skyence_buryme_Remix.svg
+++ b/packages/app/studio/public/templates/images/BMX_Skyence_buryme_Remix.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">BMX_Skyence_buryme_Remix</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Ben.svg
+++ b/packages/app/studio/public/templates/images/Ben.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Ben</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Breeze.svg
+++ b/packages/app/studio/public/templates/images/Breeze.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Breeze</text>
+</svg>

--- a/packages/app/studio/public/templates/images/BuryMe.svg
+++ b/packages/app/studio/public/templates/images/BuryMe.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">BuryMe</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Dub-Techno.svg
+++ b/packages/app/studio/public/templates/images/Dub-Techno.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Dub-Techno</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Fatso.svg
+++ b/packages/app/studio/public/templates/images/Fatso.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Fatso</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Release.svg
+++ b/packages/app/studio/public/templates/images/Release.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Release</text>
+</svg>

--- a/packages/app/studio/public/templates/images/SeekDeeper.svg
+++ b/packages/app/studio/public/templates/images/SeekDeeper.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">SeekDeeper</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Shafted.svg
+++ b/packages/app/studio/public/templates/images/Shafted.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Shafted</text>
+</svg>

--- a/packages/app/studio/public/templates/images/Sunset.svg
+++ b/packages/app/studio/public/templates/images/Sunset.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="60">
+  <rect width="100%" height="100%" fill="#ccc"/>
+  <text x="50%" y="50%" font-size="10" text-anchor="middle" fill="#000" dy=".3em">Sunset</text>
+</svg>

--- a/packages/docs/docs-learn/lessons/arrangement-basics.md
+++ b/packages/docs/docs-learn/lessons/arrangement-basics.md
@@ -2,6 +2,8 @@
 
 Crafting a song involves placing sections on the timeline so that the music unfolds logically.
 
+To experiment with song structure right away, load one of the [template projects](../../docs-user/examples/templates.md) bundled with the Studio.
+
 ## Song Structure
 
 ```mermaid

--- a/packages/docs/docs-user/examples/templates.md
+++ b/packages/docs/docs-user/examples/templates.md
@@ -1,0 +1,16 @@
+# Template projects
+
+Use these starter projects to explore arrangement ideas. Each link downloads a template bundled with the Studio.
+
+- ![BMX_LiquidDrums](../../../app/studio/public/templates/images/BMX_LiquidDrums.svg) [BMX_LiquidDrums.od](../../../app/studio/public/templates/BMX_LiquidDrums.od)
+- ![BMX_Playfield](../../../app/studio/public/templates/images/BMX_Playfield.svg) [BMX_Playfield.od](../../../app/studio/public/templates/BMX_Playfield.od)
+- ![BMX_Skyence_buryme_Remix](../../../app/studio/public/templates/images/BMX_Skyence_buryme_Remix.svg) [BMX_Skyence_buryme_Remix.od](../../../app/studio/public/templates/BMX_Skyence_buryme_Remix.od)
+- ![Breeze](../../../app/studio/public/templates/images/Breeze.svg) [Breeze.od](../../../app/studio/public/templates/Breeze.od)
+- ![Dub-Techno](../../../app/studio/public/templates/images/Dub-Techno.svg) [Dub-Techno.od](../../../app/studio/public/templates/Dub-Techno.od)
+- ![Fatso](../../../app/studio/public/templates/images/Fatso.svg) [Fatso.od](../../../app/studio/public/templates/Fatso.od)
+- ![Release](../../../app/studio/public/templates/images/Release.svg) [Release.od](../../../app/studio/public/templates/Release.od)
+- ![Ben](../../../app/studio/public/templates/images/Ben.svg) [Ben.od](../../../app/studio/public/templates/Ben.od)
+- ![BuryMe](../../../app/studio/public/templates/images/BuryMe.svg) [BuryMe.od](../../../app/studio/public/templates/BuryMe.od)
+- ![Shafted](../../../app/studio/public/templates/images/Shafted.svg) [Shafted.od](../../../app/studio/public/templates/Shafted.od)
+- ![SeekDeeper](../../../app/studio/public/templates/images/SeekDeeper.svg) [SeekDeeper.od](../../../app/studio/public/templates/SeekDeeper.od)
+- ![Sunset](../../../app/studio/public/templates/images/Sunset.svg) [Sunset.od](../../../app/studio/public/templates/Sunset.od)


### PR DESCRIPTION
## Summary
- add metadata comments for each Studio template
- showcase templates in new docs page
- link arrangement basics lesson to templates
- replace template PNG thumbnails with inline SVGs

## Testing
- `npm test` *(fails: File '@opendaw/typescript-config/base.json' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2d77c6c8321ac868960a6abc417