### PR TITLE
docs: add DSP TSDoc and documentation

### DIFF
--- a/packages/docs/docs-dev/dsp/delay.md
+++ b/packages/docs/docs-dev/dsp/delay.md
@@ -1,0 +1,14 @@
+# Delay
+
+Implements a basic delay line with feedback and wet/dry mix.
+
+```ts
+import {Delay} from '@opendaw/lib-dsp';
+
+const delay = new Delay(48000, 64);
+delay.offset = 12000;
+delay.process(input, output, 0, input.length);
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/classes/Delay.html) for full reference.
+

--- a/packages/docs/docs-dev/dsp/fft.md
+++ b/packages/docs/docs-dev/dsp/fft.md
@@ -1,0 +1,13 @@
+# FFT
+
+Performs in-place radix-2 fast Fourier transforms.
+
+```ts
+import {FFT} from '@opendaw/lib-dsp';
+
+const fft = new FFT(1024);
+fft.process(real, imag);
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/classes/FFT.html) for full reference.
+

--- a/packages/docs/docs-dev/dsp/grooves.md
+++ b/packages/docs/docs-dev/dsp/grooves.md
@@ -1,0 +1,19 @@
+# Grooves
+
+Utilities for warping rhythmic positions using bijective functions.
+
+```ts
+import {GroovePattern, QuantisedGrooveFunction} from '@opendaw/lib-dsp';
+
+const func = new QuantisedGrooveFunction(new Float32Array([0, 0.5, 1]));
+const groove = new GroovePattern({
+  duration: () => 480,
+  fx: x => func.fx(x),
+  fy: y => func.fy(y)
+});
+
+const warped = groove.warp(240);
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/) for related types.
+

--- a/packages/docs/docs-dev/dsp/notes.md
+++ b/packages/docs/docs-dev/dsp/notes.md
@@ -1,0 +1,14 @@
+# Notes
+
+Helpers for working with musical note events.
+
+```ts
+import {NoteEvent} from '@opendaw/lib-dsp';
+
+if (NoteEvent.isOfType(event)) {
+  console.log(event.pitch);
+}
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/) for additional utilities.
+

--- a/packages/docs/docs-dev/dsp/oscillators.md
+++ b/packages/docs/docs-dev/dsp/oscillators.md
@@ -1,0 +1,13 @@
+# Oscillators
+
+Band-limited oscillator capable of generating several waveforms.
+
+```ts
+import {BandLimitedOscillator, Waveform} from '@opendaw/lib-dsp';
+
+const osc = new BandLimitedOscillator();
+osc.generate(buffer, 440 / 48000, Waveform.square, 0, buffer.length);
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/classes/BandLimitedOscillator.html) for full reference.
+

--- a/packages/docs/docs-dev/dsp/utilities.md
+++ b/packages/docs/docs-dev/dsp/utilities.md
@@ -1,0 +1,39 @@
+# Utilities
+
+Miscellaneous helpers for digital signal processing.
+
+## General Helpers
+
+```ts
+import {midiToHz, parseTimeSignature} from '@opendaw/lib-dsp';
+
+midiToHz(69); // 440
+parseTimeSignature('3/4'); // [3, 4]
+```
+
+## RMS
+
+`RMS` tracks the root-mean-square level over a sliding window.
+
+```ts
+import {RMS} from '@opendaw/lib-dsp';
+
+const rms = new RMS(128);
+rms.pushPop(0.5);
+```
+
+## Value
+
+Utilities for working with automation value events.
+
+```ts
+import {ValueEvent} from '@opendaw/lib-dsp';
+
+// Iterate events in a window
+for (const e of ValueEvent.iterateWindow(events, 0, 960)) {
+  console.log(e.value);
+}
+```
+
+See the [API docs](https://opendaw.org/docs/api/dsp/) for full reference.
+

--- a/packages/lib/dsp/README.md
+++ b/packages/lib/dsp/README.md
@@ -8,6 +8,18 @@ Digital Signal Processing utilities and audio processing functions for TypeScrip
 
 See the [API documentation](https://opendaw.org/docs/api/dsp/) for detailed reference.
 
+## Example
+
+```ts
+import {BandLimitedOscillator, Waveform} from "@opendaw/lib-dsp";
+
+const osc = new BandLimitedOscillator();
+const buffer = new Float32Array(128);
+osc.generate(buffer, 440 / 48000, Waveform.sawtooth, 0, buffer.length);
+```
+
+For more guides and recipes see the [DSP docs](../../docs/docs-dev/dsp/).
+
 ## Signal Flow
 
 ```mermaid
@@ -21,21 +33,21 @@ See {@link BiquadProcessor} and {@link StereoMatrix} for the stages shown above.
 
 ## Core Audio Processing
 
-* **fft.ts** - Fast Fourier Transform implementations
-* **rms.ts** - Root Mean Square calculations
-* **delay.ts** - Audio delay effects and processing
+* **[fft.ts](../../docs/docs-dev/dsp/fft.md)** - Fast Fourier Transform implementations
+* **[rms.ts](../../docs/docs-dev/dsp/utilities.md#rms)** - Root Mean Square calculations
+* **[delay.ts](../../docs/docs-dev/dsp/delay.md)** - Audio delay effects and processing
 * **stereo.ts** - Stereo audio processing utilities ({@link StereoMatrix})
 * **window.ts** - Windowing functions for signal processing ({@link Window})
 
 ## Oscillators & Synthesis
 
-* **osc.ts** - Oscillator implementations and waveform generation
-* **value.ts** - Audio value processing and manipulation
+* **[osc.ts](../../docs/docs-dev/dsp/oscillators.md)** - Oscillator implementations and waveform generation
+* **[value.ts](../../docs/docs-dev/dsp/utilities.md#value)** - Audio value processing and manipulation
 * **ramp.ts** - Smooth parameter transitions and ramping ({@link Ramp})
 
 ## Musical Theory & MIDI
 
-* **notes.ts** - Musical note utilities and conversions
+* **[notes.ts](../../docs/docs-dev/dsp/notes.md)** - Musical note utilities and conversions
 * **chords.ts** - Chord theory and generation ({@link Chord})
 * **midi-keys.ts** - MIDI key mapping and utilities ({@link MidiKeys})
 * **fractions.ts** - Musical fraction calculations ({@link Fraction})
@@ -44,7 +56,7 @@ See {@link BiquadProcessor} and {@link StereoMatrix} for the stages shown above.
 
 * **ppqn.ts** - Pulses Per Quarter Note timing utilities ({@link PPQN})
 * **bpm-tools.ts** - Beats Per Minute calculations and tools ({@link BPMTools})
-* **grooves.ts** - Rhythm and groove pattern utilities
+* **[grooves.ts](../../docs/docs-dev/dsp/grooves.md)** - Rhythm and groove pattern utilities
 
 ## Audio Graph & Events
 
@@ -59,5 +71,5 @@ See {@link BiquadProcessor} and {@link StereoMatrix} for the stages shown above.
 
 ## Utilities
 
-* **utils.ts** - General DSP utility functions
+* **[utils.ts](../../docs/docs-dev/dsp/utilities.md)** - General DSP utility functions
 * **global-console.d.ts** - Global console type definitions

--- a/packages/lib/dsp/src/fft.ts
+++ b/packages/lib/dsp/src/fft.ts
@@ -1,6 +1,8 @@
 import {int} from "@opendaw/lib-std"
 
+/** In-place radix-2 fast Fourier transform. */
 export class FFT {
+    /** Bit-reversal helper for FFT processing. */
     static reverse(i: int) {
         i = (i & 0x55555555) << 1 | (i >>> 1) & 0x55555555
         i = (i & 0x33333333) << 2 | (i >>> 2) & 0x33333333
@@ -14,6 +16,11 @@ export class FFT {
     readonly #cosTable: Float32Array
     readonly #sinTable: Float32Array
 
+    /**
+     * Creates an FFT instance.
+     *
+     * @param n - FFT size (must be power of two).
+     */
     constructor(n: int) {
         this.#n = n
 
@@ -28,6 +35,7 @@ export class FFT {
         }
     }
 
+    /** Performs the transform on the provided real and imaginary arrays. */
     process(real: Float32Array, imag: Float32Array): void {
         let i: int, j: int, k: int, temp: number
         for (let i = 0 | 0; i < this.#n; ++i) {

--- a/packages/lib/dsp/src/fragmentor.ts
+++ b/packages/lib/dsp/src/fragmentor.ts
@@ -1,7 +1,9 @@
 import {int} from "@opendaw/lib-std"
 import {ppqn} from "./ppqn"
 
+/** Helpers to iterate over PPQN ranges. */
 export class Fragmentor {
+    /** Iterates positions between two PPQN values using a fixed step size. */
     static* iterate(p0: ppqn, p1: ppqn, stepSize: ppqn): Generator<ppqn> {
         let index = Math.ceil(p0 / stepSize)
         let position = index * stepSize
@@ -11,6 +13,11 @@ export class Fragmentor {
         }
     }
 
+    /**
+     * Iterates positions and their corresponding index within the range.
+     *
+     * @returns An iterator yielding objects with position and step index.
+     */
     static* iterateWithIndex(p0: ppqn, p1: ppqn, stepSize: ppqn): Generator<{ position: ppqn, index: int }> {
         let index = Math.ceil(p0 / stepSize)
         let position = index * stepSize

--- a/packages/lib/dsp/src/grooves.test.ts
+++ b/packages/lib/dsp/src/grooves.test.ts
@@ -1,3 +1,4 @@
+/** Vitest specifications for groove utilities. */
 import {describe, expect, it} from "vitest"
 import {
     Groove,
@@ -10,18 +11,22 @@ import {
 import {PPQN, ppqn} from "./ppqn"
 import {moebiusEase, Random} from "@opendaw/lib-std"
 
+/** Helper to create a moebius-easing groove pattern. */
 const createMEGroove = (duration: ppqn, amount: number) => new GroovePattern({
     duration: (): ppqn => duration,
     fx: x => moebiusEase(x, amount),
     fy: y => moebiusEase(y, 1.0 - amount)
 } satisfies GroovePatternFunction)
 
+/** Creates a groove that offsets positions by a constant amount. */
 const createOffsetGroove = (offset: ppqn): Groove => ({
     warp: (position: ppqn): ppqn => position + offset,
     unwarp: (position: ppqn): ppqn => position - offset
 })
 
+/** Ensures a groove's warp/unwarp functions are inverse. */
 const groovePingPong = (groove: Groove, x: ppqn) => expect(groove.unwarp(groove.warp(x))).toBeCloseTo(x, 7)
+/** Ensures a bijective function round-trips correctly. */
 const bijectivePingPong = (func: GrooveFunction, x: ppqn) => expect(func.fy(func.fx(x))).toBeCloseTo(x, 7)
 
 describe("Grooves", () => {

--- a/packages/lib/dsp/src/grooves.ts
+++ b/packages/lib/dsp/src/grooves.ts
@@ -1,24 +1,32 @@
 import {ppqn} from "./ppqn"
 import {assert, Bijective, BinarySearch, FloatArray, NumberComparator, quantizeFloor, unitValue} from "@opendaw/lib-std"
 
+/** Bijective mapping between normalised time values. */
 export interface GrooveFunction extends Bijective<unitValue, unitValue> {}
 
+/** Time-warping function that repeats over a duration. */
 export interface GroovePatternFunction extends GrooveFunction {
+    /** Duration of a single pattern cycle in PPQN. */
     duration(): ppqn
 }
 
+/** Warp/unwarp positions expressed in PPQN. */
 export interface Groove {
+    /** Maps a position from original to warped space. */
     warp(position: ppqn): ppqn
+    /** Maps a position from warped back to original space. */
     unwarp(position: ppqn): ppqn
 }
 
 export namespace Groove {
+    /** No-op groove that leaves positions unchanged. */
     export const Identity: Groove = {
         warp: (position: ppqn): ppqn => position,
         unwarp: (position: ppqn): ppqn => position
     }
 }
 
+/** Applies a {@link GroovePatternFunction} to warp PPQN positions. */
 export class GroovePattern implements Groove {
     readonly #func: GroovePatternFunction
 
@@ -36,6 +44,7 @@ export class GroovePattern implements Groove {
     }
 }
 
+/** Groove function defined by quantised lookup table. */
 export class QuantisedGrooveFunction implements GrooveFunction {
     readonly #values: FloatArray
 
@@ -46,6 +55,7 @@ export class QuantisedGrooveFunction implements GrooveFunction {
         this.#values = values
     }
 
+    /** Forward transform from input to output space. */
     fx(x: unitValue): unitValue {
         if (x <= 0.0) {return 0.0}
         if (x >= 1.0) {return 1.0}
@@ -56,6 +66,7 @@ export class QuantisedGrooveFunction implements GrooveFunction {
         return valueFloor + alpha * (this.#values[idxInteger + 1] - valueFloor)
     }
 
+    /** Inverse transform from output back to input space. */
     fy(y: unitValue): unitValue {
         if (y <= 0.0) {return 0.0}
         if (y >= 1.0) {return 1.0}
@@ -67,6 +78,7 @@ export class QuantisedGrooveFunction implements GrooveFunction {
     }
 }
 
+/** Combines multiple grooves and applies them sequentially. */
 export class GrooveChain implements Groove {
     readonly #grooves: ReadonlyArray<Groove>
 

--- a/packages/lib/dsp/src/index.ts
+++ b/packages/lib/dsp/src/index.ts
@@ -1,3 +1,4 @@
+/** Entry point for the DSP library and module re-exports. */
 const key = Symbol.for("@openDAW/lib-dsp")
 
 if ((globalThis as any)[key]) {

--- a/packages/lib/dsp/src/notes.ts
+++ b/packages/lib/dsp/src/notes.ts
@@ -1,17 +1,23 @@
 import {Comparator, float, int, unitValue} from "@opendaw/lib-std"
 import {Event, EventSpan} from "./events"
 
+/** MIDI-style note event with pitch and velocity. */
 export interface NoteEvent extends EventSpan {
     readonly type: "note-event"
 
+    /** MIDI note number. */
     get pitch(): int
+    /** Cent offset from the pitch. */
     get cent(): number
+    /** Velocity value between 0 and 1. */
     get velocity(): float
 }
 
 export namespace NoteEvent {
+    /** Type guard for {@link NoteEvent}. */
     export const isOfType = (event: Event): event is NoteEvent => event.type === "note-event"
 
+    /** Sorts notes by position and pitch. */
     export const Comparator: Comparator<NoteEvent> = (a, b) => {
         const positionDiff = a.position - b.position
         if (positionDiff !== 0) {return positionDiff}
@@ -22,12 +28,15 @@ export namespace NoteEvent {
     }
 
     // TODO Replace with https://www.desmos.com/calculator/ekbzuu5j2x
+    /** Applies an exponential curve to a ratio. */
     export const curveFunc = (ratio: unitValue, curve: number): unitValue =>
         curve < 0.0 ? ratio ** (2.0 ** -curve) : 1.0 - (1.0 - ratio) ** (2.0 ** curve)
 
+    /** Inverse of {@link curveFunc}. */
     export const inverseCurveFunc = (ratio: unitValue, curve: number): unitValue =>
         curve < 0.0 ? ratio ** (2.0 ** curve) : 1.0 - Math.max(0.0, 1.0 - ratio) ** (2.0 ** -curve)
 
+    /** Comparator that also accounts for event completion time. */
     export const CompleteComparator: Comparator<NoteEvent> = (a: NoteEvent, b: NoteEvent) => {
         const diffComplete = EventSpan.complete(a) - EventSpan.complete(b)
         if (diffComplete !== 0) {return diffComplete}

--- a/packages/lib/dsp/src/osc.ts
+++ b/packages/lib/dsp/src/osc.ts
@@ -1,9 +1,20 @@
+/** Supported oscillator waveforms. */
 export enum Waveform {sine, triangle, sawtooth, square}
 
+/** PolyBLEP-based band-limited oscillator. */
 export class BandLimitedOscillator {
     #phase = 0.0
     #integrator = 0.0
 
+    /**
+     * Fills the buffer with the selected waveform.
+     *
+     * @param buffer - Output buffer.
+     * @param phaseInc - Phase increment per sample.
+     * @param waveform - Waveform type to generate.
+     * @param fromIndex - Starting sample index.
+     * @param toIndex - Exclusive end sample index.
+     */
     generate(buffer: Float32Array, phaseInc: number, waveform: Waveform, fromIndex: number, toIndex: number): void {
         for (let i = fromIndex; i < toIndex; i++) {
             const t = this.#phase % 1.0
@@ -35,6 +46,7 @@ export class BandLimitedOscillator {
         }
     }
 
+    /** Band-limited step function used to reduce aliasing. */
     #polyBLEP(t: number, dt: number): number {
         if (t < dt) {
             t /= dt

--- a/packages/lib/dsp/src/rms.ts
+++ b/packages/lib/dsp/src/rms.ts
@@ -1,5 +1,6 @@
 import {int} from "@opendaw/lib-std"
 
+/** Sliding window root-mean-square calculator. */
 export class RMS {
     readonly #values: Float32Array
     readonly #inv: number
@@ -7,6 +8,9 @@ export class RMS {
     #index: int
     #sum: number
 
+    /**
+     * @param n - Number of samples forming the RMS window.
+     */
     constructor(n: int) {
         this.#values = new Float32Array(n)
         this.#inv = 1.0 / n
@@ -15,6 +19,7 @@ export class RMS {
         this.#sum = 0.0
     }
 
+    /** Pushes a sample and returns the current RMS value. */
     pushPop(x: number): number {
         const squared = x * x
         this.#sum -= this.#values[this.#index]
@@ -24,6 +29,7 @@ export class RMS {
         return this.#sum <= 0.0 ? 0.0 : Math.sqrt(this.#sum * this.#inv)
     }
 
+    /** Resets the internal state to zero. */
     clear(): void {
         this.#values.fill(0.0)
         this.#sum = 0.0

--- a/packages/lib/dsp/src/utils.ts
+++ b/packages/lib/dsp/src/utils.ts
@@ -2,21 +2,32 @@ import {int, panic, unitValue} from "@opendaw/lib-std"
 
 const LogDb = Math.log(10.0) / 20.0
 
+/** Converts MIDI note numbers to frequency in hertz. */
 export const midiToHz = (note: number = 60.0, baseFrequency: number = 440.0): number =>
     baseFrequency * Math.pow(2.0, (note + 3.0) / 12.0 - 6.0)
+/** Converts a frequency to its nearest MIDI note number. */
 export const hzToMidi = (hz: number, baseFrequency: number = 440.0): number =>
     (12.0 * Math.log(hz / baseFrequency) + 69.0 * Math.LN2) / Math.LN2
+/** Converts decibels to linear gain. */
 export const dbToGain = (db: number): number => Math.exp(db * LogDb)
+/** Converts linear gain to decibels. */
 export const gainToDb = (gain: number): number => Math.log(gain) / LogDb
+/** Converts MIDI velocity (0–1) to linear gain. */
 export const velocityToGain = (velocity: unitValue): number => dbToGain(20 * Math.log10(velocity))
+/** Calculates BPM from a number of bars and duration in seconds. */
 export const barsToBpm = (bars: number, duration: number): number => (bars * 240.0) / duration
+/** Calculates number of bars played over a duration at given BPM. */
 export const bpmToBars = (bpm: number, duration: number): number => (bpm * duration) / 240.0
+/** Estimates a likely BPM given a duration and maximum allowed tempo. */
 export const estimateBpm = (duration: number, maxBpm: number = 180.0): number => {
     const bpm = barsToBpm(Math.pow(2.0, Math.floor(Math.log(bpmToBars(maxBpm, duration)) / Math.LN2)), duration)
     return Math.round(bpm * 1000.0) / 1000.0
 }
+/** Converts a MIDI semitone value to frequency. */
 export const semitoneToHz = (semitones: number) => 440 * Math.pow(2.0, (semitones - 69.0) / 12.0)
+/** Converts frequency to a MIDI semitone value. */
 export const hzToSemitone = (hz: number) => 69.0 + 12.0 * Math.log2(hz / 440.0)
+/** Parses a time signature string (e.g. "4/4"). */
 export const parseTimeSignature = (input: string): [int, int] => {
     const [first, second] = input.split("/")
     const numerator = parseInt(first, 10)


### PR DESCRIPTION
## Summary
- document DSP utilities with TSDoc
- expand lib-dsp README with example and links
- add developer docs for Delay, FFT, Grooves, Oscillators, Notes and Utilities

## Testing
- `npm test --workspace packages/lib/dsp`
- `npm run --workspace packages/lib/dsp lint`


------
https://chatgpt.com/codex/tasks/task_b_68af1fa18a388321b109cc0ded17361a