### PR TITLE
docs: expand headless and service docs

### DIFF
--- a/packages/app/headless/src/ExampleProject.ts
+++ b/packages/app/headless/src/ExampleProject.ts
@@ -2,6 +2,9 @@
 
 /**
  * Utilities for building a tiny demo project that plays a simple arpeggio.
+ *
+ * The exported {@link createExampleProject} helper is consumed by the
+ * headless {@code main.ts} entry point.
  */
 import {PPQN} from "@opendaw/lib-dsp"
 import {EffectFactories, InstrumentFactories, Project, ProjectEnv} from "@opendaw/studio-core"

--- a/packages/app/headless/src/SampleApi.ts
+++ b/packages/app/headless/src/SampleApi.ts
@@ -1,6 +1,8 @@
 /**
  * Utility functions for fetching and decoding sample data from the public
  * openDAW sample service.
+ *
+ * Network requests are throttled via {@link network.limitFetch}.
  */
 /* eslint-disable @typescript-eslint/no-namespace */
 import {Arrays, asDefined, panic, Procedure, unitValue, UUID} from "@opendaw/lib-std"
@@ -25,6 +27,8 @@ export namespace SampleApi {
 
     /**
      * Fetches the complete list of samples available on the service.
+     *
+     * @see network.limitFetch
      */
     export const all = async (): Promise<ReadonlyArray<Sample>> => {
         return await Promises.retry(() => fetch(`${ApiRoot}/list.php`, headers).then(x => x.json(), () => []))
@@ -32,6 +36,8 @@ export namespace SampleApi {
 
     /**
      * Retrieve a single sample's metadata.
+     *
+     * @see network.limitFetch
      */
     export const get = async (uuid: UUID.Format): Promise<Sample> => {
         const url = `${ApiRoot}/get.php?uuid=${UUID.toString(uuid)}`
@@ -43,6 +49,8 @@ export namespace SampleApi {
 
     /**
      * Download and decode a sample, reporting progress via the provided handler.
+     *
+     * @see network.limitFetch
      */
     export const load = async (context: AudioContext,
                                uuid: UUID.Format,

--- a/packages/app/headless/src/Test.tsx
+++ b/packages/app/headless/src/Test.tsx
@@ -5,6 +5,8 @@ type Construct = {}
 
 /**
  * A tiny component used to verify JSX transpilation in the headless setup.
+ * It renders a simple greeting and demonstrates {@link createElement} from
+ * `@opendaw/lib-jsx`.
  */
 export const Test = ({}: Construct) => {
     return (

--- a/packages/app/headless/src/features.ts
+++ b/packages/app/headless/src/features.ts
@@ -2,6 +2,9 @@
  * Ensure the browser exposes all APIs required by the headless demo. This
  * function throws if a feature is missing so the caller can present a useful
  * error to the user.
+ *
+ * Used by the headless `main.ts` entry point before bootstrapping the audio
+ * engine.
  */
 import {requireProperty} from "@opendaw/lib-std"
 

--- a/packages/app/headless/src/main.ts
+++ b/packages/app/headless/src/main.ts
@@ -3,6 +3,10 @@
  * engine and plays a small example project once the user interacts with the
  * page.
  *
+ * Relies on {@link testFeatures} to ensure required browser APIs are present
+ * and uses {@link SampleApi} to fetch audio data for
+ * {@link createExampleProject}.
+ *
  * Security note: The demo relies on cross-origin isolation and local worker
  * bundles. Serve this page over HTTPS and avoid loading untrusted scripts to
  * prevent privilege escalation.

--- a/packages/app/studio/src/service/SampleApi.ts
+++ b/packages/app/studio/src/service/SampleApi.ts
@@ -15,6 +15,9 @@ const headers: RequestInit = {
 /**
  * REST API helpers for retrieving and uploading sample files.
  *
+ * Uses {@link network.limitFetch} to throttle HTTP requests. See
+ * [StudioService](./StudioService.ts) for how the API integrates with the app.
+ *
  * ```mermaid
  * sequenceDiagram
  *   participant U as Client
@@ -39,6 +42,11 @@ export namespace SampleApi {
         return Object.freeze({...sample, cloud: FileRoot})
     }
 
+    /**
+     * Download and decode a sample, reporting progress via the provided handler.
+     *
+     * @see network.limitFetch
+     */
     export const load = async (context: AudioContext,
                                uuid: UUID.Format,
                                progress: Procedure<unitValue>): Promise<[AudioData, SampleMetaData]> => {
@@ -80,6 +88,9 @@ export namespace SampleApi {
         numberOfChannels: buffer.numberOfChannels
     })
 
+    /**
+     * Upload a sample file along with metadata to the remote service.
+     */
     export const upload = async (arrayBuffer: ArrayBuffer, metaData: SampleMetaData) => {
         const progress = new DefaultObservableValue(0.0)
         const dialogHandler = showProcessDialog("Uploading", progress)

--- a/packages/app/studio/src/service/SessionService.ts
+++ b/packages/app/studio/src/service/SessionService.ts
@@ -22,6 +22,9 @@ import {Project} from "@opendaw/studio-core"
  * Handles the lifecycle of a project session, including loading, saving and
  * exporting bundles.
  *
+ * See {@link StudioService} for application orchestration and
+ * [SampleApi](./SampleApi.ts) for sample transfers.
+ *
  * ```mermaid
  * flowchart LR
  *   SessionService -->|creates| ProjectSession

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -81,6 +81,9 @@ export type Session = {
  * Central service orchestrating workspace screens, project handling and the
  * audio engine.
  *
+ * See {@link SessionService} for session lifecycle management and
+ * [SampleApi](./SampleApi.ts) for network-backed sample retrieval.
+ *
  * ```mermaid
  * flowchart LR
  *   StudioService --> SessionService

--- a/packages/docs/docs-dev/architecture/service-bridge.md
+++ b/packages/docs/docs-dev/architecture/service-bridge.md
@@ -1,0 +1,17 @@
+# Service Bridge
+
+The service bridge coordinates communication between the user interface and
+worker-hosted services. Both the Studio app and the headless demo rely on this
+bridge to access long-running tasks in a dedicated thread.
+
+```mermaid
+flowchart LR
+    Client --> Bridge --> WorkerService
+```
+
+`StudioService` delegates session management to `SessionService` over the
+bridge, while network operations are throttled via
+[`network.limitFetch`](../../../lib/runtime/src/network.ts).
+
+See the [headless vs studio comparison](./headless-vs-studio.md) for how the
+bridge enables feature parity across builds.

--- a/packages/docs/docs-user/workflows/headless-mode.md
+++ b/packages/docs/docs-user/workflows/headless-mode.md
@@ -15,6 +15,4 @@ The build loads `src/main.ts`, which in turn creates a project from code using
 `createExampleProject` and bootstraps the audio engine. See the package README
 for more details.
 
-
-This demo uses the same sample management API and core engine as the Studio service, providing feature parity for audio processing. See the [headless vs studio comparison](../../docs-dev/architecture/headless-vs-studio.md) for architectural details.
-
+This demo uses the same sample management API and core engine as the Studio service, providing feature parity for audio processing. For how services communicate across threads see the [service bridge](../../docs-dev/architecture/service-bridge.md) and the [headless vs studio comparison](../../docs-dev/architecture/headless-vs-studio.md).

--- a/packages/lib/runtime/src/network.ts
+++ b/packages/lib/runtime/src/network.ts
@@ -3,6 +3,9 @@ import { Promises } from "./promises";
 /**
  * Network related helper functions.
  *
+ * Used by services such as the Studio's [SampleApi](../../../app/studio/src/service/SampleApi.ts)
+ * to throttle HTTP requests.
+ *
  * Security note: These utilities perform no validation or authentication.
  * Callers should only request trusted URLs and must verify responses before
  * using them.


### PR DESCRIPTION
## Summary
- document headless entry, sample API and utility modules
- cross-reference studio services with sample API and runtime network helpers
- add service bridge architecture doc and update headless mode workflow

## Testing
- `npm test`
- `npm run lint` *(fails: npm error workspace @opendaw/studio-enums@0.0.20)*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa6e07883218e551513240e4931