### PR TITLE
docs: document feature flags and ui handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Documentation Site Guide](packages/docs/docs-dev/documentation-site/overview.md)
 - [Cross-Origin Isolation Guide](packages/docs/docs-dev/build-and-run/cross-origin-isolation.md)
 - [Headless mode workflow](packages/docs/docs-user/workflows/headless-mode.md) – feature parity with Studio service, see [headless vs studio](packages/docs/docs-dev/architecture/headless-vs-studio.md)
+- [Feature Flags](packages/docs/docs-dev/architecture/feature-flags.md)
+- [Troubleshooting Guide](packages/docs/docs-user/troubleshooting.md)
 - [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
 
 ### Style Documentation
@@ -218,4 +220,3 @@ participate, visit our [Contribute](https://opendaw.org/contribute) page.
 This project is licensed under the [MIT License](LICENSE)
 
 The bundled fonts (`rubik.woff2` and `OpenSans-Regular.ttf` in packages/app/studio/public/fonts) are provided under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL). See [fonts/README.md](packages/app/studio/public/fonts/README.md) for details.
-

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -6,6 +6,9 @@ For a guided overview of the interface, see the [UI tour](../../docs/docs-user/u
 Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md).
 Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
+For browser compatibility considerations refer to the [feature flags overview](../../docs/docs-dev/architecture/feature-flags.md).
+Common problems are addressed in the [troubleshooting guide](../../docs/docs-user/troubleshooting.md).
+
 For individual topics, browse the in-app [manuals](public/manuals/index.md).
 
 ## Component Hierarchy

--- a/packages/app/studio/src/BuildInfo.ts
+++ b/packages/app/studio/src/BuildInfo.ts
@@ -1,8 +1,9 @@
 /**
- * Metadata about the current build generated during the build step
- * (see `vite.config.ts`). The information is written to the public
- * folder and fetched at runtime to verify cache validity and expose
- * build details to the client.
+ * Describes metadata emitted during the bundling process.
+ *
+ * `vite.config.ts` serializes this structure into `build.json` which is
+ * served from the `public` directory. The Studio reads the file at runtime
+ * to validate caches and display build information to the user.
  */
 export type BuildInfo = {
   /** Unix timestamp of when the build was created. */

--- a/packages/app/studio/src/features.ts
+++ b/packages/app/studio/src/features.ts
@@ -1,10 +1,14 @@
 import { requireProperty } from "@opendaw/lib-std";
 
 /**
- * Ensures that essential Web APIs are available in the current browser
- * before the studio attempts to boot. Each check throws if the feature
- * is missing which prevents the application from starting in an
- * unsupported environment.
+ * Tests browser capabilities that are required for the Studio to run.
+ *
+ * The application performs these checks before booting and aborts if any
+ * API is unavailable. Keeping the logic centralized ensures that feature
+ * requirements stay in sync with the documentation and user messaging.
+ *
+ * @throws {Error} When a mandatory Web API is missing from the host
+ * browser.
  */
 export const testFeatures = async (): Promise<void> => {
   // Promise.withResolvers is used throughout for ergonomic async flows

--- a/packages/app/studio/src/ui/App.tsx
+++ b/packages/app/studio/src/ui/App.tsx
@@ -14,6 +14,11 @@ import { ErrorsPage } from "@/ui/pages/ErrorsPage.tsx";
 import { ImprintPage } from "@/ui/pages/ImprintPage.tsx";
 import { GraphPage } from "@/ui/pages/GraphPage";
 
+/**
+ * Root application component that wires global UI elements and sets up
+ * the router. It renders the header, footer and the current page while
+ * providing a default 404 fallback.
+ */
 export const App = (service: StudioService) => {
   const terminator = new Terminator();
   return (

--- a/packages/app/studio/src/ui/Dashboard.sass
+++ b/packages/app/studio/src/ui/Dashboard.sass
@@ -1,4 +1,4 @@
-// Styles for the Dashboard landing page
+// Styles for the Dashboard landing page including template grid and project list
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/Dashboard.tsx
+++ b/packages/app/studio/src/ui/Dashboard.tsx
@@ -9,12 +9,20 @@ import { Colors } from "@opendaw/studio-core";
 
 const className = Html.adoptStyleSheet(css, "Dashboard");
 
+/**
+ * Dependencies required by the {@link Dashboard} component.
+ */
 type Construct = {
   lifecycle: Lifecycle;
   service: StudioService;
 };
 
-/** Landing page presenting templates and recent projects. */
+/**
+ * Landing page presenting templates and recent projects.
+ *
+ * @param service Provides access to template loading and the project
+ * browser.
+ */
 export const Dashboard = ({ service }: Construct) => {
   const time = TimeSpan.millis(
     new Date(service.buildInfo.date).getTime() - new Date().getTime(),

--- a/packages/app/studio/src/ui/MissingFeature.sass
+++ b/packages/app/studio/src/ui/MissingFeature.sass
@@ -1,3 +1,4 @@
+// Layout for the "missing feature" warning screen
 component
   display: flex
   flex-direction: column

--- a/packages/app/studio/src/ui/MissingFeature.tsx
+++ b/packages/app/studio/src/ui/MissingFeature.tsx
@@ -1,21 +1,36 @@
-import css from "./MissingFeature.sass?inline"
-import {createElement} from "@opendaw/lib-jsx"
-import {Html} from "@opendaw/lib-dom"
-import {Colors} from "@opendaw/studio-core"
+import css from "./MissingFeature.sass?inline";
+import { createElement } from "@opendaw/lib-jsx";
+import { Html } from "@opendaw/lib-dom";
+import { Colors } from "@opendaw/studio-core";
 
-const className = Html.adoptStyleSheet(css, "MissingFeature")
+const className = Html.adoptStyleSheet(css, "MissingFeature");
 
-type Construct = { error: unknown }
+type Construct = { error: unknown };
 
-export const MissingFeature = ({error}: Construct) => {
-    return (
-        <div className={className}>
-            <h1>Get openDAW Working</h1>
-            <h2>An important feature <span style={{color: Colors.purple}}>"{error}"</span> is missing.</h2>
-            <p>Please update your browser or switch to the latest Chrome (recommended).</p>
-            <p>openDAW should run on all modern browsers like Chrome, Edge, Firefox, and Safari.</p>
-            <p>If you are already using one of these, please report your problem to <a
-                href="mailto:support@opendaw.org">support@opendaw.org</a></p>
-        </div>
-    )
-}
+/**
+ * Full‑screen notice displayed when a required browser capability is
+ * missing. The message lists the unsupported feature and suggests
+ * upgrading or switching browsers.
+ */
+export const MissingFeature = ({ error }: Construct) => {
+  return (
+    <div className={className}>
+      <h1>Get openDAW Working</h1>
+      <h2>
+        An important feature{" "}
+        <span style={{ color: Colors.purple }}>"{error}"</span> is missing.
+      </h2>
+      <p>
+        Please update your browser or switch to the latest Chrome (recommended).
+      </p>
+      <p>
+        openDAW should run on all modern browsers like Chrome, Edge, Firefox,
+        and Safari.
+      </p>
+      <p>
+        If you are already using one of these, please report your problem to
+        <a href="mailto:support@opendaw.org">support@opendaw.org</a>
+      </p>
+    </div>
+  );
+};

--- a/packages/app/studio/src/ui/UpdateMessage.sass
+++ b/packages/app/studio/src/ui/UpdateMessage.sass
@@ -1,4 +1,4 @@
-// Styles for the update notification banner
+// Styles for the update notification banner shown above the workspace
 component
   display: flex
   flex: 0 0 1.25rem

--- a/packages/app/studio/src/ui/UpdateMessage.tsx
+++ b/packages/app/studio/src/ui/UpdateMessage.tsx
@@ -4,7 +4,12 @@ import { createElement } from "@opendaw/lib-jsx";
 
 const className = Html.adoptStyleSheet(css, "UpdateMessage");
 
-/** Banner shown when a new application version is available. */
+/**
+ * Banner shown when a new application version is available.
+ *
+ * The message lives in an assertive ARIA live region so assistive
+ * technologies announce it immediately.
+ */
 export const UpdateMessage = () => {
   return (
     <div className={className} role="alert" aria-live="assertive">

--- a/packages/app/studio/src/ui/configs.ts
+++ b/packages/app/studio/src/ui/configs.ts
@@ -1,9 +1,24 @@
-import {ValueMapping} from "@opendaw/lib-std"
+import { ValueMapping } from "@opendaw/lib-std";
 
-export const SnapCenter = {snap: {threshold: 0.5, snapLength: 12}}
+/**
+ * Configuration for snapping elements to the center of the timeline.
+ *
+ * `snapLength` defines the granularity in pixels while `threshold`
+ * specifies how close elements need to be before they snap into place.
+ */
+export const SnapCenter = {
+  snap: { threshold: 0.5, snapLength: 12 },
+};
+
+/**
+ * Common decibel snapping presets used in the mixer.
+ *
+ * Values are converted from human‑readable decibels into the internal
+ * linear scale via {@link ValueMapping.DefaultDecibel}.
+ */
 export const SnapCommonDecibel = {
-    snap: {
-        threshold: [-12, -9, -6, -3]
-            .map(y => ValueMapping.DefaultDecibel.x(y)), snapLength: 12
-    }
-}
+  snap: {
+    threshold: [-12, -9, -6, -3].map((y) => ValueMapping.DefaultDecibel.x(y)),
+    snapLength: 12,
+  },
+};

--- a/packages/docs/docs-dev/architecture/feature-flags.md
+++ b/packages/docs/docs-dev/architecture/feature-flags.md
@@ -1,0 +1,31 @@
+# Feature Flags
+
+openDAW relies on a handful of feature checks at startup to ensure the
+Studio only runs in supported environments. The checks live in
+[`packages/app/studio/src/features.ts`](../../../app/studio/src/features.ts)
+and guard access to critical Web APIs.
+
+## Runtime detection
+
+`testFeatures()` verifies the presence of APIs such as:
+
+- `Promise.withResolvers` for ergonomic asynchronous flows
+- `indexedDB` for persistent project storage
+- `AudioWorkletNode` for real‑time audio processing
+- Origin Private File System access (`navigator.storage.getDirectory`) for
+  project files
+- `crypto.randomUUID` and `crypto.subtle.digest` for unique identifiers and
+  cache validation
+
+Each missing capability throws, preventing the Studio from starting.
+
+## User messaging
+
+When a requirement is not met the application renders the
+[`MissingFeature`](../../../app/studio/src/ui/MissingFeature.tsx) component
+which explains the limitation and suggests updating the browser.
+
+## Extending flags
+
+New checks can be added to `features.ts`. Keep the list concise and backed
+by user-facing messaging so unsupported browsers fail fast and clearly.

--- a/packages/docs/docs-user/troubleshooting.md
+++ b/packages/docs/docs-user/troubleshooting.md
@@ -36,6 +36,21 @@
 - Check browser permissions and allow access when prompted.
 - Verify that the correct input device is selected in audio settings.
 
+### openDAW reports that a feature is missing
+
+- Some browsers lack APIs required by the Studio. If you see a warning
+  about a missing feature, upgrade to the latest version of Chrome,
+  Edge, Firefox or Safari.
+- Older versions of the above browsers may also omit support for
+  required features. Updating usually resolves the issue.
+
+### I see an "Update available" banner
+
+- The application fetched a newer build. Reload the page to switch to
+  the latest version.
+- If the message persists after reloading, try clearing the browser
+  cache.
+
 ### Reporting errors
 
 - When an unexpected error dialog appears, note the steps that led to the


### PR DESCRIPTION
## Summary
- add TSDoc for feature detection and build metadata
- document UI banners and dashboard behaviors
- expand docs with feature-flag details and troubleshooting notes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af1f9b2c688321995ee78c05a4a728