### PR TITLE
docs: add tsdoc and std dev guides

### DIFF
--- a/packages/docs/docs-dev/std/collections.md
+++ b/packages/docs/docs-dev/std/collections.md
@@ -1,0 +1,20 @@
+# Collections
+
+The standard library includes a set of lean data structures that avoid
+allocations and keep dependencies minimal.
+
+## Sorted Set
+
+`sorted-set.ts` implements an ordered set with custom key extraction and
+comparison.  Lookups are `O(log n)` thanks to binary search over an internal
+array.
+
+## Multimap
+
+`multimap.ts` provides array and set based multimap implementations allowing
+multiple values per key.
+
+## Maps & Objects
+
+Utility helpers in `maps.ts` and `objects.ts` simplify working with
+JavaScript's `Map`, `WeakMap` and plain object types.

--- a/packages/docs/docs-dev/std/observers.md
+++ b/packages/docs/docs-dev/std/observers.md
@@ -1,0 +1,12 @@
+# Observers
+
+Reactive patterns in the standard library are built around small, synchronous
+primitives.
+
+- `observers.ts` defines the `Observer` callback type.
+- `observables.ts` and `notifier.ts` provide observable values and a simple
+  broadcaster.
+- `terminable.ts` supplies lifecycle management for subscriptions.
+
+Together these pieces enable lightweight reactive flows without pulling in a
+full reactive framework.

--- a/packages/docs/docs-dev/std/overview.md
+++ b/packages/docs/docs-dev/std/overview.md
@@ -1,0 +1,15 @@
+# Standard Library Overview
+
+The `@opendaw/lib-std` package provides a grab bag of utilities used across
+openDAW.  Modules are designed to be imported individually and have no
+runtime dependencies on the DOM or Node.js APIs.
+
+Key areas covered by the library include:
+
+- Type and language helpers such as `lang.ts` and `option.ts`
+- Data structures like `sorted-set.ts` and `multimap.ts`
+- Reactive primitives `observables.ts`, `notifier.ts` and friends
+- Randomness helpers in `random.ts` and `uuid.ts`
+
+Refer to the package [README](../../../lib/std/README.md) for a full list of
+available modules.

--- a/packages/docs/docs-dev/std/randomness.md
+++ b/packages/docs/docs-dev/std/randomness.md
@@ -1,0 +1,9 @@
+# Randomness
+
+Utilities for non‑cryptographic randomness live in `random.ts` and are backed
+by the fast Mulberry32 PRNG.  The `uuid.ts` module builds upon this to generate
+RFC‑4122 compliant UUIDv4 values and to hash arbitrary data into deterministic
+IDs.
+
+These helpers are intended for simulations, tests and procedural generation
+rather than security sensitive tasks.

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -178,5 +178,15 @@ module.exports = {
         "services/stems",
       ],
     },
+    {
+      type: "category",
+      label: "Std Library",
+      items: [
+        "std/overview",
+        "std/collections",
+        "std/observers",
+        "std/randomness",
+      ],
+    },
   ],
 };

--- a/packages/lib/std/README.md
+++ b/packages/lib/std/README.md
@@ -6,6 +6,15 @@ A lightweight standard library offering foundational utilities, algorithms and
 data structures for TypeScript projects. Each file listed below can be imported
 individually.
 
+## Developer Guides
+
+For in-depth discussions and usage examples, see the developer documentation:
+
+* [Standard Library Overview](../../docs/docs-dev/std/overview.md)
+* [Collections](../../docs/docs-dev/std/collections.md)
+* [Observers & Reactivity](../../docs/docs-dev/std/observers.md)
+* [Randomness Utilities](../../docs/docs-dev/std/randomness.md)
+
 ## API Docs
 
 See the [API documentation](https://opendaw.org/docs/api/std/) for detailed reference.

--- a/packages/lib/std/src/crypto.ts
+++ b/packages/lib/std/src/crypto.ts
@@ -1,9 +1,24 @@
 // We do not want to include DOM as a library in ts-config
 // For some strange reason, crypto is not included in WebWorker
 
+/**
+ * Minimal `crypto` API surface used in the project.
+ * This mirrors the subset of the Web Crypto API available in both
+ * browser and worker contexts without pulling in the entire DOM lib.
+ */
 export type Crypto = {
+    /** Web Crypto subtle API for hashing algorithms. */
     subtle: {
+        /**
+         * Computes a digest of the given data using the provided algorithm.
+         * @param algorithm Name of the hash algorithm such as `SHA-256`.
+         * @param data Data to digest.
+         */
         digest(algorithm: string, data: ArrayBufferView | ArrayBuffer): Promise<ArrayBuffer>
     }
+    /**
+     * Fills the provided array with cryptographically strong random values.
+     * @param array Typed array to populate.
+     */
     getRandomValues<T extends ArrayBufferView | null>(array: T): T
 }

--- a/packages/lib/std/src/maps.ts
+++ b/packages/lib/std/src/maps.ts
@@ -1,6 +1,10 @@
 import {Func} from "./lang"
 
+/** Utility helpers for working with `Map` and `WeakMap`. */
 export class Maps {
+    /**
+     * Returns the value for `key` or creates and stores one via `factory`.
+     */
     static createIfAbsent<K, V>(map: Map<K, V>, key: K, factory: Func<K, V>): V {
         let value = map.get(key)
         if (value === undefined) {
@@ -11,7 +15,9 @@ export class Maps {
     }
 }
 
+/** Utilities specifically for `WeakMap`. */
 export class WeakMaps {
+    /** Returns the value for `key` or creates one if absent. */
     static createIfAbsent<K extends object, V>(map: WeakMap<K, V>, key: K, factory: Func<K, V>): V {
         let value = map.get(key)
         if (value === undefined) {

--- a/packages/lib/std/src/multimap.test.ts
+++ b/packages/lib/std/src/multimap.test.ts
@@ -1,3 +1,4 @@
+/** Tests for array and set based multimap implementations. */
 import {beforeEach, describe, expect, it} from "vitest"
 import {ArrayMultimap, Multimap, SetMultimap} from "./multimap"
 import {int} from "./lang"

--- a/packages/lib/std/src/multimap.ts
+++ b/packages/lib/std/src/multimap.ts
@@ -6,6 +6,9 @@ import {Maps} from "./maps"
 import {Option} from "./option"
 import {BinarySearch} from "./binary-search"
 
+/**
+ * Map allowing multiple values per key with various implementations.
+ */
 export interface Multimap<K, V> {
     clear(): void
     containsEntry(key: K, value: V): boolean
@@ -26,6 +29,7 @@ export interface Multimap<K, V> {
     clone(): Multimap<K, V>
 }
 
+/** Multimap backed by arrays preserving insertion order. */
 export class ArrayMultimap<K, V> implements Multimap<K, V>, Iterable<[K, Array<V>]> {
     readonly #map: Map<K, Array<V>>
     readonly #comparator: Option<Comparator<V>>
@@ -153,6 +157,7 @@ export class ArrayMultimap<K, V> implements Multimap<K, V>, Iterable<[K, Array<V
     }
 }
 
+/** Multimap backed by `Set` to ensure unique values per key. */
 export class SetMultimap<K, V> implements Multimap<K, V> {
     private readonly map: Map<K, Set<V>>
 

--- a/packages/lib/std/src/notifier.ts
+++ b/packages/lib/std/src/notifier.ts
@@ -2,7 +2,14 @@ import {Subscription, Terminable} from "./terminable"
 import {Observer} from "./observers"
 import {Observable} from "./observables"
 
+/**
+ * Simple observable implementation for manually notifying observers.
+ */
 export class Notifier<T> implements Observable<T>, Terminable {
+    /**
+     * Subscribes an observer to multiple observables and returns a combined
+     * subscription for easy disposal.
+     */
     static subscribeMany<T extends Observable<any>>(observer: Observer<T>,
                                                     ...observables: ReadonlyArray<T>): Subscription {
         return Terminable.many(...observables
@@ -16,8 +23,12 @@ export class Notifier<T> implements Observable<T>, Terminable {
         return {terminate: (): unknown => this.#observers.delete(observer)}
     }
 
+    /** True if no observers are registered. */
     isEmpty(): boolean {return this.#observers.size === 0}
+    /** Notify all observers with the given value. */
     notify(value: T): void {this.#observers.forEach((observer: Observer<T>) => observer(value))}
+    /** Direct access to the underlying set of observers. */
     observers(): Set<Observer<T>> {return this.#observers}
+    /** Removes all observers and releases references. */
     terminate(): void {this.#observers.clear()}
 }

--- a/packages/lib/std/src/objects.test.ts
+++ b/packages/lib/std/src/objects.test.ts
@@ -1,3 +1,4 @@
+/** Tests for object utility helpers. */
 import {describe, expect, it} from "vitest"
 import {Objects} from "./objects"
 

--- a/packages/lib/std/src/objects.ts
+++ b/packages/lib/std/src/objects.ts
@@ -1,8 +1,14 @@
 import {panic} from "./lang"
 
+/** Convenience utilities for plain JavaScript objects. */
 export namespace Objects {
+    /** Type ensuring two object types share no overlapping keys. */
     export type Disjoint<U, V> = keyof U & keyof V extends never ? V : never
 
+    /**
+     * Merges two objects while asserting that their keys do not overlap.
+     * @throws if a key exists in both objects.
+     */
     export const mergeNoOverlap = <U extends {}, V extends {}>(u: U, v: Disjoint<U, V>): U & V => {
         const keys = new Set(Object.keys(u))
         for (const key of Object.keys(v)) {
@@ -13,12 +19,14 @@ export namespace Objects {
         return ({...u, ...v}) as U & V
     }
 
+    /** Picks only the specified keys from an object. */
     export const include = <T extends {}>(obj: T, ...keys: Array<keyof T>): Partial<T> =>
         keys.reduce((result: Partial<T>, key) => {
             result[key] = obj[key]
             return result
         }, {})
 
+    /** Returns a copy of `obj` without the specified keys. */
     export const exclude = <T extends {}, K extends keyof T>(obj: T, ...keys: Array<K>): Omit<T, K> => {
         const exclude = new Set<keyof T>(keys)
         return Object.entries(obj).reduce((result: any, [key, value]) => {
@@ -29,5 +37,6 @@ export namespace Objects {
         }, {}) as Omit<T, K>
     }
 
+    /** Mutates target by shallow‑merging the patch object. */
     export const overwrite = <T extends {}>(target: T, patch: Partial<T>): T => Object.assign(target, patch)
 }

--- a/packages/lib/std/src/observers.ts
+++ b/packages/lib/std/src/observers.ts
@@ -1,3 +1,4 @@
 import {Procedure} from "./lang"
 
+/** Callback invoked when an {@link Observable} emits a value. */
 export type Observer<VALUE> = Procedure<VALUE>

--- a/packages/lib/std/src/option.test.ts
+++ b/packages/lib/std/src/option.test.ts
@@ -1,3 +1,4 @@
+/** Tests for the {@link Option} utility type. */
 import {describe, expect, it, vi} from "vitest"
 import {Option} from "./option"
 

--- a/packages/lib/std/src/option.ts
+++ b/packages/lib/std/src/option.ts
@@ -12,39 +12,65 @@ import {
     ValueOrProvider
 } from "./lang"
 
+/**
+ * Lightweight `Option` type inspired by Rust.
+ * Represents either `Some<T>` or `None` and provides combinators for
+ * working with potentially missing values without `null` checks.
+ */
 export interface Option<T> {
+    /** Returns the contained value or throws. */
     unwrap(fail?: ValueOrProvider<string>): T
+    /** Returns the contained value or a fallback. */
     unwrapOrElse(or: ValueOrProvider<T>): T
+    /** Returns the value or `null`. */
     unwrapOrNull(): Nullable<T>
+    /** Returns the value or `undefined`. */
     unwrapOrUndefined(): T | undefined
+    /** Pattern matches on the option. */
     match<R>(matchable: Option.Matchable<T, R>): R
+    /** Executes the procedure if the option is `Some`. */
     ifSome<R>(procedure: Procedure<T>): R | undefined
+    /** Checks whether the option contains the given value. */
     contains(value: T): boolean
+    /** True if the option is `None`. */
     isEmpty(): boolean
+    /** True if the option is `Some`. */
     nonEmpty(): boolean
+    /** Maps the wrapped value through a function. */
     map<U>(func: Func<T, U>): Option<U>
+    /** Maps the value or returns a fallback. */
     mapOr<U>(func: Func<T, U>, or: ValueOrProvider<U>): U
+    /** Flat maps to another option. */
     flatMap<U>(func: Func<T, Option<U>>): Option<U>
+    /** Compares for structural equality. */
     equals(other: Option<T>): boolean
+    /** Asserts the option is not `None`. */
     assert(fail?: ValueOrProvider<string>): this
 }
 
 export namespace Option {
+    /** Function pair used by {@link Option.match}. */
     export interface Matchable<T, RETURN> {
         some: Func<T, RETURN>
         none: Provider<RETURN>
     }
 
+    /** Wraps a possibly nullish value into an {@link Option}. */
     export const wrap = <T>(value: Nullish<T>): Option<T | never> => isDefined(value) ? new Some(value) : None
+    /** Lazily evaluates a provider and wraps the result. */
     export const from = <T>(provider: Provider<Nullish<T>>): Option<T> => wrap(provider())
+    /** Executes a provider and catches thrown errors, returning `None` on failure. */
     export const tryFrom = <T>(provider: Provider<T>): Option<T> => {
         try {return Option.wrap(provider())} catch (_error) {return Option.None}
     }
+    /** Executes the function if present and wraps the result. */
     export const execute = <F extends AnyFunc>(func: Nullish<F>, ...args: Parameters<F>)
         : Option<ReturnType<F>> => Option.wrap(func?.apply(null, args))
+    /** Wraps the resolved value of a promise or `None` on rejection. */
     export const async = <RESULT>(promise: Promise<RESULT>): Promise<Option<RESULT>> =>
         promise.then(value => wrap(value), () => None)
 
+    /** Concrete `Some` implementation holding a value. */
     export class Some<T> implements Option<T> {
         readonly #value: T
         constructor(value: T) {this.#value = asDefined(value)}
@@ -66,6 +92,7 @@ export namespace Option {
         get [Symbol.toStringTag]() {return this.toString()}
     }
 
+    /** Constant representing the absence of a value. */
     export const None: Option<never> = new class implements Option<never> {
         readonly unwrap = (fail?: ValueOrProvider<string>): never => panic(isDefined(fail) ? getOrProvide(fail) : "unwrap failed")
         readonly unwrapOrElse = <T>(value: ValueOrProvider<T>): T => getOrProvide(value)

--- a/packages/lib/std/src/progress.ts
+++ b/packages/lib/std/src/progress.ts
@@ -1,11 +1,20 @@
 import {int, Procedure, unitValue} from "./lang"
 import {Arrays} from "./arrays"
 
+/** Utilities for reporting proportional progress of parallel tasks. */
 export namespace Progress {
+    /** Callback receiving progress in the range `[0,1]`. */
     export type Handler = Procedure<unitValue>
 
+    /** No‑op handler used as default. */
     export const Empty: Handler = Object.freeze(_ => {})
 
+    /**
+     * Splits a progress handler into `count` sub handlers that each report
+     * a fraction of the total progress.
+     * @param progress Aggregate handler to receive combined progress.
+     * @param count Number of parallel subtasks.
+     */
     export const split = (progress: Handler, count: int): ReadonlyArray<Handler> => {
         const collect = new Float32Array(count)
         return Arrays.create(index => (value: number) => {

--- a/packages/lib/std/src/random.ts
+++ b/packages/lib/std/src/random.ts
@@ -1,15 +1,30 @@
 import {FloatArray, int, panic, unitValue} from "./lang"
 
+/**
+ * Interface for deterministic pseudo random number generators.
+ * Implementations should produce repeatable sequences when seeded
+ * with the same value.
+ */
 export interface Random {
+    /** Seed the generator with the given value. */
     setSeed(value: int): void
+    /** Returns a random floating point number in `[min,max)`. */
     nextDouble(min: number, max: number): number
+    /** Returns a random integer in `[min,max)`. */
     nextInt(min: int, max: int): int
+    /** Picks a random element from the provided array-like. */
     nextElement<T>(array: ArrayLike<T>): T
+    /** Returns a random boolean value. */
     nextBoolean(): boolean
+    /** Returns a random unit interval value in `[0,1)`. */
     uniform(): unitValue
 }
 
 export namespace Random {
+    /**
+     * Creates a {@link Random} instance seeded with the given value.
+     * @param seed Initial seed for the generator.
+     */
     export const create = (seed: int = 0xF123F42): Random => new Mulberry32(seed)
 
     /**
@@ -38,16 +53,27 @@ export namespace Random {
     }
 }
 
+/**
+ * Mulberry32 PRNG by Tommy Ettinger.
+ * Small and fast generator with 32‑bit state suitable for non‑cryptographic
+ * use cases such as tests or procedural content.
+ */
 export class Mulberry32 implements Random {
     #seed: int = 0
 
     constructor(seed: int) {this.setSeed(seed)}
 
+    /** @inheritdoc */
     setSeed(value: int): void {this.#seed = value & 0xFFFFFFFF}
+    /** @inheritdoc */
     nextDouble(min: number, max: number): number {return min + this.uniform() * (max - min)}
+    /** @inheritdoc */
     nextInt(min: int, max: int): int {return min + Math.floor(this.uniform() * (max - min))}
+    /** @inheritdoc */
     nextElement<T>(array: ArrayLike<T>): T {return array[Math.floor(this.uniform() * array.length)]}
+    /** @inheritdoc */
     nextBoolean(): boolean {return this.uniform() < 0.5}
+    /** @inheritdoc */
     uniform(): unitValue {
         let t = this.#seed += 0x6D2B79F5
         t = Math.imul(t ^ t >>> 15, t | 1)

--- a/packages/lib/std/src/selection.ts
+++ b/packages/lib/std/src/selection.ts
@@ -1,33 +1,55 @@
 import {Subscription} from "./terminable"
 import {int} from "./lang"
 
+/** Coordinate pair used when selecting items in two dimensional space. */
 export type Coordinates<U, V> = { u: U, v: V }
 
+/** Component that reacts when it becomes selected. */
 export interface Selectable {
     onSelected(): void
     onDeselected(): void
 }
 
+/** Listener notified of selection changes. */
 export interface SelectionListener<SELECTABLE> {
     onSelected(selectable: SELECTABLE): void
     onDeselected(selectable: SELECTABLE): void
 }
 
+/**
+ * Mutable set of selected items.
+ */
 export interface Selection<SELECTABLE> {
+    /** Adds the given selectables to the selection. */
     select(...selectables: Array<SELECTABLE>): void
+    /** Removes the given selectables from the selection. */
     deselect(...selectables: Array<SELECTABLE>): void
+    /** Clears the selection. */
     deselectAll(): void
+    /** Checks whether the selectable is currently selected. */
     isSelected(selectable: SELECTABLE): boolean
+    /** True if no elements are selected. */
     isEmpty(): boolean
+    /** Number of selected items. */
     count(): int
+    /** Returns a snapshot of selected items. */
     selected(): ReadonlyArray<SELECTABLE>
+    /**
+     * Returns selectables from inventory which are nearest to the current selection.
+     */
     distance(inventory: ReadonlyArray<SELECTABLE>): ReadonlyArray<SELECTABLE>
+    /** Subscribe to selection events. */
     subscribe(listener: SelectionListener<SELECTABLE>): Subscription
+    /** Subscribe and immediately receive current selection. */
     catchupAndSubscribe(listener: SelectionListener<SELECTABLE>): Subscription
 }
 
+/** Locates selectable items based on coordinates. */
 export interface SelectableLocator<SELECTABLE, U, V> {
+    /** Selectable at a specific coordinate. */
     selectableAt(coordinates: Coordinates<U, V>): Iterable<SELECTABLE>
+    /** Selectables within the rectangular region between coordinates. */
     selectablesBetween(selectionBegin: Coordinates<U, V>, selectionEnd: Coordinates<U, V>): Iterable<SELECTABLE>
+    /** Iterable of all selectables. */
     selectable(): Iterable<SELECTABLE>
 }

--- a/packages/lib/std/src/sorted-set.test.ts
+++ b/packages/lib/std/src/sorted-set.test.ts
@@ -1,3 +1,4 @@
+/** Behavioural tests for {@link SortedSet}. */
 import {describe, expect, it} from "vitest"
 import {SortedSet} from "./sorted-set"
 

--- a/packages/lib/std/src/sorted-set.ts
+++ b/packages/lib/std/src/sorted-set.ts
@@ -41,6 +41,12 @@ export class SortedSet<K, V> implements Iterable<V> {
         this.#array = []
     }
 
+    /**
+     * Inserts a value into the set.
+     * @param value Element to insert.
+     * @param replace When `true`, existing element with same key is replaced.
+     * @returns `true` if the element was added.
+     */
     add(value: V, replace: boolean = false): boolean {
         const key: K = this.#extractor(value)
         const insertIndex: int = BinarySearch.leftMostMapped(this.#array, key, this.#comparator, this.#extractor)

--- a/packages/lib/std/src/terminable.test.ts
+++ b/packages/lib/std/src/terminable.test.ts
@@ -1,3 +1,4 @@
+/** Tests for terminable utilities and cascading subscriptions. */
 import {beforeEach, describe, expect, it} from "vitest"
 import {Option} from "./option"
 import {CascadingSubscriptions, Subscription, Terminable, Terminator} from "./terminable"


### PR DESCRIPTION
## Summary
- document std modules and utilities with TSDoc
- expand lib-std README and add developer docs
- expose std documentation in dev site sidebar

## Testing
- `npm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa3a87483219786258d54abd3ef