### PR TITLE
docs: add typography and notepad docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Cross-Origin Isolation Guide](packages/docs/docs-dev/build-and-run/cross-origin-isolation.md)
 - [Headless mode workflow](packages/docs/docs-user/workflows/headless-mode.md) – feature parity with Studio service, see [headless vs studio](packages/docs/docs-dev/architecture/headless-vs-studio.md)
 - [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
+- [Notepad Guide](packages/docs/docs-user/features/notepad.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -3,7 +3,7 @@
 This package contains the web-based user interface for the OpenDAW project.
 
 For a guided overview of the interface, see the [UI tour](../../docs/docs-user/ui-tour.md).
-Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md).
+Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md). The [notepad feature](../../docs/docs-user/features/notepad.md) lets you store project notes using Markdown.
 Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
 For individual topics, browse the in-app [manuals](public/manuals/index.md).

--- a/packages/app/studio/public/fonts/README.md
+++ b/packages/app/studio/public/fonts/README.md
@@ -8,3 +8,4 @@ This directory contains the font files bundled with openDAW.
 These files are used by the studio UI and loaded via `src/ui/Fonts.ts`.
 
 If you add or replace fonts, ensure that the license is compatible and update this document accordingly.
+

--- a/packages/app/studio/src/ui/App.tsx
+++ b/packages/app/studio/src/ui/App.tsx
@@ -14,6 +14,11 @@ import { ErrorsPage } from "@/ui/pages/ErrorsPage.tsx";
 import { ImprintPage } from "@/ui/pages/ImprintPage.tsx";
 import { GraphPage } from "@/ui/pages/GraphPage";
 
+/**
+ * Main entry point for the studio UI.
+ *
+ * Sets up the header, router-driven content area and footer.
+ */
 export const App = (service: StudioService) => {
   const terminator = new Terminator();
   return (

--- a/packages/app/studio/src/ui/FontLoader.ts
+++ b/packages/app/studio/src/ui/FontLoader.ts
@@ -2,11 +2,23 @@ import {Fonts} from "@/ui/Fonts"
 import {loadFont} from "@opendaw/lib-dom"
 import {Lazy} from "@opendaw/lib-std"
 
+/**
+ * Loads the font faces used by the studio UI.
+ *
+ * Fonts are declared in {@link Fonts} and fetched only once on first access.
+ */
 export class FontLoader {
+    /**
+     * Trigger loading for all fonts used by the application.
+     *
+     * The result resolves when all `FontFace` objects have either loaded or
+     * failed, mirroring the behaviour of `Promise.allSettled`.
+     */
     @Lazy
     static async load() {
         return Promise.allSettled([
-            loadFont(Fonts.Rubik), loadFont(Fonts.OpenSans)
+            loadFont(Fonts.Rubik),
+            loadFont(Fonts.OpenSans),
         ])
     }
 }

--- a/packages/app/studio/src/ui/Fonts.ts
+++ b/packages/app/studio/src/ui/Fonts.ts
@@ -1,16 +1,25 @@
 import {FontFaceProperties} from "@opendaw/lib-dom"
 
+/**
+ * Describes the font faces bundled with the application.
+ *
+ * Each entry is used by {@link FontLoader} to register the fonts with the
+ * browser.
+ */
 export const Fonts = {
+    /** Rubik typeface used for headings and UI labels. */
     Rubik: <FontFaceProperties>{
         "font-family": "Rubik",
         "font-weight": 300,
         "font-style": "normal",
-        "src": "/fonts/rubik.woff2"
+        "src": "/fonts/rubik.woff2",
     },
+    /** Open Sans typeface used for body text. */
     OpenSans: <FontFaceProperties>{
         "font-family": "Open Sans",
         "font-weight": "normal",
         "font-style": "normal",
-        "src": "/fonts/OpenSans-Regular.ttf"
-    }
+        "src": "/fonts/OpenSans-Regular.ttf",
+    },
 }
+

--- a/packages/app/studio/src/ui/Footer.sass
+++ b/packages/app/studio/src/ui/Footer.sass
@@ -1,3 +1,4 @@
+// Styling for the application footer
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/Footer.tsx
+++ b/packages/app/studio/src/ui/Footer.tsx
@@ -12,6 +12,10 @@ const className = Html.adoptStyleSheet(css, "footer");
 
 type Construct = { lifecycle: Lifecycle; service: StudioService };
 
+/**
+ * Footer component showing connection state, project metadata and runtime
+ * statistics.
+ */
 export const Footer = ({ lifecycle, service }: Construct) => {
   const labelOnline: HTMLElement = <div title="Online" aria-live="polite" />;
   const updateOnline = () =>

--- a/packages/app/studio/src/ui/Markdown.sass
+++ b/packages/app/studio/src/ui/Markdown.sass
@@ -1,3 +1,4 @@
+// Styling for rendered Markdown content
 @use "@/mixins"
 
 component

--- a/packages/app/studio/src/ui/Markdown.tsx
+++ b/packages/app/studio/src/ui/Markdown.tsx
@@ -11,6 +11,11 @@ type Construct = {
   text: string;
 };
 
+/**
+ * Renders markdown into the given element and enriches the output with
+ * application specific behaviour such as internal navigation and
+ * copy-to-clipboard for code blocks.
+ */
 export const renderMarkdown = (element: HTMLElement, text: string) => {
   if (Browser.isWindows()) {
     Object.entries(ModfierKeys.Mac).forEach(
@@ -50,6 +55,11 @@ export const renderMarkdown = (element: HTMLElement, text: string) => {
   });
 };
 
+/**
+ * Stateless component that converts the provided markdown string to HTML.
+ *
+ * @param text - Markdown source to render.
+ */
 export const Markdown = ({ text }: Construct) => {
   if (text.startsWith("<")) {
     return "Invalid Markdown";

--- a/packages/app/studio/src/ui/NotePadPanel.sass
+++ b/packages/app/studio/src/ui/NotePadPanel.sass
@@ -1,3 +1,4 @@
+// Layout and edit-mode styling for the session notepad panel
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/NotePadPanel.tsx
+++ b/packages/app/studio/src/ui/NotePadPanel.tsx
@@ -16,6 +16,12 @@ type Construct = {
   service: StudioService;
 };
 
+/**
+ * Markdown based notepad embedded in the workspace.
+ *
+ * Allows users to jot down notes. Content is persisted in the session's
+ * metadata under the key `notepad`.
+ */
 export const NotePadPanel = ({ lifecycle, service }: Construct) => {
   const markdownText = new DefaultObservableValue("");
   const editMode = new DefaultObservableValue(false);

--- a/packages/app/studio/src/ui/TextScroller.ts
+++ b/packages/app/studio/src/ui/TextScroller.ts
@@ -1,7 +1,15 @@
 import {clamp, Terminable, Terminator} from "@opendaw/lib-std"
 import {AnimationFrame, Events} from "@opendaw/lib-dom"
 
+/**
+ * Provides an auto-scrolling effect for overflowing text blocks.
+ */
 export namespace TextScroller {
+    /**
+     * Enable smooth scrolling for the supplied element on pointer hover.
+     *
+     * @returns A {@link Terminable} used to remove installed listeners.
+     */
     export const install = (element: HTMLElement): Terminable => {
         element.style.overflow = "hidden"
         const scrolling = new Terminator()

--- a/packages/docs/docs-dev/ui/typography/font-loading.md
+++ b/packages/docs/docs-dev/ui/typography/font-loading.md
@@ -1,0 +1,11 @@
+---
+title: Font Loading
+---
+
+Fonts are defined in [`src/ui/Fonts.ts`](../../../../../app/studio/src/ui/Fonts.ts)
+and loaded on demand through [`FontLoader`](../../../../../app/studio/src/ui/FontLoader.ts).
+
+`FontLoader.load()` lazily registers both the Rubik and Open Sans typefaces
+using the `FontFace` API. The operation returns a `Promise.allSettled` result so
+the application can continue even if a font fails to load.
+

--- a/packages/docs/docs-dev/ui/typography/markdown.md
+++ b/packages/docs/docs-dev/ui/typography/markdown.md
@@ -1,0 +1,16 @@
+---
+title: Markdown Rendering
+---
+
+[`src/ui/Markdown.tsx`](../../../../../app/studio/src/ui/Markdown.tsx) wraps the
+[`markdown-it`](https://github.com/markdown-it/markdown-it) parser with a few
+convenience features:
+
+- Internal links are captured and routed through the application's navigation
+  system.
+- Images are constrained to the container width and marked as anonymous for
+  proper CORS handling.
+- Code blocks become clickable and copy their contents to the clipboard.
+
+The same renderer powers the in‑app manuals and the workspace notepad.
+

--- a/packages/docs/docs-dev/ui/typography/notepad.md
+++ b/packages/docs/docs-dev/ui/typography/notepad.md
@@ -1,0 +1,12 @@
+---
+title: Notepad Panel
+---
+
+The workspace exposes a Markdown based notepad implemented in
+[`src/ui/NotePadPanel.tsx`](../../../../../app/studio/src/ui/NotePadPanel.tsx).
+
+The panel toggles between edit and preview modes. In edit mode the content is
+plain text, limited to 10&nbsp;000 characters, and persisted to the current
+session's metadata on blur or explicit save. Preview mode renders the text using
+the shared `renderMarkdown` helper.
+

--- a/packages/docs/docs-dev/ui/typography/overview.md
+++ b/packages/docs/docs-dev/ui/typography/overview.md
@@ -1,0 +1,15 @@
+---
+title: Typography Overview
+---
+
+The studio uses a small set of fonts and utilities to keep text rendering
+consistent across browsers. This section outlines the building blocks and how
+they interact.
+
+- [`font-loading`](font-loading.md) explains how fonts are registered with the
+  browser.
+- [`markdown`](markdown.md) describes the Markdown renderer used for manuals and
+  the in‑app notepad.
+- [`notepad`](notepad.md) covers the editable notes panel available inside the
+  workspace.
+

--- a/packages/docs/docs-user/features/notepad.md
+++ b/packages/docs/docs-user/features/notepad.md
@@ -1,0 +1,21 @@
+---
+title: Notepad
+---
+
+openDAW includes a simple notepad for keeping project notes. The panel is
+available from the workspace and supports basic
+[Markdown](../../../../app/studio/src/ui/Markdown.tsx) formatting.
+
+## Editing
+
+- Toggle edit mode using the pencil button in the corner.
+- While editing, press <kbd>Ctrl</kbd>+<kbd>S</kbd> (or
+  <kbd>Cmd</kbd>+<kbd>S</kbd> on macOS) to save your changes.
+- Content is limited to 10&nbsp;000 characters. Extra text is truncated
+  automatically.
+
+## Persistence
+
+Notes are stored inside the project file and restored the next time you open the
+session.
+

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -63,6 +63,16 @@ module.exports = {
             "ui/workspace/examples",
           ],
         },
+        {
+          type: "category",
+          label: "Typography",
+          items: [
+            "ui/typography/overview",
+            "ui/typography/font-loading",
+            "ui/typography/markdown",
+            "ui/typography/notepad",
+          ],
+        },
       ],
     },
     {

--- a/packages/docs/sidebarsUser.js
+++ b/packages/docs/sidebarsUser.js
@@ -16,6 +16,7 @@ module.exports = {
         "features/devices-and-plugins",
         "features/file-management",
         "features/browse",
+        "features/notepad",
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- document font loading and markdown utilities with TSDoc
- add developer typography docs and user notepad guide
- link notepad docs from root and studio readmes

## Testing
- `npm test` *(fails: run failed)*
- `npm run lint` *(fails: run failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af1f9abf7c832185de9f2c4e5aeb5e