### PR TITLE
docs: add file management and drag helpers

### DIFF
--- a/packages/app/studio/src/project/SampleImporter.ts
+++ b/packages/app/studio/src/project/SampleImporter.ts
@@ -10,6 +10,15 @@ import {Sample} from "@opendaw/studio-adapters"
  * ```
  */
 export type SampleImporter = {
+    /**
+     * Store a sample within the project.
+     *
+     * @param sample.uuid Unique identifier for the sample.
+     * @param sample.name User visible name.
+     * @param sample.arrayBuffer Raw audio data.
+     * @param sample.progressHandler Optional progress updates during encoding.
+     * @returns The imported sample descriptor.
+     */
     importSample(sample: {
         uuid: UUID.Format,
         name: string,

--- a/packages/app/studio/src/ui/AnyDragData.ts
+++ b/packages/app/studio/src/ui/AnyDragData.ts
@@ -2,20 +2,29 @@ import { byte, int } from "@opendaw/lib-std";
 import { Sample } from "@opendaw/studio-adapters";
 import { EffectFactories, InstrumentFactories } from "@opendaw/studio-core";
 
+/**
+ * Type definitions describing drag payloads passed between drag sources and
+ * drop targets inside the studio UI.
+ */
+
 /** Hint to drop targets that a drag operation should be copied instead of moved. */
 export type DragCopyHint = { copy?: boolean };
 
-/** Dragged sample originating from the browser's file system. */
+/** Dragged sample originating from the browser's file system or library. */
 export type DragSample = { type: "sample"; sample: Sample } & DragCopyHint;
 
 /**
- * Raw file supplied by the host operating system. Note that the file handle
- * cannot be accessed while the drag operation is active.
+ * Raw file supplied by the host operating system.
+ *
+ * @remarks The file handle cannot be accessed while the drag operation is active.
  */
 export type DragFile = {
+  /** Type discriminator. */
   type: "file";
+  /** Placeholder file handle; unusable until drop has completed. */
   file: File /* This cannot be accessed while dragging! */;
 } & DragCopyHint;
+
 /** Dragged device, instrument or playfield slot within the UI. */
 export type DragDevice = (
   | {
@@ -46,10 +55,17 @@ export type DragDevice = (
 
 /** Dragged channel strip reference. */
 export type DragChannelStrip = {
+  /** Discriminator identifying channel strip drags. */
   type: "channelstrip";
+  /** Unique identifier of the strip. */
   uuid: string;
+  /** Original index before dragging begins. */
   start_index: int;
 } & DragCopyHint;
 
 /** Union of all supported drag data shapes. */
-export type AnyDragData = DragSample | DragFile | DragDevice | DragChannelStrip;
+export type AnyDragData =
+  | DragSample
+  | DragFile
+  | DragDevice
+  | DragChannelStrip;

--- a/packages/app/studio/src/ui/DragAndDrop.ts
+++ b/packages/app/studio/src/ui/DragAndDrop.ts
@@ -38,6 +38,7 @@ export namespace DragAndDrop {
    * @param element      The DOM element that initiates the drag.
    * @param provider     Supplies drag data when the drag starts.
    * @param classReceiver Optional element that receives the `dragging` CSS class.
+   * @returns Terminable subscription managing the listeners.
    */
   export const installSource = (
     element: HTMLElement,
@@ -76,7 +77,13 @@ export namespace DragAndDrop {
     leave(): void;
   }
 
-  /** Registers the element as a drop target. */
+  /**
+   * Registers the element as a drop target.
+   *
+   * @param element The DOM node that accepts drops.
+   * @param process Callbacks defining drop behaviour.
+   * @returns Terminable subscription managing the listeners.
+   */
   export const installTarget = (
     element: HTMLElement,
     process: Process,
@@ -170,6 +177,11 @@ export namespace DragAndDrop {
   /**
    * Computes the insertion index for a dragged item within a parent element.
    * Children participating in the calculation must carry the `data-drag` attribute.
+   *
+   * @param client Pointer coordinates of the drag.
+   * @param parent Container whose children are examined.
+   * @param limit Optional index range limiting the search.
+   * @returns Tuple of desired index and the element currently at that slot.
    */
   export const findInsertLocation = (
     { clientX }: Client,

--- a/packages/app/studio/src/ui/FilePickerAcceptTypes.ts
+++ b/packages/app/studio/src/ui/FilePickerAcceptTypes.ts
@@ -1,29 +1,40 @@
+/** Predefined `accept` type configurations for file picker dialogs. */
 export namespace FilePickerAcceptTypes {
-    export const WavFiles: FilePickerOptions = {
-        types: [{
-            description: "wav-file",
-            accept: {"audio/wav": [".wav"]}
-        }]
-    }
-    export const ProjectSyncLog: FilePickerOptions = {
-        types: [{
-            description: "openDAW sync-log-file",
-            accept: {"application/octet-stream": [".odsl"]}
-        }]
-    }
+  /** Accepts Wave audio files. */
+  export const WavFiles: FilePickerOptions = {
+    types: [
+      {
+        description: "wav-file",
+        accept: { "audio/wav": [".wav"] },
+      },
+    ],
+  };
 
-    export const ProjectFileType: FilePickerAcceptType = {
-        description: "openDAW project",
-        accept: {"application/octet-stream": [".od"]}
-    }
+  /** Accepts openDAW project synchronisation log files. */
+  export const ProjectSyncLog: FilePickerOptions = {
+    types: [
+      {
+        description: "openDAW sync-log-file",
+        accept: { "application/octet-stream": [".odsl"] },
+      },
+    ],
+  };
 
-    export const ProjectBundleFileType: FilePickerAcceptType = {
-        description: "openDAW project bundle",
-        accept: {"application/octet-stream": [".odb"]}
-    }
+  /** Accepts native openDAW project files. */
+  export const ProjectFileType: FilePickerAcceptType = {
+    description: "openDAW project",
+    accept: { "application/octet-stream": [".od"] },
+  };
 
-    export const DawprojectFileType: FilePickerAcceptType = {
-        description: "dawproject",
-        accept: {"application/octet-stream": [".dawproject"]}
-    }
+  /** Accepts bundled project archives containing samples. */
+  export const ProjectBundleFileType: FilePickerAcceptType = {
+    description: "openDAW project bundle",
+    accept: { "application/octet-stream": [".odb"] },
+  };
+
+  /** Accepts [dawproject](https://dawproject.org) interchange files. */
+  export const DawprojectFileType: FilePickerAcceptType = {
+    description: "dawproject",
+    accept: { "application/octet-stream": [".dawproject"] },
+  };
 }

--- a/packages/app/studio/src/ui/browse/SampleBrowser.sass
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.sass
@@ -13,6 +13,7 @@ component
   outline: none
   @include colors.panel-background
 
+  // Top row with location selector and search field
   > div.filter
     display: flex
     align-items: center
@@ -22,6 +23,7 @@ component
     margin-bottom: 0.5rem
     grid-column: 1 / -1
 
+  // Scrollable list of sample entries
   > div.content
     flex: 1 0 0
     display: grid
@@ -30,6 +32,7 @@ component
     align-content: start
     overflow: hidden
 
+  // Bottom row with preview volume slider
   > div.footer
     display: flex
     align-items: center
@@ -45,6 +48,7 @@ component
   header
     padding-left: 6px
 
+  // Header and entry grid share column layout
   header, div.scrollable
     display: grid
     grid-template-columns: subgrid
@@ -60,9 +64,11 @@ component
   div.scrollable
     overflow-y: scroll
 
+  // Loading indicator while samples are fetched
   div.loading
     display: flex
 
+  // Error message with retry button
   div.error
     display: flex
     flex-direction: column

--- a/packages/app/studio/src/ui/browse/SampleBrowser.tsx
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.tsx
@@ -35,7 +35,9 @@ const className = Html.adoptStyleSheet(css, "Samples");
 
 /** Construction parameters for {@link SampleBrowser}. */
 type Construct = {
+  /** Lifecycle into which subscriptions are registered. */
   lifecycle: Lifecycle;
+  /** Access to studio services such as sample playback. */
   service: StudioService;
 };
 
@@ -44,7 +46,9 @@ const location = new DefaultObservableValue(SampleLocation.Cloud);
 
 /**
  * Browser and management UI for audio samples, allowing local or cloud
- * sources and providing preview and deletion options.
+ * sources and providing preview, deletion and volume control.
+ *
+ * Keyboard delete removes selected local samples.
  */
 export const SampleBrowser = ({ lifecycle, service }: Construct) => {
   lifecycle.own({ terminate: () => service.samplePlayback.eject() });

--- a/packages/app/studio/src/ui/browse/SampleDialogs.tsx
+++ b/packages/app/studio/src/ui/browse/SampleDialogs.tsx
@@ -11,13 +11,24 @@ import { FilePickerAcceptTypes } from "@/ui/FilePickerAcceptTypes";
 
 /** Dialog helpers for managing samples. */
 export namespace SampleDialogs {
-  /** Open the browser's file picker for selecting sample files. */
+  /**
+   * Open the browser's file picker for selecting sample files.
+   *
+   * @param multiple Allow selection of multiple files.
+   * @returns Result of the picker invocation.
+   */
   export const nativeFileBrowser = async (multiple: boolean = true) =>
     Promises.tryCatch(
       Files.open({ ...FilePickerAcceptTypes.WavFiles, multiple }),
     );
 
-  /** Prompt the user to locate a missing sample on disk. */
+  /**
+   * Prompt the user to locate a missing sample on disk.
+   *
+   * @param importer Handles storing the selected sample.
+   * @param uuid Identifier of the missing sample.
+   * @param name Display name shown to the user.
+   */
   export const missingSampleDialog = async (
     importer: SampleImporter,
     uuid: UUID.Format,
@@ -89,7 +100,12 @@ export namespace SampleDialogs {
     return promise;
   };
 
-  /** Show a dialog to edit the name and bpm metadata of a sample. */
+  /**
+   * Show a dialog to edit the name and bpm metadata of a sample.
+   *
+   * @param sample The sample to mutate.
+   * @returns Updated sample after confirmation.
+   */
   export const showEditSampleDialog = async (
     sample: Sample,
   ): Promise<Sample> => {

--- a/packages/docs/docs-dev/ui/files/drag-and-drop.md
+++ b/packages/docs/docs-dev/ui/files/drag-and-drop.md
@@ -1,0 +1,7 @@
+# Drag and Drop
+
+Generic helpers and data shapes for drag operations.
+
+- [`DragAndDrop`](../../../../../packages/app/studio/src/ui/DragAndDrop.ts) installs drag sources and targets in the UI.
+- [`AnyDragData`](../../../../../packages/app/studio/src/ui/AnyDragData.ts) documents the payload formats shared between drag participants.
+- [`Dragging`](../../../../../packages/lib/dom/src/dragging.ts) offers low‑level pointer tracking used by timeline and mixer editors.

--- a/packages/docs/docs-dev/ui/files/overview.md
+++ b/packages/docs/docs-dev/ui/files/overview.md
@@ -1,0 +1,9 @@
+# File Utilities
+
+Helpers for working with files in the studio UI.
+
+- [`FilePickerAcceptTypes`](../../../../../packages/app/studio/src/ui/FilePickerAcceptTypes.ts) defines preset accept filters for the browser's file picker.
+- [`SampleDialogs`](../../../../../packages/app/studio/src/ui/browse/SampleDialogs.tsx) prompts users to locate, import or edit samples.
+- [`SampleBrowser`](../../../../../packages/app/studio/src/ui/browse/SampleBrowser.tsx) lists local and cloud samples with search and preview.
+- [`SampleImporter`](../../../../../packages/app/studio/src/project/SampleImporter.ts) describes the contract for storing audio in a project.
+- [Drag and Drop](./drag-and-drop.md) covers the generic drag helpers and payload types.

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -4,6 +4,12 @@ Import, export, and organize project files. Developers can dive deeper in the
 [project docs](../../docs-dev/projects/overview.md) and the
 [info panel reference](../../docs-dev/ui/info-panel/overview.md).
 
+## Browse and Organize Samples
+
+- Use the **Sample Browser** to switch between cloud and local libraries.
+- Search, preview and delete samples directly from the list.
+- Adjust preview volume with the slider in the browser footer.
+
 ## Save Projects
 
 1. **Write changes to the browser.** Press <kbd>Ctrl</kbd>+<kbd>S</kbd> or choose

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -117,6 +117,14 @@ module.exports = {
           ],
         },
         "ui/browse",
+        {
+          type: "category",
+          label: "Files",
+          items: [
+            "ui/files/overview",
+            "ui/files/drag-and-drop",
+          ],
+        },
       ],
     },
     {

--- a/packages/lib/dom/src/dragging.ts
+++ b/packages/lib/dom/src/dragging.ts
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import {Dragging} from "@opendaw/lib-dom";
- * import {Option} from "@opendaw/lib-std";
+ * import { Dragging } from "@opendaw/lib-dom";
+ * import { Option } from "@opendaw/lib-std";
  *
  * const detach = Dragging.attach(element, ev => Option.some({
  *   update(e) { console.log(e.clientX, e.clientY); }
@@ -57,6 +57,11 @@ export namespace Dragging {
   /**
    * Attaches pointer listeners to `target` and creates a dragging lifecycle
    * managed by a `Process` instance produced by `factory`.
+   *
+   * @param target Element initiating the pointer interaction.
+   * @param factory Produces a {@link Process} for the drag sequence.
+   * @param options Additional configuration flags.
+   * @returns Terminable subscription controlling the drag lifecycle.
    */
   export const attach = <T extends PointerCaptureTarget>(
     target: T,
@@ -152,7 +157,7 @@ export namespace Dragging {
           Events.subscribe(
             self,
             "beforeunload",
-            (_event: BeforeUnloadEvent) => {
+            () => {
               // Workaround for Chrome (does not release or cancel pointer)
               target.releasePointerCapture(pointerId);
               cancel();

--- a/packages/lib/dom/src/files.ts
+++ b/packages/lib/dom/src/files.ts
@@ -3,7 +3,8 @@
  *
  * @example
  * ```ts
- * const arrayBuffer = await fetch(url).then(r => r.arrayBuffer());
+ * import { Files } from "@opendaw/lib-dom";
+ * const arrayBuffer = await fetch(url).then((r) => r.arrayBuffer());
  * await Files.save(arrayBuffer, { suggestedName: "sample.bin" });
  * ```
  */
@@ -15,6 +16,8 @@ export namespace Files {
    * Saves an `ArrayBuffer` as a file using the File System Access API when
    * available, falling back to a download link otherwise.
    *
+   * @param arrayBuffer Data to persist.
+   * @param options Optional picker configuration.
    * @returns Name of the created file.
    */
   export const save = async (
@@ -44,6 +47,9 @@ export namespace Files {
    * Opens a file selection dialog and returns the selected `File` objects.
    * Uses the File System Access API when supported and falls back to a
    * hidden `<input>` element otherwise.
+   *
+   * @param options Optional picker configuration.
+   * @returns List of selected files.
    */
   export const open = async (
     options?: OpenFilePickerOptions,


### PR DESCRIPTION
## Summary
- document file picker accept types and drag data utilities
- expand file browser dialogs and sample interfaces
- add developer and user docs for file management and drag & drop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68af1f9e6f988321a32969b1bea14e13