### PR TITLE
Fix lint and build errors

### DIFF
--- a/packages/app/studio/src/main.ts
+++ b/packages/app/studio/src/main.ts
@@ -96,14 +96,7 @@ requestAnimationFrame(async () => {
                     Spotlight.install(surface, service)
                 )
             }
-          }),
-          ContextMenu.install(surface.owner),
-          Spotlight.install(surface, service),
-        );
-      },
-    },
-    errorHandler,
-  );
+        });
   document.querySelector("#preloader")?.remove();
   document.addEventListener(
     "touchmove",

--- a/packages/docs/docs-user/features/timeline.md
+++ b/packages/docs/docs-user/features/timeline.md
@@ -14,7 +14,7 @@ Use the loop brace and time axis to scroll or set the play range.
 
 Enable snapping to align edits to the musical grid.
 
-![Timeline snapping menu](./img/timeline-snapping.png)
+![Timeline snapping menu](./img/timeline-snapping.svg)
 
 ## Example Integration
 

--- a/packages/lib/box/package.json
+++ b/packages/lib/box/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint \"**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/lib/box/src/box.test.ts
+++ b/packages/lib/box/src/box.test.ts
@@ -335,12 +335,16 @@ describe("gen (create/navigate)", () => {
   it("find box", () => expect(fooBox.foo.solo.box).toBe(fooBox));
   it("getField(1)", () => expect(fooBox.foo.getField(1)).toBe(fooBox.foo.solo));
   it("share graph", () => expect(fooBox.foo.solo.graph).toBe(graph));
-  // @ts-expect-error: testing invalid box configuration
   it("incompatible", () =>
-    expect(() => fooBox.ref.refer(fooBox.foo.mute)).toThrow());
-  // @ts-expect-error: deliberately wrong constant usage
+    expect(() => {
+      // @ts-expect-error: testing invalid box configuration
+      fooBox.ref.refer(fooBox.foo.mute);
+    }).toThrow());
   it("incompatible", () =>
-    expect(() => fooBox.ref.refer(fooBox.foo.bar)).toThrow());
+    expect(() => {
+      // @ts-expect-error: deliberately wrong constant usage
+      fooBox.ref.refer(fooBox.foo.bar);
+    }).toThrow());
   // it("compatible", () => expect(() => barBox.ref.refer(fooBox)).not.toThrow())
   // it("compatible", () => expect(() => fooBox.ref.refer(fooBox.foo.baz)).not.toThrow())
   // it("compatible", () => expect(() => fooBox.ref.refer(fooBox.foo.solo)).not.toThrow())

--- a/packages/lib/dawproject/package.json
+++ b/packages/lib/dawproject/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint \"**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/lib/dawproject/tsconfig.json
+++ b/packages/lib/dawproject/tsconfig.json
@@ -15,5 +15,6 @@
   "exclude": [
     "dist",
     "node_modules",
+    "vitest.config.ts"
   ]
 }

--- a/packages/lib/jsx/package.json
+++ b/packages/lib/jsx/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint \"**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "echo \"No tests to run\""
   },
   "dependencies": {

--- a/packages/lib/jsx/src/types.ts
+++ b/packages/lib/jsx/src/types.ts
@@ -44,9 +44,8 @@ type ExtractProperties<T extends Element> = Partial<{
 
 declare global {
     namespace JSX {
-        // @ts-expect-error: JSX intrinsic elements are merged from multiple maps
-        type IntrinsicElements =
-            & { [K in keyof Omit<SVGElementTagNameMap, "a">]: ExtractProperties<Omit<SVGElementTagNameMap, "a">[K]> }
+         type IntrinsicElements =
+              & { [K in keyof Omit<SVGElementTagNameMap, "a">]: ExtractProperties<Omit<SVGElementTagNameMap, "a">[K]> }
             & { [K in keyof Omit<HTMLElementTagNameMap, "a">]: ExtractProperties<Omit<HTMLElementTagNameMap, "a">[K]> }
             // TODO This guy is really fuzzy. For some reason I cannot type it properly
             & { a: any } // ExtractProperties<HTMLAnchorElement & HTMLElement & HTMLHyperlinkElementUtils>

--- a/packages/studio/boxes/package.json
+++ b/packages/studio/boxes/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint \"**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "echo \"No tests to run\""
   },
   "dependencies": {

--- a/packages/studio/core/package.json
+++ b/packages/studio/core/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "lint": "eslint \"**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {

--- a/packages/studio/core/tsconfig.json
+++ b/packages/studio/core/tsconfig.json
@@ -12,7 +12,6 @@
   },
   "include": [
     "src",
-    "vitest.config.ts",
     "vite-env.d.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- Repair main app bootstrap to remove stray installs and fix lint parsing
- Relocate `@ts-expect-error` directives and drop unused ones
- Adjust build configs and lint scripts to skip generated artifacts
- Correct timeline documentation image path

## Testing
- `npm run lint`
- `npm test`
- `npm run docs:build`


------
https://chatgpt.com/codex/tasks/task_b_68af15df22f08321aff5d3faa67fbbed