### PR TITLE
docs: document navigation components

### DIFF
--- a/packages/app/studio/src/ui/App.tsx
+++ b/packages/app/studio/src/ui/App.tsx
@@ -14,6 +14,14 @@ import { ErrorsPage } from "@/ui/pages/ErrorsPage.tsx";
 import { ImprintPage } from "@/ui/pages/ImprintPage.tsx";
 import { GraphPage } from "@/ui/pages/GraphPage";
 
+/**
+ * Root component wiring together routing, header and footer.
+ *
+ * @example
+ * ```tsx
+ * render(App(service), mountNode);
+ * ```
+ */
 export const App = (service: StudioService) => {
   const terminator = new Terminator();
   return (

--- a/packages/app/studio/src/ui/Dashboard.sass
+++ b/packages/app/studio/src/ui/Dashboard.sass
@@ -1,6 +1,11 @@
-// Styles for the Dashboard landing page
 @use "@/colors"
 
+/**
+ * Styles for the Dashboard landing page showing starter templates and projects.
+ *
+ * @example
+ * <div class="Dashboard">...</div>
+ */
 component
   flex: 1
   display: flex

--- a/packages/app/studio/src/ui/Dashboard.tsx
+++ b/packages/app/studio/src/ui/Dashboard.tsx
@@ -14,7 +14,14 @@ type Construct = {
   service: StudioService;
 };
 
-/** Landing page presenting templates and recent projects. */
+/**
+ * Landing page presenting templates and recent projects.
+ *
+ * @example
+ * ```tsx
+ * <Dashboard lifecycle={lifecycle} service={service} />
+ * ```
+ */
 export const Dashboard = ({ service }: Construct) => {
   const time = TimeSpan.millis(
     new Date(service.buildInfo.date).getTime() - new Date().getTime(),

--- a/packages/app/studio/src/ui/Footer.sass
+++ b/packages/app/studio/src/ui/Footer.sass
@@ -1,5 +1,11 @@
 @use "@/colors"
 
+/**
+ * Styling for the application footer showing status and version labels.
+ *
+ * @example
+ * <footer class="footer">...</footer>
+ */
 component
   flex: 0 0 1.25rem
   display: flex

--- a/packages/app/studio/src/ui/Footer.tsx
+++ b/packages/app/studio/src/ui/Footer.tsx
@@ -12,6 +12,14 @@ const className = Html.adoptStyleSheet(css, "footer");
 
 type Construct = { lifecycle: Lifecycle; service: StudioService };
 
+/**
+ * Application footer displaying session information and build metadata.
+ *
+ * @example
+ * ```tsx
+ * <Footer lifecycle={lifecycle} service={service} />
+ * ```
+ */
 export const Footer = ({ lifecycle, service }: Construct) => {
   const labelOnline: HTMLElement = <div title="Online" aria-live="polite" />;
   const updateOnline = () =>

--- a/packages/app/studio/src/ui/pages/AutomationPage.sass
+++ b/packages/app/studio/src/ui/pages/AutomationPage.sass
@@ -1,5 +1,7 @@
-// Styles for the automation examples page.
 @use "@/colors"
+
+// Styles for the automation examples page.
+// See also: ComponentsPage.sass, ManualPage.sass.
 
 component
   flex: 1

--- a/packages/app/studio/src/ui/pages/AutomationPage.tsx
+++ b/packages/app/studio/src/ui/pages/AutomationPage.tsx
@@ -1,5 +1,8 @@
 /**
  * Development page demonstrating value stream rendering and automation edge cases.
+ *
+ * @see ComponentsPage for the interactive component gallery.
+ * @see ManualPage for developer manual navigation.
  */
 import css from "./AutomationPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/pages/BackButton.sass
+++ b/packages/app/studio/src/ui/pages/BackButton.sass
@@ -1,4 +1,9 @@
-// Styles for the studio back navigation button.
+/**
+ * Styles for the studio back navigation button.
+ *
+ * @example
+ * <BackButton />
+ */
 component
   display: contents
 

--- a/packages/app/studio/src/ui/pages/BackButton.tsx
+++ b/packages/app/studio/src/ui/pages/BackButton.tsx
@@ -1,5 +1,10 @@
 /**
  * Navigation button leading back to the studio root.
+ *
+ * @example
+ * ```tsx
+ * <BackButton />
+ * ```
  */
 import css from "./BackButton.sass?inline"
 import {Html} from "@opendaw/lib-dom"

--- a/packages/app/studio/src/ui/pages/ComponentsPage.sass
+++ b/packages/app/studio/src/ui/pages/ComponentsPage.sass
@@ -1,5 +1,7 @@
-// Styles for the components showcase page.
 @use "@/colors"
+
+// Styles for the components showcase page.
+// See also: AutomationPage.sass, ManualPage.sass.
 
 component
   flex: 1

--- a/packages/app/studio/src/ui/pages/ComponentsPage.tsx
+++ b/packages/app/studio/src/ui/pages/ComponentsPage.tsx
@@ -1,5 +1,8 @@
 /**
  * Interactive showcase of reusable UI components.
+ *
+ * @see AutomationPage for automation rendering tests.
+ * @see ManualPage for developer manual navigation.
  */
 import css from "./ComponentsPage.sass?inline"
 import {createElement, PageContext, PageFactory} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/pages/ManualPage.sass
+++ b/packages/app/studio/src/ui/pages/ManualPage.sass
@@ -1,6 +1,8 @@
-// Layout styles for the manuals page and sidebar.
 @use "@/colors"
 @use "@/mixins"
+
+// Layout styles for the manuals page and sidebar.
+// See also: AutomationPage.sass, ComponentsPage.sass.
 
 component
   flex: 1

--- a/packages/app/studio/src/ui/pages/ManualPage.tsx
+++ b/packages/app/studio/src/ui/pages/ManualPage.tsx
@@ -1,5 +1,8 @@
 /**
  * Renders documentation manuals and navigation.
+ *
+ * @see AutomationPage for automation examples.
+ * @see ComponentsPage for the component showcase.
  */
 import css from "./ManualPage.sass?inline"
 import {Await, createElement, LocalLink, PageContext, PageFactory} from "@opendaw/lib-jsx"

--- a/packages/docs/docs-dev/ui/navigation/dashboard.md
+++ b/packages/docs/docs-dev/ui/navigation/dashboard.md
@@ -1,0 +1,6 @@
+# Dashboard
+
+The landing page offering project templates and quick access to recent
+sessions. Implemented by the `Dashboard` component in the Studio
+application.
+

--- a/packages/docs/docs-dev/ui/navigation/footer.md
+++ b/packages/docs/docs-dev/ui/navigation/footer.md
@@ -1,0 +1,5 @@
+# Footer
+
+Displays online status, project name and build information at the bottom of
+the Studio. Provided by the `Footer` component.
+

--- a/packages/docs/docs-dev/ui/navigation/overview.md
+++ b/packages/docs/docs-dev/ui/navigation/overview.md
@@ -1,0 +1,8 @@
+# Navigation
+
+Entry points and global navigation elements in the Studio.
+
+- [Dashboard](./dashboard.md)
+- [Footer](./footer.md)
+- [Pages](./pages.md)
+

--- a/packages/docs/docs-dev/ui/navigation/pages.md
+++ b/packages/docs/docs-dev/ui/navigation/pages.md
@@ -1,0 +1,9 @@
+# Pages
+
+Developer-only pages extend the navigation with utilities and diagnostics.
+These include:
+
+- [Automation](../pages/automation.md)
+- [Components](../pages/components.md)
+- [Manuals](../pages/manuals.md)
+

--- a/packages/docs/docs-dev/ui/overview.md
+++ b/packages/docs/docs-dev/ui/overview.md
@@ -4,4 +4,5 @@
 - [Menu](./menu/overview.md)
 - [Validator](./validator/overview.md)
 - [Canvas](./canvas/overview.md)
+- [Navigation](./navigation/overview.md)
 

--- a/packages/docs/docs-user/ui-tour.md
+++ b/packages/docs/docs-user/ui-tour.md
@@ -52,3 +52,4 @@ For internal tooling and diagnostics see:
 - [Diagnostics](../docs-dev/ui/pages/diagnostics.md)
 - [Icons](../docs-dev/ui/pages/icons.md)
 - [Manuals](../docs-dev/ui/pages/manuals.md)
+ - [Navigation](../docs-dev/ui/navigation/overview.md)


### PR DESCRIPTION
## Summary
- add usage TSDoc for dashboard, footer, back button, and app
- cross-link developer pages for automation, components, and manuals
- write navigation docs and link from UI tour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af1fa12fe88321890deee30b98e8bd