### PR TITLE
docs: expand MIDI docs

### DIFF
--- a/packages/docs/docs-dev/midi/events.md
+++ b/packages/docs/docs-dev/midi/events.md
@@ -1,0 +1,6 @@
+# MIDI Events
+
+`ControlEvent` and `MetaEvent` describe the contents of a MIDI track.
+
+- Channel events such as note on/off are represented by `ControlEvent` with a `ControlType`.
+- Meta events like tempo changes are represented by `MetaEvent` and `MetaType`.

--- a/packages/docs/docs-dev/midi/examples.md
+++ b/packages/docs/docs-dev/midi/examples.md
@@ -1,0 +1,11 @@
+# MIDI Examples
+
+```ts
+import { MidiFile } from "@opendaw/lib-midi";
+
+// Decode a file
+const format = MidiFile.decoder(buffer).decode();
+
+// Encode a new file from existing tracks
+const bytes = MidiFile.encoder().addTrack(format.tracks[0]).encode();
+```

--- a/packages/docs/docs-dev/midi/format.md
+++ b/packages/docs/docs-dev/midi/format.md
@@ -1,0 +1,4 @@
+# MIDI File Format
+
+`MidiFileDecoder` reads Standard MIDI Files and yields a `MidiFileFormat` containing tracks and timing information.
+`MidiFile` provides helpers for both decoding and encoding files.

--- a/packages/docs/docs-dev/midi/overview.md
+++ b/packages/docs/docs-dev/midi/overview.md
@@ -1,0 +1,7 @@
+# MIDI Library Overview
+
+Utilities in `@opendaw/lib-midi` provide low level access to Standard MIDI Files and raw MIDI messages.
+
+- [Event types](./events.md)
+- [File format](./format.md)
+- [Usage examples](./examples.md)

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -41,6 +41,16 @@ module.exports = {
     { type: "doc", id: "licensing" },
     {
       type: "category",
+      label: "MIDI",
+      items: [
+        "midi/overview",
+        "midi/events",
+        "midi/format",
+        "midi/examples",
+      ],
+    },
+    {
+      type: "category",
       label: "Architecture",
       items: [
         "architecture/overview",

--- a/packages/lib/midi/README.md
+++ b/packages/lib/midi/README.md
@@ -16,11 +16,20 @@ an overview of how MIDI structures map onto binary files and other formats.
 ```ts
 import { MidiFile } from "@opendaw/lib-midi";
 
+// Fetch a MIDI file from the network
 const response = await fetch("song.mid");
 const buffer = await response.arrayBuffer();
+// Decode the file into a format object
 const midi = MidiFile.decoder(buffer).decode();
+// Inspect the number of tracks
 console.log(midi.tracks.length);
 ```
+
+### Other decoding scenarios
+
+- Reading from the filesystem using Node.js buffers
+- Inspecting meta-events such as tempo or time signatures
+- Filtering channel events before rendering
 
 ## Encoding a MIDI file
 
@@ -32,12 +41,14 @@ import {
   ControlType,
 } from "@opendaw/lib-midi";
 
+// Create a track and populate it with two note events
 const track = MidiTrack.createEmpty();
 track.controlEvents.add(0, new ControlEvent(0, ControlType.NOTE_ON, 60, 127));
 track.controlEvents.add(0, new ControlEvent(480, ControlType.NOTE_OFF, 60, 0));
 
+// Encode the track into a MIDI file buffer
 const output = MidiFile.encoder().addTrack(track).encode();
-// write output.toUint8Array() to disk
+// Write output.toUint8Array() to disk
 ```
 
 ## Integrating with DSP
@@ -46,6 +57,7 @@ const output = MidiFile.encoder().addTrack(track).encode();
 import { MidiData } from "@opendaw/lib-midi";
 import { BandLimitedOscillator, Waveform } from "@opendaw/lib-dsp";
 
+// Synthesize a note when a MIDI message is received
 const message = MidiData.noteOn(0, 69, 100);
 if (MidiData.isNoteOn(message)) {
   const freq = 440 * Math.pow(2, (MidiData.readPitch(message) - 69) / 12);
@@ -57,6 +69,10 @@ if (MidiData.isNoteOn(message)) {
 
 ## Documentation
 
+- [Package overview](../../docs/docs-dev/midi/overview.md)
+- [Event types](../../docs/docs-dev/midi/events.md)
+- [File format](../../docs/docs-dev/midi/format.md)
+- [Usage examples](../../docs/docs-dev/midi/examples.md)
 - [Serialization mapping](../../docs/docs-dev/serialization/midi.md)
 - [Project-wide overview](../../docs/docs-dev/serialization/overview.md)
 

--- a/packages/lib/midi/src/ControlEvent.ts
+++ b/packages/lib/midi/src/ControlEvent.ts
@@ -13,17 +13,23 @@ export class ControlEvent implements Event<ControlType> {
     a.ticks - b.ticks;
 
   constructor(
+    /** Absolute tick position */
     readonly ticks: int,
+    /** Event type identifier */
     readonly type: ControlType,
+    /** First data byte */
     readonly param0: byte,
+    /** Second data byte */
     readonly param1: byte,
   ) {}
 
   /**
    * Decode a control event from the stream if supported.
-   * @param decoder MIDI file decoder providing the bytes
-   * @param type status byte high nibble
-   * @param ticks absolute tick position
+   *
+   * @param decoder - MIDI file decoder providing the bytes
+   * @param type - status byte high nibble
+   * @param ticks - absolute tick position
+   * @returns the decoded event or {@code null} if unsupported
    */
   static decode(
     decoder: MidiFileDecoder,
@@ -59,6 +65,8 @@ export class ControlEvent implements Event<ControlType> {
 
   /**
    * Apply the visitor callback for this event type.
+   *
+   * @param visitor - visitor with callbacks for supported event kinds
    */
   accept(visitor: ControlEventVisitor): void {
     switch (this.type) {

--- a/packages/lib/midi/src/ControlEventVisitor.ts
+++ b/packages/lib/midi/src/ControlEventVisitor.ts
@@ -4,12 +4,30 @@ import { byte } from "@opendaw/lib-std";
  * Visitor interface for handling decoded {@link ControlEvent} instances.
  */
 export interface ControlEventVisitor {
-  /** Called for a note on message */
+  /**
+   * Called for a note on message.
+   *
+   * @param note - MIDI pitch value
+   * @param velocity - normalized velocity 0..1
+   */
   noteOn?(note: byte, velocity: number): void;
-  /** Called for a note off message */
+  /**
+   * Called for a note off message.
+   *
+   * @param note - MIDI pitch value
+   */
   noteOff?(note: byte): void;
-  /** Called for pitch bend messages with value in -1..1 */
+  /**
+   * Called for pitch bend messages.
+   *
+   * @param delta - bend amount in the range -1..1
+   */
   pitchBend?(delta: number): void;
-  /** Called for controller changes with normalized value */
+  /**
+   * Called for controller changes.
+   *
+   * @param id - controller number
+   * @param value - normalized controller value
+   */
   controller?(id: byte, value: number): void;
 }

--- a/packages/lib/midi/src/MetaType.ts
+++ b/packages/lib/midi/src/MetaType.ts
@@ -28,12 +28,21 @@ export const enum MetaType {
  */
 export class MetaEvent implements Event<MetaType> {
   private constructor(
+    /** Absolute tick position */
     readonly ticks: number,
+    /** Meta-event type identifier */
     readonly type: MetaType,
+    /** Associated payload value */
     readonly value: unknown,
   ) {}
 
-  /** Decode a meta-event from the stream. */
+  /**
+   * Decode a meta-event from the stream.
+   *
+   * @param decoder - MIDI file decoder providing the bytes
+   * @param ticks - absolute tick position
+   * @returns the decoded event or {@code null} if unsupported
+   */
   static decode(decoder: MidiFileDecoder, ticks: number): MetaEvent | null {
     const type = decoder.readByte() & 0xff;
     const length = decoder.readVarLen();

--- a/packages/lib/midi/src/MidiData.ts
+++ b/packages/lib/midi/src/MidiData.ts
@@ -14,40 +14,110 @@ export namespace MidiData {
     Controller = 0xb0,
   }
 
-  /** Extract the command nibble from a MIDI message. */
+  /**
+   * Extract the command nibble from a MIDI message.
+   *
+   * @param data - MIDI message bytes
+   * @returns the command bits from the status byte
+   */
   export const readCommand = (data: Uint8Array) => data[0] & 0xf0;
-  /** Extract the channel nibble from a MIDI message. */
+
+  /**
+   * Extract the channel nibble from a MIDI message.
+   *
+   * @param data - MIDI message bytes
+   * @returns channel number encoded in the status byte
+   */
   export const readChannel = (data: Uint8Array) => data[0] & 0x0f;
-  /** Read first parameter byte if present. */
+
+  /**
+   * Read first parameter byte if present.
+   *
+   * @param data - MIDI message bytes
+   * @returns value of the first parameter or 0 if missing
+   */
   export const readParam1 = (data: Uint8Array) =>
     1 < data.length ? data[1] & 0xff : 0;
-  /** Read second parameter byte if present. */
+
+  /**
+   * Read second parameter byte if present.
+   *
+   * @param data - MIDI message bytes
+   * @returns value of the second parameter or 0 if missing
+   */
   export const readParam2 = (data: Uint8Array) =>
     2 < data.length ? data[2] & 0xff : 0;
-  /** Determine whether the message is a note on event. */
+
+  /**
+   * Determine whether the message is a note on event.
+   *
+   * @param data - MIDI message bytes
+   * @returns true if the command nibble is {@link Command.NoteOn}
+   */
   export const isNoteOn = (data: Uint8Array) =>
     MidiData.readCommand(data) === Command.NoteOn;
-  /** Read the pitch from a note event. */
+
+  /**
+   * Read the pitch from a note event.
+   *
+   * @param data - MIDI message bytes
+   * @returns pitch value in MIDI note numbers
+   */
   export const readPitch = (data: Uint8Array) => data[1];
-  /** Read the velocity from a note-on event and normalize to 0..1. */
+
+  /**
+   * Read the velocity from a note-on event and normalize to 0..1.
+   *
+   * @param data - MIDI message bytes
+   * @returns normalized velocity value
+   */
   export const readVelocity = (data: Uint8Array) => data[2] / 127.0;
-  /** Determine whether the message is a note off event. */
+
+  /**
+   * Determine whether the message is a note off event.
+   *
+   * @param data - MIDI message bytes
+   * @returns true if the command nibble is {@link Command.NoteOff}
+   */
   export const isNoteOff = (data: Uint8Array) =>
     MidiData.readCommand(data) === Command.NoteOff;
-  /** Determine whether the message is a pitch bend. */
+
+  /**
+   * Determine whether the message is a pitch bend.
+   *
+   * @param data - MIDI message bytes
+   * @returns true if the command nibble is {@link Command.PitchBend}
+   */
   export const isPitchWheel = (data: Uint8Array) =>
     MidiData.readCommand(data) === Command.PitchBend;
-  /** Convert pitch wheel data to a normalized value in -1..1. */
+
+  /**
+   * Convert pitch wheel data to a normalized value in -1..1.
+   *
+   * @param data - MIDI message bytes
+   * @returns normalized pitch bend amount
+   */
   export const asPitchBend = (data: Uint8Array) => {
     const p1 = MidiData.readParam1(data) & 0x7f;
     const p2 = MidiData.readParam2(data) & 0x7f;
     const value = p1 | (p2 << 7);
     return 8192 >= value ? value / 8192.0 - 1.0 : (value - 8191) / 8192.0;
   };
-  /** Determine whether the message is a controller change. */
+  /**
+   * Determine whether the message is a controller change.
+   *
+   * @param data - MIDI message bytes
+   * @returns true if the command nibble is {@link Command.Controller}
+   */
   export const isController = (data: Uint8Array): boolean =>
     MidiData.readCommand(data) === Command.Controller;
-  /** Convert controller data to a normalized value. */
+
+  /**
+   * Convert controller data to a normalized value.
+   *
+   * @param data - MIDI message bytes
+   * @returns controller value in the range 0..1
+   */
   export const asValue = (data: Uint8Array) => {
     const value = MidiData.readParam2(data);
     if (64 < value) {
@@ -58,7 +128,14 @@ export namespace MidiData {
       return 0.5;
     }
   };
-  /** Create a note on message */
+  /**
+   * Create a note on message.
+   *
+   * @param channel - MIDI channel number
+   * @param note - MIDI pitch value
+   * @param velocity - note velocity
+   * @returns encoded note-on bytes
+   */
   export const noteOn = (channel: byte, note: byte, velocity: byte) => {
     const bytes = new Uint8Array(3);
     bytes[0] = channel | Command.NoteOn;
@@ -66,7 +143,13 @@ export namespace MidiData {
     bytes[2] = velocity | 0;
     return bytes;
   };
-  /** Create a note off message */
+  /**
+   * Create a note off message.
+   *
+   * @param channel - MIDI channel number
+   * @param note - MIDI pitch value
+   * @returns encoded note-off bytes
+   */
   export const noteOff = (channel: byte, note: byte) => {
     const bytes = new Uint8Array(3);
     bytes[0] = channel | Command.NoteOff;
@@ -74,7 +157,12 @@ export namespace MidiData {
     return bytes;
   };
 
-  /** Render a MIDI message as a human readable string. */
+  /**
+   * Render a MIDI message as a human readable string.
+   *
+   * @param data - MIDI message bytes or null
+   * @returns descriptive text for logging
+   */
   export const debug = (data: Nullable<Uint8Array>): string => {
     if (data === null) {
       return "null";

--- a/packages/lib/midi/src/MidiFile.ts
+++ b/packages/lib/midi/src/MidiFile.ts
@@ -16,6 +16,8 @@ export namespace MidiFile {
    * Create a decoder for the provided MIDI file buffer.
    *
    * @see {@link MidiFile.encoder} for the reverse operation
+   * @param buffer - raw bytes of the MIDI file
+   * @returns decoder instance for reading the file
    */
   export const decoder = (buffer: ArrayBuffer): MidiFileDecoder =>
     new MidiFileDecoder(new ByteArrayInput(buffer));
@@ -24,6 +26,7 @@ export namespace MidiFile {
    * Create a new encoder for generating MIDI files.
    *
    * @see {@link MidiFile.decoder} to read files back
+   * @returns encoder used to build a file
    */
   export const encoder = (): MidiFileEncoder => new MidiFileEncoder();
 
@@ -33,6 +36,9 @@ export namespace MidiFile {
   class MidiFileEncoder {
     /**
      * Write a variable-length integer to the output.
+     *
+     * @param output - destination byte stream
+     * @param value - integer to encode
      */
       static writeVarLen(output: ByteArrayOutput, value: number): void {
         const bytes: Array<byte> = [];
@@ -51,6 +57,8 @@ export namespace MidiFile {
     /**
      * Add a track to the encoder.
      *
+     * @param track - track to append
+     * @returns reference to this encoder for chaining
      * @see {@link MidiTrack}
      */
     addTrack(track: MidiTrack): this {
@@ -61,6 +69,7 @@ export namespace MidiFile {
     /**
      * Encode the added tracks into a MIDI file.
      *
+     * @returns byte stream containing the encoded file
      * @see {@link MidiFile.decoder} for reading the output
      */
     encode(): ByteArrayOutput {

--- a/packages/lib/midi/src/MidiFileDecoder.ts
+++ b/packages/lib/midi/src/MidiFileDecoder.ts
@@ -15,6 +15,8 @@ export class MidiFileDecoder {
 
   /**
    * Create a decoder that reads from the given input.
+   *
+   * @param input - byte source containing the MIDI file
    */
   constructor(input: ByteArrayInput) {
     this.input = input;
@@ -22,6 +24,8 @@ export class MidiFileDecoder {
 
   /**
    * Decode the entire MIDI file and return its format description.
+   *
+   * @returns structure describing the file contents
    */
   decode(): MidiFileFormat {
     this.input.littleEndian = false;
@@ -53,7 +57,11 @@ export class MidiFileDecoder {
     return new MidiFileFormat(tracks, formatType, timeDivision);
   }
 
-  /** Read a variable-length integer as defined by the MIDI specification. */
+  /**
+   * Read a variable-length integer as defined by the MIDI specification.
+   *
+   * @returns decoded integer value
+   */
   readVarLen(): int {
     let value: int = this.input.readByte() & 0xff;
     let c: int;
@@ -67,7 +75,11 @@ export class MidiFileDecoder {
     return value;
   }
 
-  /** Read a time signature meta-event payload. */
+  /**
+   * Read a time signature meta-event payload.
+   *
+   * @returns tuple of `[numerator, denominator]`
+   */
   readSignature(): [int, int] {
     const b0 = this.input.readByte() & 0xff;
     const b1 = this.input.readByte() & 0xff;
@@ -84,7 +96,11 @@ export class MidiFileDecoder {
     return [b0, 1 << b1];
   }
 
-  /** Read a tempo meta-event payload and return beats per minute. */
+  /**
+   * Read a tempo meta-event payload and return beats per minute.
+   *
+   * @returns tempo in beats per minute
+   */
   readTempo(): number {
     const b0 = this.input.readByte() & 0xff;
     const b1 = this.input.readByte() & 0xff;
@@ -93,7 +109,11 @@ export class MidiFileDecoder {
     return MICROSECONDS_PER_MINUTE / ((b0 << 16) | (b1 << 8) | b2);
   }
 
-  /** Skip over a system exclusive message. */
+  /**
+   * Skip over a system exclusive message.
+   *
+   * @param value - initial status byte of the SysEx message
+   */
   skipSysEx(value: int): void {
     if (0xf0 === value) {
       if (this.#sysMode) {
@@ -110,12 +130,20 @@ export class MidiFileDecoder {
       }
     }
   }
-  /** Skip a number of bytes from the input. */
+  /**
+   * Skip a number of bytes from the input.
+   *
+   * @param count - number of bytes to advance
+   */
   skip(count: int): void {
     this.input.skip(count);
   }
 
-  /** Read a raw byte from the input. */
+  /**
+   * Read a raw byte from the input.
+   *
+   * @returns the next byte value
+   */
   readByte(): byte {
     return this.input.readByte();
   }

--- a/packages/lib/midi/src/MidiFileFormat.ts
+++ b/packages/lib/midi/src/MidiFileFormat.ts
@@ -6,8 +6,11 @@ import { MidiTrack } from "./MidiTrack";
  */
 export class MidiFileFormat {
   constructor(
+    /** Array of decoded tracks */
     readonly tracks: ReadonlyArray<MidiTrack>,
+    /** MIDI file format type (0,1,2) */
     readonly formatType: int,
+    /** Ticks per quarter note or SMPTE division */
     readonly timeDivision: int,
   ) {}
 }

--- a/packages/lib/midi/src/MidiTrack.ts
+++ b/packages/lib/midi/src/MidiTrack.ts
@@ -16,6 +16,9 @@ import { ControlType } from "./ControlType";
 export class MidiTrack {
   /**
    * Decode a track from the given decoder.
+   *
+   * @param decoder - MIDI file decoder positioned at the start of a track
+   * @returns a populated {@link MidiTrack} instance
    */
   static decode(decoder: MidiFileDecoder): MidiTrack {
     const controlEvents: ArrayMultimap<Channel, ControlEvent> =
@@ -59,18 +62,24 @@ export class MidiTrack {
     return new MidiTrack(controlEvents, metaEvents);
   }
 
-  /** Create an empty track with no events. */
+  /**
+   * Create an empty track with no events.
+   */
   static createEmpty(): MidiTrack {
     return new MidiTrack(new ArrayMultimap<Channel, ControlEvent>(), []);
   }
 
   constructor(
+    /** Control events grouped by channel */
     readonly controlEvents: ArrayMultimap<Channel, ControlEvent>,
+    /** Meta events belonging to this track */
     readonly metaEvents: Array<MetaEvent>,
   ) {}
 
   /**
    * Encode the track into a MIDI track chunk.
+   *
+   * @returns an ArrayBuffer containing the serialized track data
    */
   encode(): ArrayBufferLike {
     const output = ByteArrayOutput.create();


### PR DESCRIPTION
## Summary
- add TSDoc comments across MIDI library
- document MIDI decoding scenarios and add developer docs

## Testing
- `npm test --workspace packages/lib/midi`
- `npm run lint --workspace packages/lib/midi`
- `npm run lint --workspace packages/docs` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa4bf688321ad264184f051fcba