### PR TITLE
docs: document icon library and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Cross-Origin Isolation Guide](packages/docs/docs-dev/build-and-run/cross-origin-isolation.md)
 - [Headless mode workflow](packages/docs/docs-user/workflows/headless-mode.md) – feature parity with Studio service, see [headless vs studio](packages/docs/docs-dev/architecture/headless-vs-studio.md)
 - [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
+- [Icon Library](packages/docs/docs-dev/ui/icons/overview.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/public/images/README.md
+++ b/packages/app/studio/public/images/README.md
@@ -1,0 +1,12 @@
+# Image Assets
+
+This directory holds image assets used by the studio. Icons in the parent directory are referenced here for convenience.
+
+- `../grid16.svg` – 16×16 grid pattern used for canvas backgrounds.
+- `../favicon.svg` – The application's favicon.
+- `../logo.png` – Main openDAW logo.
+- `../cover.png` – Social sharing cover image.
+- `meta.jpg` – Open Graph preview image.
+- `../become_a_patron_button.png` – Patreon support button displayed in the app.
+
+Add any new images to this list with a short description of their purpose.

--- a/packages/app/studio/src/ui/IconLibrary.tsx
+++ b/packages/app/studio/src/ui/IconLibrary.tsx
@@ -1,6 +1,11 @@
 import { createElement } from "@opendaw/lib-jsx";
 import { IconSymbol } from "@opendaw/studio-adapters";
 
+/**
+ * Renders a hidden `<svg>` element containing `symbol` definitions for every
+ * icon used in the studio. The component should be included once at the root
+ * of the document so icons can be referenced via `<use>` elements elsewhere.
+ */
 export const IconLibrary = () => (
   <svg width="0" height="0" display="none" aria-hidden="true" focusable="false">
     <defs>

--- a/packages/app/studio/src/ui/pages/IconsPage.sass
+++ b/packages/app/studio/src/ui/pages/IconsPage.sass
@@ -1,4 +1,4 @@
-// Styles for the icon gallery page.
+// Styles for the developer icon gallery page.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/pages/IconsPage.tsx
+++ b/packages/app/studio/src/ui/pages/IconsPage.tsx
@@ -1,5 +1,5 @@
 /**
- * Lists all available SVG icons in the application.
+ * Developer page listing every SVG icon shipped with the application.
  */
 import css from "./IconsPage.sass?inline"
 import {createElement, Frag, PageContext, PageFactory} from "@opendaw/lib-jsx"

--- a/packages/docs/docs-dev/ui/icons/conventions.md
+++ b/packages/docs/docs-dev/ui/icons/conventions.md
@@ -1,0 +1,6 @@
+# Icon Conventions
+
+- Icons are defined as `<symbol>` elements inside `IconLibrary.tsx`.
+- Each symbol id is generated from the `IconSymbol` enum using `IconSymbol.toName`.
+- Artwork should be drawn on a 24×24 viewbox and use `currentColor` for fills where possible.
+- Add a preview to the Icons developer page when introducing a new symbol.

--- a/packages/docs/docs-dev/ui/icons/overview.md
+++ b/packages/docs/docs-dev/ui/icons/overview.md
@@ -1,0 +1,6 @@
+# Icons Overview
+
+The studio ships with a central SVG sprite containing every icon used in the UI.
+The [`IconLibrary`](../../../../app/studio/src/ui/IconLibrary.tsx) component injects these symbols into the DOM so they can be referenced anywhere.
+
+For a visual catalogue see the [Icons developer page](../pages/icons.md).

--- a/packages/docs/docs-dev/ui/icons/usage.md
+++ b/packages/docs/docs-dev/ui/icons/usage.md
@@ -1,0 +1,11 @@
+# Icon Usage
+
+Include `<IconLibrary />` once near the root of the application. Individual icons are rendered with the [`Icon`](../../../../app/studio/src/ui/components/Icon.tsx) component:
+
+```tsx
+import { Icon, IconSymbol } from "@opendaw/studio-adapters";
+
+<Icon symbol={IconSymbol.Play} />
+```
+
+The `symbol` prop maps to entries in the `IconSymbol` enum. Additional styling is applied through CSS, allowing icons to inherit color and size from their context.

--- a/packages/docs/docs-user/ui-tour.md
+++ b/packages/docs/docs-user/ui-tour.md
@@ -50,5 +50,5 @@ For internal tooling and diagnostics see:
 - [Automation](../docs-dev/ui/pages/automation.md)
 - [Components](../docs-dev/ui/pages/components.md)
 - [Diagnostics](../docs-dev/ui/pages/diagnostics.md)
-- [Icons](../docs-dev/ui/pages/icons.md)
+- [Icons](../docs-dev/ui/pages/icons.md) – [icon docs](../docs-dev/ui/icons/overview.md)
 - [Manuals](../docs-dev/ui/pages/manuals.md)


### PR DESCRIPTION
## Summary
- document IconLibrary component with TSDoc
- add icon documentation and images README
- link icon docs from UI tour and project README

## Testing
- `npm test`
- `npm run lint` *(fails: command exited with 1 in @opendaw/studio-enums)*

------
https://chatgpt.com/codex/tasks/task_b_68af1f9dbef48321a615c2f22bc548ea