### PR TITLE
docs: document messaging architecture and services

### DIFF
--- a/packages/app/studio/src/service/SessionService.ts
+++ b/packages/app/studio/src/service/SessionService.ts
@@ -37,11 +37,18 @@ export class SessionService implements MutableObservableValue<Option<ProjectSess
         this.#session = new DefaultObservableValue<Option<ProjectSession>>(Option.None)
     }
 
+    /** @inheritdoc */
     getValue(): Option<ProjectSession> {return this.#session.getValue()}
+    /** @inheritdoc */
     setValue(value: Option<ProjectSession>): void {this.#session.setValue(value)}
+    /** @inheritdoc */
     subscribe(observer: Observer<ObservableValue<Option<ProjectSession>>>): Terminable {
         return this.#session.subscribe(observer)
     }
+    /**
+     * Subscribes to the session value and immediately dispatches the current
+     * state to the observer.
+     */
     catchupAndSubscribe(observer: Observer<ObservableValue<Option<ProjectSession>>>): Terminable {
         observer(this)
         return this.#session.subscribe(observer)

--- a/packages/app/studio/src/service/StudioSignal.ts
+++ b/packages/app/studio/src/service/StudioSignal.ts
@@ -14,9 +14,12 @@ import {Sample} from "@opendaw/studio-adapters"
  */
 export type StudioSignal =
     | {
+    /** Request to reset all waveform peaks. */
     type: "reset-peaks"
 } | {
+    /** Import the given sample into the project. */
     type: "import-sample", sample: Sample
 } | {
+    /** Delete a project identified by its metadata. */
     type: "delete-project", meta: ProjectMeta
 }

--- a/packages/app/studio/src/service/SyncLogService.ts
+++ b/packages/app/studio/src/service/SyncLogService.ts
@@ -15,6 +15,11 @@ import {Commit, SyncLogReader, SyncLogWriter} from "@opendaw/studio-core"
  * ```
  */
 export namespace SyncLogService {
+    /**
+     * Start a new SyncLog and attach it to the current project.
+     *
+     * @param service - Studio service providing the project context.
+     */
     export const start = async (service: StudioService) => {
         if (!isDefined(window.showSaveFilePicker)) {return}
         const {
@@ -32,6 +37,11 @@ export namespace SyncLogService {
         SyncLogWriter.attach(service.project, wrapBlockWriter(handle, () => label.setValue(`${++count} commits`)))
     }
 
+    /**
+     * Append commits to an existing SyncLog file selected by the user.
+     *
+     * @param service - Studio service providing the project context.
+     */
     export const append = async (service: StudioService) => {
         const openResult = await Promises.tryCatch(window.showOpenFilePicker(FilePickerAcceptTypes.ProjectSyncLog))
         if (openResult.status === "rejected") {return}
@@ -65,6 +75,12 @@ export namespace SyncLogService {
         SyncLogWriter.attach(service.project, wrapBlockWriter(handle, () => label.setValue(`${++count} commits`)), lastCommit)
     }
 
+    /**
+     * Creates a block writer that serializes commits to the given file handle.
+     *
+     * @param handle - Destination file handle.
+     * @param callback - Invoked after each commit has been queued.
+     */
     const wrapBlockWriter = (handle: FileSystemFileHandle, callback: Exec) => {
         let blocks: Array<Commit> = []
         let lastPromise: Promise<void> = Promise.resolve()
@@ -83,6 +99,7 @@ export namespace SyncLogService {
         }
     }
 
+    /** Concatenates array buffers into a single buffer. */
     const appendArrayBuffers = (buffers: ReadonlyArray<ArrayBuffer>): ArrayBuffer => {
         const totalLength = buffers.reduce((sum, buffer) => sum + buffer.byteLength, 0)
         const result = new Uint8Array(totalLength)

--- a/packages/docs/docs-dev/architecture/messaging.md
+++ b/packages/docs/docs-dev/architecture/messaging.md
@@ -1,0 +1,34 @@
+# Messaging
+
+openDAW components communicate across thread and process boundaries using
+light‑weight messaging abstractions built on top of the browser's
+`postMessage` API.  The runtime's {@link packages/lib/runtime/src/messenger.ts | `Messenger`}
+wraps `MessagePort`‑like endpoints and the {@link packages/lib/runtime/src/communicator.ts | `Communicator`}
+layer adds a small RPC mechanism.
+
+## Channels and Workers
+
+```mermaid
+sequenceDiagram
+    participant Main
+    participant Worker
+    participant Worklet
+    Main->>Worker: install shared worker
+    Worker-->>Main: acknowledgement
+    Main->>Worklet: construct AudioWorkletNode
+    Worklet-->>Worker: exchange session data
+```
+
+## Remote Calls
+
+```mermaid
+sequenceDiagram
+    participant Sender
+    participant Executor
+    Sender->>Executor: dispatchAndReturn(func, args)
+    Executor-->>Sender: resolve(value)
+```
+
+Messages are structured cloned, so objects with methods or private fields lose
+behaviour when transferred.  Always validate messages received from other
+contexts and prefer passing plain data objects.

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -76,6 +76,9 @@ learn how to build the project in [Build and Run](../build-and-run/setup.md).
 - **Lib** – Supplies shared utilities and reusable logic across modules.
 - **Config** – Delivers runtime and build settings consumed by other components.
 
+Communication between these parts is based on lightweight message channels; see
+the [messaging architecture](./messaging.md) for details.
+
 ## Worker Lifecycle
 
 ```mermaid

--- a/packages/docs/docs-user/troubleshooting.md
+++ b/packages/docs/docs-user/troubleshooting.md
@@ -42,4 +42,5 @@
   issue and send them to support using the built-in error report template.
 
 - Developers looking to diagnose issues in depth can consult the
-  [debugging guide](/dev/debugging/overview).
+  [debugging guide](/dev/debugging/overview) and read about inter-thread
+  messaging in the [architecture docs](../docs-dev/architecture/messaging.md).

--- a/packages/lib/fusion/src/index.ts
+++ b/packages/lib/fusion/src/index.ts
@@ -12,6 +12,7 @@
  * - {@link OpfsWorker} implements file system access backed by the
  *   {@link OpfsProtocol}.
  */
+/** Symbol used to mark that the fusion utilities have been loaded. */
 const key = Symbol.for("@openDAW/lib-fusion")
 
 if ((globalThis as Record<PropertyKey, unknown>)[key]) {

--- a/packages/lib/runtime/src/communicator.test.ts
+++ b/packages/lib/runtime/src/communicator.test.ts
@@ -8,18 +8,30 @@ import { Messenger } from "./messenger";
 import { Communicator } from "./communicator";
 import { Wait } from "./wait";
 
+/**
+ * Structured object used to verify that cloning and round‑tripping data works
+ * across messaging boundaries.
+ */
 type DetailedType = {
   amount: number;
   numbers: Uint8Array;
   nested: { key: { value: "xyz" } };
 };
 
+/** Protocol exposed by the remote implementation. */
 interface RemoteInterface {
+  /** Sends a notification without expecting a response. */
   sendNotification(num: number): void;
+  /** Requests a transformation and resolves with the returned object. */
   fetchAndTransformData(data: DetailedType): Promise<DetailedType>;
+  /** Runs a task reporting progress callbacks. */
   runTask(init: Exec, progress: Procedure<number>): Promise<void>;
 }
 
+/**
+ * Creates a proxy that forwards {@link RemoteInterface} calls over the given
+ * {@link Messenger}.
+ */
 export const setupRemoteCaller = (messenger: Messenger): RemoteInterface =>
   Communicator.sender(
     messenger,
@@ -41,6 +53,7 @@ export const setupRemoteCaller = (messenger: Messenger): RemoteInterface =>
 
 const notificationTracker = new DefaultObservableValue(0);
 
+/** Concrete implementation used by the tests to handle calls. */
 const remoteImplementation = new (class implements RemoteInterface {
   sendNotification(num: number): void {
     notificationTracker.setValue(num);

--- a/packages/lib/runtime/src/communicator.ts
+++ b/packages/lib/runtime/src/communicator.ts
@@ -13,11 +13,16 @@ import { Messenger } from "./messenger";
 import { ExecutorTuple } from "./promises";
 
 /**
- * Communicator provides type-safe communication between Window, Worker, MessagePort, BroadcastChannel.
- * Passed objects are structured cloned: https://developer.mozilla.org/en-US/docs/Web/API/structuredClone
- * It is highly advised not to pass classes with methods and or real private properties (starting with #).
- * They will lose their prototype and private property inheritance, and it is cumbersome to patch that up later.
- * Also read: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain
+ * @packageDocumentation
+ * Implements a typed RPC mechanism that builds on {@link Messenger}.
+ *
+ * Communicator provides type-safe communication between {@link Window},
+ * {@link Worker}, {@link MessagePort} and {@link BroadcastChannel}.  Passed
+ * objects are structured cloned – avoid sending class instances with methods or
+ * private fields as their prototypes will be lost during transport. See
+ * https://developer.mozilla.org/en-US/docs/Web/API/structuredClone and
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain for
+ * further details.
  *
  * Error Handling: protocol violations trigger {@link panic}. Returned promises
  * reject with errors sent from the remote side and should be handled by the
@@ -79,6 +84,13 @@ export namespace Communicator {
     ) => Promise<R>;
   }
 
+  /**
+   * Internal helper that proxies protocol calls through a {@link Messenger}.
+   *
+   * @remarks
+   * Instances track pending promises so that results returned by the remote
+   * executor are mapped back to the correct call site.
+   */
   class Sender<PROTOCOL> implements Dispatcher, Terminable {
     readonly #messenger: Messenger;
     readonly #expected = new Map<int, Return>();

--- a/packages/lib/runtime/src/messenger.ts
+++ b/packages/lib/runtime/src/messenger.ts
@@ -1,6 +1,16 @@
 import { isDefined, Notifier, Nullable, Observable, Observer, Procedure, Subscription, Terminable } from "@opendaw/lib-std"
 
 /**
+ * Utilities for exchanging messages over {@link Port}‑like endpoints.
+ *
+ * @remarks
+ * A messenger wraps objects such as {@link Worker}, {@link MessagePort} or
+ * {@link BroadcastChannel} and exposes a simple observable interface.  It can
+ * also create logical sub‑channels so multiple communication streams share the
+ * same underlying transport.
+ */
+
+/**
  * Minimal subset of the {@link MessagePort} interface required by {@link Messenger}.
  *
  * @remarks

--- a/packages/lib/runtime/src/network.ts
+++ b/packages/lib/runtime/src/network.ts
@@ -8,6 +8,7 @@ import { Promises } from "./promises";
  * using them.
  */
 export namespace network {
+  /** Limits the number of concurrent fetch requests. */
   const limit = new Promises.Limit<Response>(4);
 
   /**

--- a/packages/studio/core/src/EngineWorklet.ts
+++ b/packages/studio/core/src/EngineWorklet.ts
@@ -46,8 +46,10 @@ import { Engine, NoteTrigger } from "./Engine";
  * and must be handled by callers awaiting engine readiness.
  */
 export class EngineWorklet extends AudioWorkletNode implements Engine {
+  /** Monotonic identifier assigned to each worklet instance. */
   static ID: int = 0 | 0;
 
+  /** Unique id of this worklet instance. */
   readonly id = EngineWorklet.ID++;
 
   readonly #terminator: Terminator = new Terminator();
@@ -219,52 +221,68 @@ export class EngineWorklet extends AudioWorkletNode implements Engine {
     );
   }
 
+  /** Starts playback. */
   play(): void {
     this.#commands.play();
   }
+  /** Stops playback optionally resetting the transport. */
   stop(reset: boolean = false): void {
     this.#commands.stop(reset);
   }
+  /** Sets the playback position in pulses per quarter note. */
   setPosition(position: ppqn): void {
     this.#commands.setPosition(position);
   }
+  /** Begins recording; optionally count in before starting. */
   startRecording(countIn: boolean): void {
     this.#commands.startRecording(countIn);
   }
+  /** Stops the current recording session. */
   stopRecording(): void {
     this.#commands.stopRecording();
   }
+  /** Immediately silences the engine. */
   panic(): void {
     this.#commands.panic();
   }
 
+  /** Observable playback state. */
   get isPlaying(): ObservableValue<boolean> {
     return this.#isPlaying;
   }
+  /** True while the engine is recording. */
   get isRecording(): ObservableValue<boolean> {
     return this.#isRecording;
   }
+  /** Indicates that the engine is counting in before recording. */
   get isCountingIn(): ObservableValue<boolean> {
     return this.#isCountingIn;
   }
+  /** Total number of beats to count in before playback starts. */
   get countInBeatsTotal(): ObservableValue<int> {
     return this.#countInBeatsTotal;
   }
+  /** Remaining beats of the active count in. */
   get countInBeatsRemaining(): ObservableValue<number> {
     return this.#countInBeatsRemaining;
   }
+  /** Current transport position in pulses per quarter note. */
   get position(): ObservableValue<ppqn> {
     return this.#position;
   }
+  /** Timestamp reported by the processor used for syncing. */
   get playbackTimestamp(): MutableObservableValue<number> {
     return this.#playbackTimestamp;
   }
+  /** Enables or disables the metronome. */
   get metronomeEnabled(): MutableObservableValue<boolean> {
     return this.#metronomeEnabled;
   }
+  /** Currently active marker or `null` if none. */
   get markerState(): ObservableValue<Nullable<[UUID.Format, int]>> {
     return this.#markerState;
   }
+  /** Project instance the engine operates on. */
   get project(): Project {
     return this.#project;
   }

--- a/packages/studio/core/src/WorkerAgents.ts
+++ b/packages/studio/core/src/WorkerAgents.ts
@@ -18,6 +18,8 @@ export class WorkerAgents {
     /**
      * Installs the shared worker bundle and prepares the underlying
      * {@link Messenger} for communication.
+     *
+     * @param workerURL - URL pointing to the bundled worker script.
      */
     static install(workerURL: string): void {
         console.debug("workerURL", workerURL)
@@ -27,7 +29,12 @@ export class WorkerAgents {
     /** Messenger connected to the worker, set by {@link install}. */
     static messenger: Option<Messenger> = Option.None
 
-    /** Lazily obtains the sample peak protocol exposed by the worker. */
+    /**
+     * Lazily obtains the sample peak protocol exposed by the worker.
+     *
+     * @returns Proxy implementing {@link SamplePeakProtocol} over the worker
+     * channel.
+     */
     @Lazy
     static get Peak(): SamplePeakProtocol {
         return Communicator
@@ -44,7 +51,11 @@ export class WorkerAgents {
                 })
     }
 
-    /** Lazily obtains the OPFS protocol exposed by the worker. */
+    /**
+     * Lazily obtains the OPFS protocol exposed by the worker.
+     *
+     * @returns Proxy implementing {@link OpfsProtocol} for file operations.
+     */
     @Lazy
     static get Opfs(): OpfsProtocol {
         return Communicator


### PR DESCRIPTION
## Summary
- add TSDoc for runtime messaging utilities and related tests
- document Studio services and worker agents
- introduce messaging architecture doc with sequence diagrams and cross references

## Testing
- `npm test`
- `npm run lint` *(fails: command @opendaw/lib-midi#lint exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa0b99c8321a54230e28177a4d0