### PR TITLE
docs: document metering components

### DIFF
--- a/packages/app/studio/src/ui/meter/VUMeter.tsx
+++ b/packages/app/studio/src/ui/meter/VUMeter.tsx
@@ -28,8 +28,15 @@ export namespace VUMeter {
     geometry: Geometry;
   }
 
+  /** Props for {@link Element}. */
   type Construct = { design: Design; model: ObservableValue<unitValue> };
 
+  /**
+   * Builds a URL to load a Google Web Font.
+   *
+   * @param fontFamily - Name of the font family.
+   * @param fontWeight - Desired weight to request.
+   */
   const getGoogleFontUrl = (fontFamily: string, fontWeight: number) =>
     `url("https://fonts.googleapis.com/css?family=${fontFamily.replace(" ", "+")}:${fontWeight}")`;
 
@@ -202,6 +209,9 @@ export namespace VUMeter {
       this.#style = style;
     }
 
+    /**
+     * Defines the section of the meter the stripe occupies.
+     */
     setSection(u0: number, u1: number, v0: number, v1: number): this {
       this.#u0 = u0;
       this.#u1 = u1;
@@ -210,11 +220,20 @@ export namespace VUMeter {
       return this;
     }
 
+    /** Adds a marker spanning from `u0` to `u1` with the given radial `length`. */
     addMarker(u0: number, u1: number, length: number): this {
       this.#markers.push({ u0, u1, length });
       return this;
     }
 
+    /**
+     * Adds a marker centered around a unit value.
+     *
+     * @param unit - Normalised position on the scale.
+     * @param width - Width of the marker in unit space.
+     * @param length - Radial length of the marker.
+     * @param align - Alignment relative to the unit value.
+     */
     addMarkerAt(
       unit: number,
       width: number,
@@ -243,6 +262,7 @@ export namespace VUMeter {
       return this;
     }
 
+    /** Finalises the stripe and returns the SVG path element. */
     build(): SVGPathElement {
       const markers = this.#markers;
       const u0 =

--- a/packages/app/studio/src/ui/meter/VUMeterPanel.tsx
+++ b/packages/app/studio/src/ui/meter/VUMeterPanel.tsx
@@ -25,7 +25,12 @@ type Construct = {
   service: StudioService;
 };
 
-/** Renders the VU meters and subscribes to peak data from the engine. */
+/**
+ * Renders the VU meters and subscribes to peak data from the engine.
+ *
+ * @param lifecycle - Lifecycle owner managing subscriptions.
+ * @param service - Studio service used to obtain the metering stream.
+ */
 export const VUMeterPanel = ({ lifecycle, service }: Construct) => {
   const peakL = lifecycle.own(new DefaultObservableValue(0.0));
   const peakR = lifecycle.own(new DefaultObservableValue(0.0));

--- a/packages/app/studio/src/ui/mixer/ChannelStrip.tsx
+++ b/packages/app/studio/src/ui/mixer/ChannelStrip.tsx
@@ -29,15 +29,25 @@ import {ChannelStripView, ColorCodes, Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "ChannelStrip")
 
+/** Props for {@link ChannelStrip}. */
 type Construct = {
+    /** Lifecycle owner for managing resources. */
     lifecycle: Lifecycle
+    /** Shared studio service. */
     service: StudioService
+    /** Adapter representing the channel's audio unit. */
     adapter: AudioUnitBoxAdapter
+    /** Whether the strip is rendered in compact form. */
     compact: boolean
 }
 
 /**
  * Displays controls for a single track or bus including meters, sends and routing.
+ *
+ * @param lifecycle - Lifecycle owner for subscriptions.
+ * @param service - Access to project state and utilities.
+ * @param adapter - Audio unit backing this channel strip.
+ * @param compact - If `true`, renders a reduced version of the strip.
  */
 export const ChannelStrip = ({lifecycle, service, adapter, compact}: Construct) => {
     const {mute, panning, solo, volume} = adapter.namedParameter

--- a/packages/app/studio/src/ui/mixer/Mixer.tsx
+++ b/packages/app/studio/src/ui/mixer/Mixer.tsx
@@ -21,14 +21,20 @@ type AudioUnitEntry = {
     editor: Element
 }
 
+/** Props for {@link Mixer}. */
 type Construct = {
+    /** Lifecycle owner for managing channel strips. */
     lifecycle: Lifecycle
+    /** Shared studio service. */
     service: StudioService
 }
 
 /**
  * Renders the main mixer view with channel strips for each audio unit.
  * Handles scrolling, ordering and selection of channels.
+ *
+ * @param lifecycle - Lifecycle owner for subscriptions.
+ * @param service - Access to project state and utilities.
  */
 export const Mixer = ({lifecycle, service}: Construct) => {
     const project = service.project

--- a/packages/docs/docs-dev/ui/metering/overview.md
+++ b/packages/docs/docs-dev/ui/metering/overview.md
@@ -1,0 +1,13 @@
+# Metering UI
+
+Developer overview of components responsible for level metering.
+
+## Components
+
+- `VUMeter` – renders an analog-style needle driven by an observable value.
+- `VUMeterPanel` – subscribes to engine streams and displays a pair of meters.
+- `PeakBroadcaster` – worklet helper that publishes peak and RMS data.
+- `SpectrumAnalyser` – FFT-based analyser for visualising frequency content.
+- `MeterWorklet` – audio worklet node that forwards metering information to the UI.
+
+These pieces work together to provide responsive metering across the application.

--- a/packages/docs/docs-dev/ui/metering/rms-vs-peak.md
+++ b/packages/docs/docs-dev/ui/metering/rms-vs-peak.md
@@ -1,0 +1,11 @@
+# RMS vs Peak Metering
+
+Metering can display two different measurements of signal level:
+
+- **Peak** reflects the instantaneous maximum amplitude of the samples.
+- **RMS** (root mean square) averages energy over time and correlates with
+  perceived loudness.
+
+The engine exposes both readings so UI components can show fast peaks alongside
+slower moving RMS bars. Using both helps with proper gain staging and headroom
+management.

--- a/packages/docs/docs-user/features/mixer.md
+++ b/packages/docs/docs-user/features/mixer.md
@@ -19,8 +19,9 @@ pre‑ or post‑fader depending on the desired behavior.
 ## Meter behavior
 
 Channel strips display peak and RMS meters so you can monitor levels at a
-glance. Meters glow red when clipping occurs, helping you manage gain staging
-across the project.
+glance. Peak meters react instantly to transients while RMS meters average
+energy over time to reflect perceived loudness. Meters glow red when clipping
+occurs, helping you manage gain staging across the project.
 
 ## Routing through a bus
 

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -153,6 +153,14 @@ module.exports = {
             "ui/menu/shortcuts",
           ],
         },
+        {
+          type: "category",
+          label: "Metering",
+          items: [
+            "ui/metering/overview",
+            "ui/metering/rms-vs-peak",
+          ],
+        },
         "ui/mixer",
         {
           type: "category",

--- a/packages/lib/dsp/src/rms.ts
+++ b/packages/lib/dsp/src/rms.ts
@@ -1,5 +1,10 @@
 import {int} from "@opendaw/lib-std"
 
+/**
+ * Rolling root-mean-square (RMS) calculator for continuous streams of
+ * samples. Internally a circular buffer is used to maintain the last `n`
+ * squared values and compute the RMS in constant time.
+ */
 export class RMS {
     readonly #values: Float32Array
     readonly #inv: number
@@ -7,6 +12,9 @@ export class RMS {
     #index: int
     #sum: number
 
+    /**
+     * @param n - Length of the sliding window in samples.
+     */
     constructor(n: int) {
         this.#values = new Float32Array(n)
         this.#inv = 1.0 / n
@@ -15,6 +23,12 @@ export class RMS {
         this.#sum = 0.0
     }
 
+    /**
+     * Inserts a new sample into the window and returns the updated RMS value.
+     *
+     * @param x - Input sample to add.
+     * @returns Current RMS of the window contents.
+     */
     pushPop(x: number): number {
         const squared = x * x
         this.#sum -= this.#values[this.#index]
@@ -24,6 +38,7 @@ export class RMS {
         return this.#sum <= 0.0 ? 0.0 : Math.sqrt(this.#sum * this.#inv)
     }
 
+    /** Resets the window contents and internal state. */
     clear(): void {
         this.#values.fill(0.0)
         this.#sum = 0.0

--- a/packages/lib/dsp/src/window.ts
+++ b/packages/lib/dsp/src/window.ts
@@ -3,7 +3,18 @@
  */
 export namespace Window {
     /** Shapes of supported window functions. */
-    export enum Type {Bartlett, Blackman, BlackmanHarris, Hamming, Hanning}
+    export enum Type {
+        /** Triangular Bartlett window. */
+        Bartlett,
+        /** Blackman window with good sidelobe suppression. */
+        Blackman,
+        /** Four-term Blackman–Harris window for very low sidelobes. */
+        BlackmanHarris,
+        /** Hamming window. */
+        Hamming,
+        /** Hanning (raised cosine) window. */
+        Hanning
+    }
 
     /**
      * Generates a window of the desired `type` and length `n`.

--- a/packages/studio/core-processors/src/PeakBroadcaster.ts
+++ b/packages/studio/core-processors/src/PeakBroadcaster.ts
@@ -72,10 +72,18 @@ export class PeakBroadcaster implements Terminable {
         }
     }
 
-    /** Convenience wrapper accepting a stereo channel tuple. */
+    /**
+     * Convenience wrapper accepting a stereo channel tuple instead of
+     * separate left and right buffers.
+     *
+     * @param channels - Tuple containing left and right channel buffers.
+     * @param fromIndex - Start index within the provided buffers.
+     * @param toIndex - End index (exclusive) within the provided buffers.
+     */
     processStereo([l, r]: StereoMatrix.Channels, fromIndex: int = 0, toIndex: int = RenderQuantum): void {
         this.process(l, r, fromIndex, toIndex)
     }
 
+    /** Stops broadcasting and releases resources. */
     terminate(): void {this.#terminable.terminate()}
 }

--- a/packages/studio/core-processors/src/SpectrumAnalyser.ts
+++ b/packages/studio/core-processors/src/SpectrumAnalyser.ts
@@ -43,9 +43,18 @@ export class SpectrumAnalyser {
         this.#index = 0
     }
 
-    /** Returns the number of frequency bins. */
+    /**
+     * Returns the number of frequency bins produced by the FFT.
+     *
+     * @returns Number of bins.
+     */
     numBins(): int {return this.#numBins}
-    /** Buffer containing the current spectrum magnitude per bin. */
+
+    /**
+     * Provides access to the current spectrum magnitudes.
+     *
+     * @returns Buffer of length {@link numBins} containing the magnitudes.
+     */
     bins(): Float32Array {return this.#bins}
 
     /**

--- a/packages/studio/core/src/MeterWorklet.ts
+++ b/packages/studio/core/src/MeterWorklet.ts
@@ -45,8 +45,14 @@ export class MeterWorklet extends AudioWorkletNode implements Terminable {
         )
     }
 
-    /** Subscribe to receive metering updates. */
+    /**
+     * Subscribe to receive metering updates.
+     *
+     * @param observer - Callback invoked with peak and RMS values.
+     * @returns Subscription handle used to unsubscribe.
+     */
     subscribe(observer: Observer<PeakSchema>): Subscription {return this.#notifier.subscribe(observer)}
+
     /** Terminates the worklet and releases resources. */
     terminate(): void {this.#terminator.terminate()}
 }


### PR DESCRIPTION
## Summary
- add TSDoc for RMS utilities and window functions
- document PeakBroadcaster, SpectrumAnalyser and MeterWorklet
- annotate mixer and meter UI components, add metering docs

## Testing
- `npm test` *(fails: Could not resolve workspaces in package-lock)*
- `npm run lint` *(fails: Could not resolve workspaces in package-lock)*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa035508321bdb1205cd15be794