### PR TITLE
docs: document sample workflow

### DIFF
--- a/packages/app/studio/src/project/SampleImporter.ts
+++ b/packages/app/studio/src/project/SampleImporter.ts
@@ -1,5 +1,5 @@
-import {Progress, UUID} from "@opendaw/lib-std"
-import {Sample} from "@opendaw/studio-adapters"
+import { Progress, UUID } from "@opendaw/lib-std";
+import { Sample } from "@opendaw/studio-adapters";
 
 /**
  * Interface for importing audio samples into a project.
@@ -10,10 +10,22 @@ import {Sample} from "@opendaw/studio-adapters"
  * ```
  */
 export type SampleImporter = {
-    importSample(sample: {
-        uuid: UUID.Format,
-        name: string,
-        arrayBuffer: ArrayBuffer,
-        progressHandler?: Progress.Handler
-    }): Promise<Sample>
-}
+  /**
+   * Import a new sample into the project store.
+   *
+   * @param sample description of the sample to be imported.
+   * @param sample.uuid identifier to associate with the sample.
+   * @param sample.name display name of the sample.
+   * @param sample.arrayBuffer raw audio data to be decoded.
+   * @param sample.progressHandler optional callback receiving progress
+   * updates while the audio is decoded or uploaded.
+   * @returns metadata for the imported sample once complete.
+   */
+  importSample(sample: {
+    uuid: UUID.Format;
+    name: string;
+    arrayBuffer: ArrayBuffer;
+    /** Notified with the import percentage (0-1). */
+    progressHandler?: Progress.Handler;
+  }): Promise<Sample>;
+};

--- a/packages/app/studio/src/project/SampleUtils.ts
+++ b/packages/app/studio/src/project/SampleUtils.ts
@@ -1,58 +1,91 @@
-import {panic, UUID} from "@opendaw/lib-std"
-import {Errors} from "@opendaw/lib-dom"
-import {BoxGraph} from "@opendaw/lib-box"
-import {Promises} from "@opendaw/lib-runtime"
-import {AudioFileBox} from "@opendaw/studio-boxes"
-import {Sample, SampleManager} from "@opendaw/studio-adapters"
-import {SampleStorage} from "@opendaw/studio-core"
-import {SampleDialogs} from "@/ui/browse/SampleDialogs"
-import {showInfoDialog} from "@/ui/components/dialogs"
-import {SampleImporter} from "@/project/SampleImporter"
-import {SampleApi} from "@/service/SampleApi"
+import { panic, UUID } from "@opendaw/lib-std";
+import { Errors } from "@opendaw/lib-dom";
+import { BoxGraph } from "@opendaw/lib-box";
+import { Promises } from "@opendaw/lib-runtime";
+import { AudioFileBox } from "@opendaw/studio-boxes";
+import { Sample, SampleManager } from "@opendaw/studio-adapters";
+import { SampleStorage } from "@opendaw/studio-core";
+import { SampleDialogs } from "@/ui/browse/SampleDialogs";
+import { showInfoDialog } from "@/ui/components/dialogs";
+import { SampleImporter } from "@/project/SampleImporter";
+import { SampleApi } from "@/service/SampleApi";
 
 /** Utility functions for working with audio samples. */
 export namespace SampleUtils {
-    /**
-     * Ensure all audio file boxes reference existing samples and prompt the
-     * user to replace missing ones.
-     *
-     * @param boxGraph Graph containing the boxes to inspect.
-     * @param importer Utility used to load replacement samples.
-     * @param audioManager Manager responsible for caching sample data.
-     *
-     * @example
-     * ```ts
-     * await SampleUtils.verify(project.boxGraph, importer, manager)
-     * ```
-     */
-    export const verify = async (boxGraph: BoxGraph, importer: SampleImporter, audioManager: SampleManager) => {
-        const boxes = boxGraph.boxes().filter((box) => box instanceof AudioFileBox)
-        if (boxes.length > 0) {
-            // check for missing samples
-            const online = UUID.newSet<{ uuid: UUID.Format, sample: Sample }>(x => x.uuid)
-            online.addMany((await SampleApi.all()).map(sample => ({uuid: UUID.parse(sample.uuid), sample})))
-            const offline = UUID.newSet<{ uuid: UUID.Format, sample: Sample }>(x => x.uuid)
-            offline.addMany((await SampleStorage.list()).map(sample => ({uuid: UUID.parse(sample.uuid), sample})))
-            for (const box of boxes) {
-                const uuid = box.address.uuid
-                if (online.hasKey(uuid)) {continue}
-                const optSample = offline.opt(uuid)
-                if (optSample.isEmpty()) {
-                    const {
-                        status,
-                        error,
-                        value: sample
-                    } = await Promises.tryCatch(SampleDialogs.missingSampleDialog(importer, uuid, box.fileName.getValue()))
-                    if (status === "rejected") {
-                        if (Errors.isAbort(error)) {continue} else {return panic(String(error))}
-                    }
-                    await showInfoDialog({
-                        headline: "Replaced Sample",
-                        message: `${sample.name} has been replaced`
-                    })
-                    audioManager.invalidate(UUID.parse(sample.uuid))
-                }
-            }
+  /**
+   * Ensure all audio file boxes reference existing samples and prompt the
+   * user to replace missing ones.
+   *
+   * @param boxGraph Graph containing the boxes to inspect.
+   * @param importer Utility used to load replacement samples.
+   * @param audioManager Manager responsible for caching sample data.
+   *
+   * @example
+   * ```ts
+   * await SampleUtils.verify(project.boxGraph, importer, manager)
+   * ```
+   */
+  export const verify = async (
+    boxGraph: BoxGraph,
+    importer: SampleImporter,
+    audioManager: SampleManager,
+  ) => {
+    const boxes = boxGraph.boxes().filter((box) => box instanceof AudioFileBox);
+    if (boxes.length > 0) {
+      // Build lookup tables for online and offline samples
+      const online = UUID.newSet<{ uuid: UUID.Format; sample: Sample }>(
+        (x) => x.uuid,
+      );
+      online.addMany(
+        (await SampleApi.all()).map((sample) => ({
+          uuid: UUID.parse(sample.uuid),
+          sample,
+        })),
+      );
+      const offline = UUID.newSet<{ uuid: UUID.Format; sample: Sample }>(
+        (x) => x.uuid,
+      );
+      offline.addMany(
+        (await SampleStorage.list()).map((sample) => ({
+          uuid: UUID.parse(sample.uuid),
+          sample,
+        })),
+      );
+      for (const box of boxes) {
+        const uuid = box.address.uuid;
+        // Skip boxes already backed by an online sample
+        if (online.hasKey(uuid)) {
+          continue;
         }
+        const optSample = offline.opt(uuid);
+        if (optSample.isEmpty()) {
+          const {
+            status,
+            error,
+            value: sample,
+          } = await Promises.tryCatch(
+            SampleDialogs.missingSampleDialog(
+              importer,
+              uuid,
+              box.fileName.getValue(),
+            ),
+          );
+          if (status === "rejected") {
+            // User aborted or an error occurred
+            if (Errors.isAbort(error)) {
+              continue;
+            } else {
+              return panic(String(error));
+            }
+          }
+          await showInfoDialog({
+            headline: "Replaced Sample",
+            message: `${sample.name} has been replaced`,
+          });
+          // Invalidate cached data so future playback uses the replacement
+          audioManager.invalidate(UUID.parse(sample.uuid));
+        }
+      }
     }
+  };
 }

--- a/packages/app/studio/src/service/SampleApi.ts
+++ b/packages/app/studio/src/service/SampleApi.ts
@@ -1,16 +1,25 @@
-import {Arrays, asDefined, DefaultObservableValue, panic, Procedure, tryCatch, unitValue, UUID} from "@opendaw/lib-std"
-import {AudioData, Sample, SampleMetaData} from "@opendaw/studio-adapters"
-import {showInfoDialog, showProcessDialog} from "@/ui/components/dialogs.tsx"
-import {network, Promises} from "@opendaw/lib-runtime"
+import {
+  Arrays,
+  asDefined,
+  DefaultObservableValue,
+  panic,
+  Procedure,
+  tryCatch,
+  unitValue,
+  UUID,
+} from "@opendaw/lib-std";
+import { AudioData, Sample, SampleMetaData } from "@opendaw/studio-adapters";
+import { showInfoDialog, showProcessDialog } from "@/ui/components/dialogs.tsx";
+import { network, Promises } from "@opendaw/lib-runtime";
 
-const username = "openDAW"
-const password = "prototype"
-const base64Credentials = btoa(`${username}:${password}`)
+const username = "openDAW";
+const password = "prototype";
+const base64Credentials = btoa(`${username}:${password}`);
 const headers: RequestInit = {
-    method: "GET",
-    headers: {"Authorization": `Basic ${base64Credentials}`},
-    credentials: "include"
-}
+  method: "GET",
+  headers: { Authorization: `Basic ${base64Credentials}` },
+  credentials: "include",
+};
 
 /**
  * REST API helpers for retrieving and uploading sample files.
@@ -24,97 +33,160 @@ const headers: RequestInit = {
  * ```
  */
 export namespace SampleApi {
-    export const ApiRoot = "https://api.opendaw.studio/samples"
-    export const FileRoot = "https://assets.opendaw.studio/samples"
+  /** Base endpoint for sample metadata. */
+  export const ApiRoot = "https://api.opendaw.studio/samples";
+  /** Base endpoint for raw sample files. */
+  export const FileRoot = "https://assets.opendaw.studio/samples";
 
-    export const all = async (): Promise<ReadonlyArray<Sample>> => {
-        return await Promises.retry(() => fetch(`${ApiRoot}/list.php`, headers).then(x => x.json(), () => []))
-    }
+  /**
+   * Fetch metadata for all available samples.
+   */
+  export const all = async (): Promise<ReadonlyArray<Sample>> => {
+    return await Promises.retry(() =>
+      fetch(`${ApiRoot}/list.php`, headers).then(
+        (x) => x.json(),
+        () => [],
+      ),
+    );
+  };
 
-    export const get = async (uuid: UUID.Format): Promise<Sample> => {
-        const url = `${ApiRoot}/get.php?uuid=${UUID.toString(uuid)}`
-        const sample: Sample = await Promises.retry(() => network.limitFetch(url, headers)
-            .then(x => x.json()))
-            .then(x => {if ("error" in x) {return panic(x.error)} else {return x}})
-        return Object.freeze({...sample, cloud: FileRoot})
-    }
+  /**
+   * Retrieve metadata for a single sample.
+   *
+   * @param uuid identifier of the sample to fetch.
+   */
+  export const get = async (uuid: UUID.Format): Promise<Sample> => {
+    const url = `${ApiRoot}/get.php?uuid=${UUID.toString(uuid)}`;
+    const sample: Sample = await Promises.retry(() =>
+      network.limitFetch(url, headers).then((x) => x.json()),
+    ).then((x) => {
+      if ("error" in x) {
+        return panic(x.error);
+      } else {
+        return x;
+      }
+    });
+    return Object.freeze({ ...sample, cloud: FileRoot });
+  };
 
-    export const load = async (context: AudioContext,
-                               uuid: UUID.Format,
-                               progress: Procedure<unitValue>): Promise<[AudioData, SampleMetaData]> => {
-        console.debug(`fetch ${UUID.toString(uuid)}`)
-        return get(uuid)
-            .then(({uuid, name, bpm}) => Promises.retry(() => network.limitFetch(`${FileRoot}/${uuid}`, headers))
-                .then(response => {
-                    const total = parseInt(response.headers.get("Content-Length") ?? "0")
-                    let loaded = 0
-                    return new Promise<ArrayBuffer>((resolve, reject) => {
-                        const reader = asDefined(response.body, "No body in response").getReader()
-                        const chunks: Array<Uint8Array> = []
-                        const nextChunk = ({done, value}: ReadableStreamReadResult<Uint8Array>) => {
-                            if (done) {
-                                resolve(new Blob(chunks as Array<BlobPart>).arrayBuffer())
-                            } else {
-                                chunks.push(value)
-                                loaded += value.length
-                                progress(loaded / total)
-                                reader.read().then(nextChunk, reject)
-                            }
-                        }
-                        reader.read().then(nextChunk, reject)
-                    })
-                })
-                .then(arrayBuffer => context.decodeAudioData(arrayBuffer))
-                .then(audioBuffer => ([fromAudioBuffer(audioBuffer), {
-                    bpm,
-                    name,
-                    duration: audioBuffer.duration,
-                    sample_rate: audioBuffer.sampleRate
-                }])))
-    }
-
-    const fromAudioBuffer = (buffer: AudioBuffer): AudioData => ({
-        frames: Arrays.create(channel => buffer.getChannelData(channel), buffer.numberOfChannels),
-        sampleRate: buffer.sampleRate,
-        numberOfFrames: buffer.length,
-        numberOfChannels: buffer.numberOfChannels
-    })
-
-    export const upload = async (arrayBuffer: ArrayBuffer, metaData: SampleMetaData) => {
-        const progress = new DefaultObservableValue(0.0)
-        const dialogHandler = showProcessDialog("Uploading", progress)
-        const formData = new FormData()
-        Object.entries(metaData).forEach(([key, value]) => formData.set(key, String(value)))
-        const params = new URLSearchParams(location.search)
-        const accessKey = asDefined(params.get("access-key"), "Cannot upload without access-key.")
-        formData.set("key", accessKey)
-        formData.append("file", new Blob([arrayBuffer]))
-        console.log("upload data", Array.from(formData.entries()), arrayBuffer.byteLength)
-        const xhr = new XMLHttpRequest()
-        xhr.upload.addEventListener("progress", (event: ProgressEvent) => {
-            if (event.lengthComputable) {
-                progress.setValue(event.loaded / event.total)
-            }
+  /**
+   * Load a sample into an {@link AudioContext} and return decoded data and
+   * metadata.
+   *
+   * @param context audio context used for decoding.
+   * @param uuid sample identifier.
+   * @param progress callback receiving loading progress between 0 and 1.
+   */
+  export const load = async (
+    context: AudioContext,
+    uuid: UUID.Format,
+    progress: Procedure<unitValue>,
+  ): Promise<[AudioData, SampleMetaData]> => {
+    console.debug(`fetch ${UUID.toString(uuid)}`);
+    return get(uuid).then(({ uuid, name, bpm }) =>
+      Promises.retry(() => network.limitFetch(`${FileRoot}/${uuid}`, headers))
+        .then((response) => {
+          const total = parseInt(response.headers.get("Content-Length") ?? "0");
+          let loaded = 0;
+          return new Promise<ArrayBuffer>((resolve, reject) => {
+            const reader = asDefined(
+              response.body,
+              "No body in response",
+            ).getReader();
+            const chunks: Array<Uint8Array> = [];
+            const nextChunk = ({
+              done,
+              value,
+            }: ReadableStreamReadResult<Uint8Array>) => {
+              if (done) {
+                resolve(new Blob(chunks as Array<BlobPart>).arrayBuffer());
+              } else {
+                chunks.push(value);
+                loaded += value.length;
+                progress(loaded / total);
+                reader.read().then(nextChunk, reject);
+              }
+            };
+            reader.read().then(nextChunk, reject);
+          });
         })
-        xhr.onreadystatechange = () => {
-            if (xhr.readyState === 4) {
-                dialogHandler.close()
-                if (xhr.status === 200) {
-                    showInfoDialog({message: xhr.responseText})
-                } else {
-                    const {
-                        status,
-                        value
-                    } = tryCatch(() => JSON.parse(xhr.responseText).message ?? "Unknown error message")
-                    showInfoDialog({
-                        headline: "Upload Failure",
-                        message: status === "success" ? value : "Unknown error"
-                    })
-                }
-            }
+        .then((arrayBuffer) => context.decodeAudioData(arrayBuffer))
+        .then((audioBuffer) => [
+          fromAudioBuffer(audioBuffer),
+          {
+            bpm,
+            name,
+            duration: audioBuffer.duration,
+            sample_rate: audioBuffer.sampleRate,
+          },
+        ]),
+    );
+  };
+
+  // Convert an AudioBuffer into the serialized AudioData format
+  const fromAudioBuffer = (buffer: AudioBuffer): AudioData => ({
+    frames: Arrays.create(
+      (channel) => buffer.getChannelData(channel),
+      buffer.numberOfChannels,
+    ),
+    sampleRate: buffer.sampleRate,
+    numberOfFrames: buffer.length,
+    numberOfChannels: buffer.numberOfChannels,
+  });
+
+  /**
+   * Upload a sample to the remote server.
+   *
+   * @param arrayBuffer raw WAV data.
+   * @param metaData description of the sample to accompany the upload.
+   */
+  export const upload = async (
+    arrayBuffer: ArrayBuffer,
+    metaData: SampleMetaData,
+  ) => {
+    const progress = new DefaultObservableValue(0.0);
+    const dialogHandler = showProcessDialog("Uploading", progress);
+    const formData = new FormData();
+    Object.entries(metaData).forEach(([key, value]) =>
+      formData.set(key, String(value)),
+    );
+    const params = new URLSearchParams(location.search);
+    const accessKey = asDefined(
+      params.get("access-key"),
+      "Cannot upload without access-key.",
+    );
+    formData.set("key", accessKey);
+    formData.append("file", new Blob([arrayBuffer]));
+    console.log(
+      "upload data",
+      Array.from(formData.entries()),
+      arrayBuffer.byteLength,
+    );
+    const xhr = new XMLHttpRequest();
+    xhr.upload.addEventListener("progress", (event: ProgressEvent) => {
+      if (event.lengthComputable) {
+        progress.setValue(event.loaded / event.total);
+      }
+    });
+    xhr.onreadystatechange = () => {
+      if (xhr.readyState === 4) {
+        dialogHandler.close();
+        if (xhr.status === 200) {
+          showInfoDialog({ message: xhr.responseText });
+        } else {
+          const { status, value } = tryCatch(
+            () =>
+              JSON.parse(xhr.responseText).message ?? "Unknown error message",
+          );
+          showInfoDialog({
+            headline: "Upload Failure",
+            message: status === "success" ? value : "Unknown error",
+          });
         }
-        xhr.open("POST", `${ApiRoot}/upload.php`, true)
-        xhr.setRequestHeader("Authorization", `Basic ${base64Credentials}`)
-        xhr.send(formData)
-    }
+      }
+    };
+    xhr.open("POST", `${ApiRoot}/upload.php`, true);
+    xhr.setRequestHeader("Authorization", `Basic ${base64Credentials}`);
+    xhr.send(formData);
+  };
 }

--- a/packages/app/studio/src/service/SamplePlayback.ts
+++ b/packages/app/studio/src/service/SamplePlayback.ts
@@ -1,26 +1,30 @@
 import {
-    ArrayMultimap,
-    DefaultObservableValue,
-    EmptyExec,
-    Option,
-    Procedure,
-    Subscription,
-    unitValue,
-    UUID
-} from "@opendaw/lib-std"
-import {SampleApi} from "./SampleApi"
-import {encodeWavFloat, SampleStorage} from "@opendaw/studio-core"
+  ArrayMultimap,
+  DefaultObservableValue,
+  EmptyExec,
+  Option,
+  Procedure,
+  Subscription,
+  unitValue,
+  UUID,
+} from "@opendaw/lib-std";
+import { SampleApi } from "./SampleApi";
+import { encodeWavFloat, SampleStorage } from "@opendaw/studio-core";
 
-export type PlaybackEvent = {
-    type: "idle"
-} | {
-    type: "buffering"
-} | {
-    type: "playing"
-} | {
-    type: "error"
-    reason: string
-}
+export type PlaybackEvent =
+  | {
+      type: "idle";
+    }
+  | {
+      type: "buffering";
+    }
+  | {
+      type: "playing";
+    }
+  | {
+      type: "error";
+      reason: string;
+    };
 
 /**
  * Lightweight preview player for samples. It handles buffering, playback and
@@ -35,91 +39,122 @@ export type PlaybackEvent = {
  * ```
  */
 export class SamplePlayback {
-    readonly #context: AudioContext
-    readonly #audio: HTMLAudioElement
-    readonly #notifiers: ArrayMultimap<string, Procedure<PlaybackEvent>>
-    readonly #linearVolume: DefaultObservableValue<unitValue>
+  readonly #context: AudioContext;
+  readonly #audio: HTMLAudioElement;
+  readonly #notifiers: ArrayMultimap<string, Procedure<PlaybackEvent>>;
+  readonly #linearVolume: DefaultObservableValue<unitValue>;
 
-    #current: Option<string> = Option.None
+  #current: Option<string> = Option.None;
 
-    constructor(context: AudioContext) {
-        this.#context = context
+  constructor(context: AudioContext) {
+    this.#context = context;
 
-        this.#audio = new Audio()
-        this.#audio.crossOrigin = "use-credentials"
-        this.#audio.preload = "auto"
-        this.#notifiers = new ArrayMultimap<string, Procedure<PlaybackEvent>>()
-        this.#linearVolume = new DefaultObservableValue<unitValue>(1.0)
-        this.#linearVolume.catchupAndSubscribe(owner => this.#audio.volume = owner.getValue()) // no owner needed
+    this.#audio = new Audio();
+    this.#audio.crossOrigin = "use-credentials";
+    this.#audio.preload = "auto";
+    this.#notifiers = new ArrayMultimap<string, Procedure<PlaybackEvent>>();
+    this.#linearVolume = new DefaultObservableValue<unitValue>(1.0);
+    this.#linearVolume.catchupAndSubscribe(
+      (owner) => (this.#audio.volume = owner.getValue()),
+    ); // no owner needed
+  }
+
+  /**
+   * Toggle playback of a given sample. If it is currently playing it will
+   * stop, otherwise it will buffer and start playback.
+   */
+  toggle(uuidAsString: string): void {
+    if (this.#current.contains(uuidAsString)) {
+      if (this.#audio.paused) {
+        this.#notify(uuidAsString, { type: "buffering" });
+        this.#audio.play().catch(EmptyExec);
+      } else {
+        this.#audio.currentTime = 0.0;
+        this.#audio.pause();
+      }
+    } else {
+      this.#watchAudio(uuidAsString);
+      this.#notify(uuidAsString, { type: "buffering" });
+
+      SampleStorage.load(UUID.parse(uuidAsString), this.#context)
+        .then(
+          ([audio]) => {
+            this.#audio.src = URL.createObjectURL(
+              new Blob(
+                [
+                  encodeWavFloat({
+                    channels: audio.frames.slice(),
+                    sampleRate: audio.sampleRate,
+                    numFrames: audio.numberOfFrames,
+                  }),
+                ],
+                { type: "audio/wav" },
+              ),
+            );
+          },
+          () => {
+            this.#audio.src = `${SampleApi.FileRoot}/${uuidAsString}`;
+          },
+        )
+        .finally(() => this.#audio.play().catch(EmptyExec));
+
+      this.#current.ifSome((uuid) => this.#notify(uuid, { type: "idle" }));
+      this.#current = Option.wrap(uuidAsString);
     }
+  }
 
-    toggle(uuidAsString: string): void {
-        if (this.#current.contains(uuidAsString)) {
-            if (this.#audio.paused) {
-                this.#notify(uuidAsString, {type: "buffering"})
-                this.#audio.play().catch(EmptyExec)
-            } else {
-                this.#audio.currentTime = 0.0
-                this.#audio.pause()
-            }
-        } else {
-            this.#watchAudio(uuidAsString)
-            this.#notify(uuidAsString, {type: "buffering"})
+  /** Stop playback and reset the internal state. */
+  eject(): void {
+    this.#current.ifSome((uuid) => this.#notify(uuid, { type: "idle" }));
+    this.#current = Option.None;
+    this.#audio.pause();
+    this.#unwatchAudio();
+  }
 
-            SampleStorage.load(UUID.parse(uuidAsString), this.#context)
-                .then(([audio]) => {
-                    this.#audio.src = URL.createObjectURL(new Blob([encodeWavFloat({
-                        channels: audio.frames.slice(),
-                        sampleRate: audio.sampleRate,
-                        numFrames: audio.numberOfFrames
-                    })], {type: "audio/wav"}))
-                }, () => {
-                    this.#audio.src = `${SampleApi.FileRoot}/${uuidAsString}`
-                })
-                .finally(() => this.#audio.play().catch(EmptyExec))
+  /**
+   * Subscribe to playback events for a particular sample.
+   */
+  subscribe(
+    uuidAsString: string,
+    procedure: Procedure<PlaybackEvent>,
+  ): Subscription {
+    this.#notifiers.add(uuidAsString, procedure);
+    return { terminate: () => this.#notifiers.remove(uuidAsString, procedure) };
+  }
 
-            this.#current.ifSome(uuid => this.#notify(uuid, {type: "idle"}))
-            this.#current = Option.wrap(uuidAsString)
-        }
-    }
+  /** Observable linear volume for all preview playback. */
+  get linearVolume(): DefaultObservableValue<number> {
+    return this.#linearVolume;
+  }
 
-    eject(): void {
-        this.#current.ifSome(uuid => this.#notify(uuid, {type: "idle"}))
-        this.#current = Option.None
-        this.#audio.pause()
-        this.#unwatchAudio()
-    }
+  #notify(uuidAsString: string, event: PlaybackEvent): void {
+    this.#notifiers.get(uuidAsString).forEach((procedure) => procedure(event));
+  }
 
-    subscribe(uuidAsString: string, procedure: Procedure<PlaybackEvent>): Subscription {
-        this.#notifiers.add(uuidAsString, procedure)
-        return {terminate: () => this.#notifiers.remove(uuidAsString, procedure)}
-    }
+  #watchAudio(uuidAsString: string): void {
+    this.#audio.onended = () => this.#notify(uuidAsString, { type: "idle" });
+    this.#audio.ontimeupdate = () => {
+      if (!this.#audio.paused && this.#audio.duration > 0.0) {
+        this.#notify(uuidAsString, { type: "playing" });
+      }
+    };
+    this.#audio.onpause = () => this.#notify(uuidAsString, { type: "idle" });
+    this.#audio.onstalled = () =>
+      this.#notify(uuidAsString, { type: "buffering" });
+    // Propagate any playback errors to subscribers
+    this.#audio.onerror = (event, _source, _lineno, _colno, error) =>
+      this.#notify(uuidAsString, {
+        type: "error",
+        reason: (error?.message ?? event instanceof Event) ? "Unknown" : event,
+      });
+  }
 
-    get linearVolume(): DefaultObservableValue<number> {return this.#linearVolume}
-
-    #notify(uuidAsString: string, event: PlaybackEvent): void {
-        this.#notifiers.get(uuidAsString).forEach(procedure => procedure(event))
-    }
-
-    #watchAudio(uuidAsString: string): void {
-        this.#audio.onended = () => this.#notify(uuidAsString, {type: "idle"})
-        this.#audio.ontimeupdate = () => {
-            if (!this.#audio.paused && this.#audio.duration > 0.0) {this.#notify(uuidAsString, {type: "playing"})}
-        }
-        this.#audio.onpause = () => this.#notify(uuidAsString, {type: "idle"})
-        this.#audio.onstalled = () => this.#notify(uuidAsString, {type: "buffering"})
-        this.#audio.onerror = (event, _source, _lineno, _colno, error) => this.#notify(uuidAsString, {
-            type: "error",
-            reason: error?.message ?? event instanceof Event ? "Unknown" : event
-        })
-    }
-
-    #unwatchAudio(): void {
-        this.#audio.onended = null
-        this.#audio.onplay = null
-        this.#audio.onpause = null
-        this.#audio.onerror = null
-        this.#audio.onstalled = null
-        this.#audio.ontimeupdate = null
-    }
+  #unwatchAudio(): void {
+    this.#audio.onended = null;
+    this.#audio.onplay = null;
+    this.#audio.onpause = null;
+    this.#audio.onerror = null;
+    this.#audio.onstalled = null;
+    this.#audio.ontimeupdate = null;
+  }
 }

--- a/packages/app/studio/src/ui/browse/SampleBrowser.sass
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.sass
@@ -14,6 +14,7 @@ component
   @include colors.panel-background
 
   > div.filter
+    // Search bar and location toggle
     display: flex
     align-items: center
     font-size: 1rem
@@ -23,6 +24,7 @@ component
     grid-column: 1 / -1
 
   > div.content
+    // Scrollable list area showing individual samples
     flex: 1 0 0
     display: grid
     grid-template-columns: 1fr auto auto auto
@@ -31,6 +33,7 @@ component
     overflow: hidden
 
   > div.footer
+    // Volume control section
     display: flex
     align-items: center
     height: 1.25rem

--- a/packages/app/studio/src/ui/browse/SampleBrowser.tsx
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.tsx
@@ -56,6 +56,7 @@ export const SampleBrowser = ({ lifecycle, service }: Construct) => {
   lifecycle.own(location.subscribe(() => reload.get().update()));
   const filter = new DefaultObservableValue("");
   const searchInput = <SearchInput lifecycle={lifecycle} model={filter} />;
+  // Global volume slider controlling sample preview loudness
   const slider: HTMLInputElement = (
     <input type="range" min="0.0" max="1.0" step="0.001" />
   );
@@ -189,6 +190,7 @@ export const SampleBrowser = ({ lifecycle, service }: Construct) => {
         location.getValue() === SampleLocation.Local
       ) {
         await sampleService.deleteSelected();
+        // Refresh list after deletion to reflect current state
         reload.get().update();
       }
     }),

--- a/packages/app/studio/src/ui/browse/SampleDialogs.tsx
+++ b/packages/app/studio/src/ui/browse/SampleDialogs.tsx
@@ -11,13 +11,23 @@ import { FilePickerAcceptTypes } from "@/ui/FilePickerAcceptTypes";
 
 /** Dialog helpers for managing samples. */
 export namespace SampleDialogs {
-  /** Open the browser's file picker for selecting sample files. */
+  /**
+   * Open the browser's file picker for selecting sample files.
+   *
+   * @param multiple allow the user to select multiple files at once.
+   */
   export const nativeFileBrowser = async (multiple: boolean = true) =>
     Promises.tryCatch(
       Files.open({ ...FilePickerAcceptTypes.WavFiles, multiple }),
     );
 
-  /** Prompt the user to locate a missing sample on disk. */
+  /**
+   * Prompt the user to locate a missing sample on disk.
+   *
+   * @param importer handler used to register the replacement sample.
+   * @param uuid identifier of the missing sample.
+   * @param name original name shown to the user.
+   */
   export const missingSampleDialog = async (
     importer: SampleImporter,
     uuid: UUID.Format,
@@ -89,7 +99,11 @@ export namespace SampleDialogs {
     return promise;
   };
 
-  /** Show a dialog to edit the name and bpm metadata of a sample. */
+  /**
+   * Show a dialog to edit the name and bpm metadata of a sample.
+   *
+   * @param sample sample whose metadata should be changed.
+   */
   export const showEditSampleDialog = async (
     sample: Sample,
   ): Promise<Sample> => {

--- a/packages/app/studio/src/ui/browse/SampleService.ts
+++ b/packages/app/studio/src/ui/browse/SampleService.ts
@@ -46,6 +46,7 @@ export class SampleService {
     const { editing, boxGraph, rootBoxAdapter } = project;
     editing.modify(() => {
       const samples = this.#samples();
+      // Insert new tracks sequentially after existing ones
       const startIndex = rootBoxAdapter.audioUnits.adapters().length;
       samples.forEach(
         (
@@ -57,6 +58,7 @@ export class SampleService {
             InstrumentFactories.Tape,
             { index: startIndex + index },
           );
+          // Reuse existing AudioFileBox if present, otherwise create one
           const audioFileBox = boxGraph
             .findBox<AudioFileBox>(uuid)
             .unwrapOrElse(() =>

--- a/packages/app/studio/src/ui/browse/SampleView.sass
+++ b/packages/app/studio/src/ui/browse/SampleView.sass
@@ -7,9 +7,11 @@ component
   align-items: center
 
   &.selected
+    // Highlight selected samples
     color: var(--color-gray)
 
   > div.edit
+    // Buttons for editing and deleting
     display: flex
 
   > div.meta
@@ -27,14 +29,17 @@ component
       cursor: grabbing
 
     &.buffering
+      // While audio is loading
       color: var(--color-black)
       background-color: var(--color-shadow)
 
     &.playing
+      // Playback active
       color: var(--color-black)
       background-color: var(--color-blue)
 
     &.error
+      // Playback failed
       color: var(--color-black)
       background-color: var(--color-red)
 

--- a/packages/app/studio/src/ui/browse/SampleView.tsx
+++ b/packages/app/studio/src/ui/browse/SampleView.tsx
@@ -76,6 +76,7 @@ export const SampleView = ({
     </Button>
   );
   const metaElement: HTMLElement = (
+    // Double-click on the metadata row toggles playback
     <div className="meta" ondblclick={() => playback.toggle(sample.uuid)}>
       {labelName}
       {labelBpm}
@@ -100,6 +101,7 @@ export const SampleView = ({
   );
   lifecycle.ownAll(
     DragAndDrop.installSource(element, () => ({ type: "sample", sample })),
+    // Add context menu entries for common actions
     ContextMenu.subscribe(element, (collector) =>
       collector.addItems(
         MenuItem.default({
@@ -114,6 +116,7 @@ export const SampleView = ({
         }),
       ),
     ),
+    // Reflect playback state changes in the UI
     playback.subscribe(sample.uuid, (event) => {
       metaElement.classList.remove("buffering", "playing", "error");
       metaElement.classList.add(event.type);

--- a/packages/docs/docs-dev/ui/browse/sample-pipeline.md
+++ b/packages/docs/docs-dev/ui/browse/sample-pipeline.md
@@ -1,0 +1,15 @@
+# Sample Loading Pipeline
+
+This document outlines the flow for retrieving and previewing audio samples in the studio browser.
+
+1. **Discovery** – `SampleBrowser` requests metadata from either the local `SampleStorage`
+   or the remote [`SampleApi`](../../../app/studio/src/service/SampleApi.ts).
+2. **Selection** – the user selects entries rendered by `SampleView` which exposes
+   metadata for each sample.
+3. **Playback** – selections are previewed through `SamplePlayback`, buffering from
+   `SampleStorage` when available and falling back to the server.
+4. **Management** – actions such as renaming or deletion are routed through
+   `SampleService` and the dialog helpers in `SampleDialogs`.
+
+This modular pipeline allows the browser UI to remain agnostic about where the
+samples originate while keeping playback responsive.

--- a/packages/docs/docs-user/workflows/sample-management.md
+++ b/packages/docs/docs-user/workflows/sample-management.md
@@ -1,0 +1,14 @@
+# Managing Samples
+
+This guide explains how to organize and edit audio samples within the browser:
+
+1. **Browse** – open the _Samples_ panel and switch between local and cloud libraries.
+2. **Preview** – double‑click a sample to start or stop playback. Use the volume slider
+   at the bottom to adjust preview loudness.
+3. **Edit** – for local samples, use the pencil icon to rename the file or update BPM
+   information. Changes are stored locally.
+4. **Delete** – select one or more local samples and press <kbd>Delete</kbd> to remove
+   them. Samples in use by a project cannot be deleted while offline.
+
+These tools help keep your library tidy and make it easy to audition sounds before
+bringing them into a project.


### PR DESCRIPTION
## Summary
- expand sample services with TSDoc and inline notes
- document how sample browsing and playback operates
- add user guide for managing samples in the browser

## Testing
- `npm test`
- `npm run lint` *(fails: command sh -c eslint "**/*.ts")*


------
https://chatgpt.com/codex/tasks/task_b_68af1fa569388321aec31c519d96e150