### PR TITLE
docs: add dom usage examples

### DIFF
--- a/packages/docs/docs-dev/dom/compression.md
+++ b/packages/docs/docs-dev/dom/compression.md
@@ -1,0 +1,12 @@
+# Compression
+
+`compression.ts` provides thin wrappers around the `CompressionStream` and
+`DecompressionStream` browser APIs.
+
+```ts
+import { Compression } from "@opendaw/lib-dom";
+const buffer = new TextEncoder().encode("hello").buffer;
+const zipped = await Compression.encode(buffer);
+const restored = await Compression.decode(zipped);
+```
+

--- a/packages/docs/docs-dev/dom/css-utils.md
+++ b/packages/docs/docs-dev/dom/css-utils.md
@@ -1,0 +1,10 @@
+# CSS Utils
+
+Helper functions for styling exist in `css-utils.ts`.
+
+```ts
+import { CssUtils } from "@opendaw/lib-dom";
+const value = CssUtils.calc("50% - 1em", 200, 16);
+CssUtils.setCursor("pointer");
+```
+

--- a/packages/docs/docs-dev/dom/events.md
+++ b/packages/docs/docs-dev/dom/events.md
@@ -12,4 +12,10 @@ sub.terminate();
 
 The module also contains helpers for pointer capturing and text-input
 checks that are used by higher level features such as dragging and
-keyboard shortcuts.
+keyboard shortcuts. Double pointer downs can be handled with
+`subscribeDblDwn`:
+
+```ts
+Events.subscribeDblDwn(canvas, e => console.log("double down", e.pointerId));
+```
+

--- a/packages/docs/docs-dev/dom/fonts.md
+++ b/packages/docs/docs-dev/dom/fonts.md
@@ -1,0 +1,14 @@
+# Fonts
+
+Utilities for loading fonts live in `fonts.ts`.
+
+```ts
+import { loadFont } from "@opendaw/lib-dom";
+await loadFont({
+  "font-family": "Demo",
+  "font-style": "normal",
+  "font-weight": "normal",
+  src: "/fonts/demo.woff2"
+});
+```
+

--- a/packages/lib/dom/README.md
+++ b/packages/lib/dom/README.md
@@ -45,6 +45,20 @@ AnimationFrame.add(() => console.log("frame"));
 AnimationFrame.start();
 ```
 
+```ts
+import { loadFont, Compression } from "@opendaw/lib-dom";
+
+await loadFont({
+  "font-family": "Demo",
+  "font-style": "normal",
+  "font-weight": "normal",
+  src: "/fonts/demo.woff2"
+});
+
+const buffer = new TextEncoder().encode("data").buffer;
+const zipped = await Compression.encode(buffer);
+```
+
 ## Modules
 
 - File handling and manipulation utilities **files.ts**
@@ -60,6 +74,7 @@ AnimationFrame.start();
 - Font loading and management **fonts.ts**
 - Error handling for DOM operations **errors.ts**
 - Console utility commands **console-commands.ts**
+- DOM constraint helpers **constraint.ts**
 
 ### Input & Interaction
 
@@ -94,3 +109,4 @@ AnimationFrame.start();
 - Resource cleanup and termination handling **terminable.ts**
 
 For more in‑depth discussion see the [developer docs](../docs/docs-dev/dom/overview.md).
+

--- a/packages/lib/dom/src/compression.ts
+++ b/packages/lib/dom/src/compression.ts
@@ -1,4 +1,18 @@
+/**
+ * Thin wrappers around the
+ * [`CompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
+ * and `DecompressionStream` APIs.
+ */
 export namespace Compression {
+    /**
+     * Compresses an `ArrayBuffer` using the given format.
+     *
+     * @example
+     * ```ts
+     * const data = new TextEncoder().encode("hello").buffer;
+     * const zipped = await Compression.encode(data);
+     * ```
+     */
     export const encode = async (buffer: ArrayBuffer, format: CompressionFormat = "gzip"): Promise<ArrayBuffer> => {
         const stream = new CompressionStream(format)
         const writer = stream.writable.getWriter()
@@ -7,6 +21,14 @@ export namespace Compression {
         return new Response(stream.readable).arrayBuffer()
     }
 
+    /**
+     * Decompresses an `ArrayBuffer` created with {@link encode}.
+     *
+     * @example
+     * ```ts
+     * const restored = await Compression.decode(zipped);
+     * ```
+     */
     export const decode = async (buffer: ArrayBuffer, format: CompressionFormat = "gzip"): Promise<ArrayBuffer> => {
         const stream = new DecompressionStream(format)
         const writer = stream.writable.getWriter()

--- a/packages/lib/dom/src/console-commands.ts
+++ b/packages/lib/dom/src/console-commands.ts
@@ -2,10 +2,28 @@ import {AnyFunc, DefaultObservableValue, EmptyProcedure, ObservableValue, Proced
 
 export type DotPath = string
 
+/**
+ * Exposes values and methods on the global `opendaw` namespace so they can be
+ * interacted with directly from the browser console.
+ */
 export namespace ConsoleCommands {
+    /**
+     * Registers a function that can be invoked from the console using a dot
+     * separated path.
+     *
+     * @example
+     * ```ts
+     * ConsoleCommands.exportMethod("demo.hello", () => console.log("hi"));
+     * // in devtools: opendaw.demo.hello()
+     * ```
+     */
     export const exportMethod = (path: DotPath, callback: AnyFunc): void =>
         store(path, {value: callback})
 
+    /**
+     * Exposes a mutable boolean value to the console and returns an observable
+     * that reflects changes.
+     */
     export const exportBoolean = (path: DotPath, init: boolean = false): ObservableValue<boolean> => {
         const observableValue = new DefaultObservableValue(init)
         exportAccessor(path, () => observableValue.getValue(), input => {
@@ -16,6 +34,9 @@ export namespace ConsoleCommands {
         return observableValue
     }
 
+    /**
+     * Exports a pair of getter/setter functions to the console.
+     */
     export const exportAccessor = (path: DotPath, getter: Provider<unknown>, setter: Procedure<any> = EmptyProcedure): void =>
         store(path, {
             get: () => {

--- a/packages/lib/dom/src/constraint.ts
+++ b/packages/lib/dom/src/constraint.ts
@@ -1,7 +1,24 @@
 // Supported Browsers: Chrome (latest), Firefox (latest), Safari (latest), Edge (Chromium)
 import { isUndefined, Nullish } from "@opendaw/lib-std";
 
+/**
+ * Helpers for resolving `ConstrainDOMString` values.
+ *
+ * These utilities are useful when dealing with APIs such as
+ * `MediaTrackConstraints` which allow a variety of constraint shapes.
+ */
 export namespace ConstrainDOM {
+  /**
+   * Resolves a [`ConstrainDOMString`](https://developer.mozilla.org/en-US/docs/Web/API/ConstrainDOMString)
+   * to a comma separated string or `undefined`.
+   *
+   * @example
+   * ```ts
+   * const constraint: ConstrainDOMString = ["video", "audio"];
+   * const value = ConstrainDOM.resolveString(constraint);
+   * // value === "video,audio"
+   * ```
+   */
   export const resolveString = (
     constrain: Nullish<ConstrainDOMString>,
   ): Nullish<string> => {

--- a/packages/lib/dom/src/css-utils.test.ts
+++ b/packages/lib/dom/src/css-utils.test.ts
@@ -1,6 +1,11 @@
 /**
  * Unit tests for {@link CssUtils.calc}, ensuring CSS expressions are parsed and
  * evaluated correctly.
+ *
+ * @example
+ * ```ts
+ * CssUtils.calc("50% - 1em", 200, 16);
+ * ```
  */
 import { describe, expect, it } from "vitest";
 import { CssUtils } from "./css-utils";

--- a/packages/lib/dom/src/css-utils.ts
+++ b/packages/lib/dom/src/css-utils.ts
@@ -1,6 +1,17 @@
 import {panic} from "@opendaw/lib-std"
 
+/**
+ * Miscellaneous CSS helper utilities.
+ */
 export namespace CssUtils {
+    /**
+     * Evaluates a simple CSS `calc` expression using `size` (px) and `em`.
+     *
+     * @example
+     * ```ts
+     * CssUtils.calc("50% - 1em", 200, 16); // => 84
+     * ```
+     */
     export const calc = (term: string, size: number, em: number): number => {
         const regex = /([0-9]*\.?[0-9]+)([a-zA-Z%]*)/g
         let result = term
@@ -24,8 +35,10 @@ export namespace CssUtils {
 
     const customCursors: Map<number, string> = new Map()
 
+    /** Registers a custom cursor data URI. */
     export const registerCustomCursor = (identifier: number, data: string) => customCursors.set(identifier, data)
 
+    /** Applies either a named or registered cursor to the document. */
     export const setCursor = (identifier: CssUtils.Cursor | number, doc: Document = document) => {
         doc.documentElement.style.cursor = typeof identifier === "number"
             ? customCursors.get(identifier) ?? "auto"
@@ -70,3 +83,4 @@ export namespace CssUtils {
         | "zoom-in"
         | "zoom-out"
 }
+

--- a/packages/lib/dom/src/errors.ts
+++ b/packages/lib/dom/src/errors.ts
@@ -5,6 +5,15 @@ import { panic } from "@opendaw/lib-std";
  *
  * Error Handling: unexpected values are forwarded to {@link panic} so
  * callers should catch and handle aborts explicitly.
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await controller.abort();
+ * } catch (err) {
+ *   Errors.CatchAbort(err);
+ * }
+ * ```
  */
 export namespace Errors {
   export const AbortError =

--- a/packages/lib/dom/src/events.ts
+++ b/packages/lib/dom/src/events.ts
@@ -3,7 +3,21 @@ import { isDefined, Nullable, Procedure, Subscription } from "@opendaw/lib-std";
 
 type KnownEventMap = WindowEventMap & MIDIInputEventMap & MIDIPortEventMap;
 
+/**
+ * Strongly typed helpers for subscribing to DOM events.
+ */
 export class Events {
+  /**
+   * Subscribes to a well known DOM event and returns a {@link Subscription}
+   * that can be terminated later.
+   *
+   * @example
+   * ```ts
+   * const sub = Events.subscribe(window, "resize", () => console.log("resized"));
+   * // ...later
+   * sub.terminate();
+   * ```
+   */
   static subscribe<K extends keyof KnownEventMap>(
     eventTarget: EventTarget,
     type: K,
@@ -21,6 +35,9 @@ export class Events {
     };
   }
 
+  /**
+   * Subscribes to an arbitrary event by name.
+   */
   static subscribeAny<E extends Event>(
     eventTarget: EventTarget,
     type: string,
@@ -40,6 +57,10 @@ export class Events {
 
   static DOUBLE_DOWN_THRESHOLD = 200 as const;
 
+  /**
+   * Subscribes to consecutive `pointerdown` events that occur within
+   * {@link DOUBLE_DOWN_THRESHOLD} milliseconds.
+   */
   static subscribeDblDwn = (
     eventTarget: EventTarget,
     listener: (event: PointerEvent) => void,
@@ -59,9 +80,15 @@ export class Events {
     );
   };
 
+  /**
+   * Convenience handler that calls `preventDefault` on the event.
+   */
   static readonly PreventDefault: Procedure<Event> = (event) =>
     event.preventDefault();
 
+  /**
+   * Checks whether the given target is a text input element.
+   */
   static readonly isTextInput = (target: Nullable<EventTarget>): boolean =>
     target instanceof HTMLInputElement ||
     target instanceof HTMLTextAreaElement ||

--- a/packages/lib/dom/src/fonts.ts
+++ b/packages/lib/dom/src/fonts.ts
@@ -1,4 +1,8 @@
 // Supported Browsers: Chrome (latest), Firefox (latest), Safari (latest), Edge (Chromium)
+
+/**
+ * Properties required to load a custom font.
+ */
 export type FontFaceProperties = {
   "font-family": string;
   "font-style": "normal" | "italic" | "oblique";
@@ -20,6 +24,20 @@ export type FontFaceProperties = {
   src: string;
 };
 
+/**
+ * Loads a font via the `FontFace` API and registers it with the document.
+ *
+ * @example
+ * ```ts
+ * await loadFont({
+ *   "font-family": "MyFont",
+ *   "font-style": "normal",
+ *   "font-weight": "normal",
+ *   src: "/fonts/my-font.woff2"
+ * });
+ * document.body.style.fontFamily = "MyFont";
+ * ```
+ */
 export const loadFont = async (properties: FontFaceProperties) => {
   try {
     const response = await fetch(properties.src, { credentials: "omit" });
@@ -36,3 +54,4 @@ export const loadFont = async (properties: FontFaceProperties) => {
     console.error(error);
   }
 };
+

--- a/packages/lib/dom/src/html.test.ts
+++ b/packages/lib/dom/src/html.test.ts
@@ -3,6 +3,11 @@
 /**
  * Tests for {@link Html.buildClassList}, validating class list construction
  * with optional values.
+ *
+ * @example
+ * ```ts
+ * Html.buildClassList("foo", condition && "bar");
+ * ```
  */
 import { describe, expect, it } from "vitest";
 import { Html } from "./html";

--- a/packages/lib/dom/src/index.ts
+++ b/packages/lib/dom/src/index.ts
@@ -43,3 +43,4 @@ export * from "./modifier-keys";
 export * from "./stream";
 export * from "./svg";
 export * from "./terminable";
+


### PR DESCRIPTION
## Summary
- document DOM constraint helpers, compression, fonts, events, and CSS utilities with TSDoc examples
- expand DOM README with font loading and compression usage
- add developer docs for compression, fonts, CSS utilities, and double pointer events

## Testing
- `npm run lint --workspace packages/lib/dom`
- `npm test --workspace packages/lib/dom`

------
https://chatgpt.com/codex/tasks/task_b_68af1fa3b67c83219c1ee84405834cda