### PR TITLE
docs: annotate audio import and stems

### DIFF
--- a/packages/app/studio/src/audio/AudioImport.ts
+++ b/packages/app/studio/src/audio/AudioImport.ts
@@ -7,18 +7,36 @@ import { SampleStorage, WorkerAgents } from "@opendaw/studio-core";
 import { SamplePeaks } from "@opendaw/lib-fusion";
 
 export namespace AudioImporter {
+  /**
+   * Data required to create a {@link Sample} entry.
+   *
+   * The {@link arrayBuffer} contains the raw audio file data and will be
+   * detached once decoding begins. The optional {@link uuid} can be provided to
+   * avoid hashing large files during repeated imports.
+   */
   export type Creation = {
+    /** Optional identifier for the sample. */
     uuid?: UUID.Format;
+    /** Name of the source file including extension. */
     name: string;
+    /** Audio file contents to decode. */
     arrayBuffer: ArrayBuffer;
+    /** Handler that receives peak‑generation progress updates. */
     progressHandler: Progress.Handler;
   };
 
+  /**
+   * Import an audio file into {@link SampleStorage} and return its metadata.
+   *
+   * @param context Audio context used for decoding.
+   * @param creation Parameters describing the file to import.
+   */
   export const run = async (
     context: AudioContext,
     { uuid, name, arrayBuffer, progressHandler }: Creation,
   ): Promise<Sample> => {
-    uuid ??= await UUID.sha256(arrayBuffer); // Must run before decodeAudioData laster, because it will detach the ArrayBuffer
+    // Must run before decodeAudioData, because it will detach the ArrayBuffer
+    uuid ??= await UUID.sha256(arrayBuffer);
     const audioResult = await Promises.tryCatch(
       context.decodeAudioData(arrayBuffer),
     );

--- a/packages/app/studio/src/audio/AudioOfflineRenderer.ts
+++ b/packages/app/studio/src/audio/AudioOfflineRenderer.ts
@@ -24,6 +24,16 @@ import JSZip from "jszip";
 import WorkletsUrl from "@opendaw/studio-core/processors.js?url";
 
 export namespace AudioOfflineRenderer {
+  /**
+   * Render the given project into an offline audio buffer and prompt the user
+   * to save it. When an {@link ExportStemsConfiguration} is supplied, each
+   * track is exported as an individual stem and packaged into a ZIP archive.
+   *
+   * @param source Project to render.
+   * @param meta Metadata describing the project for file names.
+   * @param optExportConfiguration Optional stem export settings.
+   * @param sampleRate Target sample rate of the rendered audio.
+   */
   export const start = async (
     source: Project,
     meta: ProjectMeta,
@@ -82,6 +92,9 @@ export namespace AudioOfflineRenderer {
     }
   };
 
+  /**
+   * Prompt the user to save a single WAV file rendered from the project.
+   */
   const saveWavFile = async (buffer: AudioBuffer, meta: ProjectMeta) => {
     const approveResult = await Promises.tryCatch(
       showApproveDialog({
@@ -103,6 +116,10 @@ export namespace AudioOfflineRenderer {
     }
   };
 
+  /**
+   * Create a ZIP archive containing individual stem files and prompt the user
+   * to save it.
+   */
   const saveZipFile = async (
     buffer: AudioBuffer,
     meta: ProjectMeta,

--- a/packages/app/studio/src/project/SampleImporter.ts
+++ b/packages/app/studio/src/project/SampleImporter.ts
@@ -8,6 +8,9 @@ import {Sample} from "@opendaw/studio-adapters"
  * ```ts
  * await importer.importSample({uuid, name: "kick", arrayBuffer})
  * ```
+ *
+ * @see SampleUtils.verify
+ * @see SampleDialogs.missingSampleDialog
  */
 export type SampleImporter = {
     importSample(sample: {

--- a/packages/app/studio/src/project/SampleUtils.ts
+++ b/packages/app/studio/src/project/SampleUtils.ts
@@ -10,7 +10,12 @@ import {showInfoDialog} from "@/ui/components/dialogs"
 import {SampleImporter} from "@/project/SampleImporter"
 import {SampleApi} from "@/service/SampleApi"
 
-/** Utility functions for working with audio samples. */
+/**
+ * Utility functions for working with audio samples.
+ *
+ * @see SampleImporter
+ * @see SampleDialogs
+ */
 export namespace SampleUtils {
     /**
      * Ensure all audio file boxes reference existing samples and prompt the

--- a/packages/app/studio/src/service/ExportStemsConfigurator.sass
+++ b/packages/app/studio/src/service/ExportStemsConfigurator.sass
@@ -1,5 +1,9 @@
 // Styles for the ExportStemsConfigurator component.
 //
+// The layout uses a five column CSS grid where the first column holds the
+// track label followed by three check boxes and a text input for the file
+// name. The header mirrors this structure so the columns line up.
+//
 // ```mermaid
 // flowchart LR
 //   header --> list
@@ -30,5 +34,5 @@ component
     max-height: 12em
     overflow: hidden scroll
 
-    > div.name
-      font-size: 0.75em
+      > div.name
+        font-size: 0.75em

--- a/packages/app/studio/src/service/ExportStemsConfigurator.tsx
+++ b/packages/app/studio/src/service/ExportStemsConfigurator.tsx
@@ -12,14 +12,22 @@ import {ColorCodes, Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "ExportStemsConfigurator")
 
-export type EditableExportStemsConfiguration = ExportStemsConfiguration & Record<string, {
-    readonly type: AudioUnitType
-    label: string
-    include: boolean
-}>
+/**
+ * Mutable view of {@link ExportStemsConfiguration} used by the UI. Each entry
+ * represents a track and stores additional flags for inclusion and naming.
+ */
+export type EditableExportStemsConfiguration = ExportStemsConfiguration &
+    Record<string, {
+        readonly type: AudioUnitType
+        label: string
+        include: boolean
+    }>
 
+/** Parameters expected by {@link ExportStemsConfigurator}. */
 type Construct = {
+    /** Lifecycle used to clean up subscriptions. */
     lifecycle: Lifecycle
+    /** Configuration object mutated by the component. */
     configuration: EditableExportStemsConfiguration
 }
 

--- a/packages/app/studio/src/ui/browse/SampleDialogs.tsx
+++ b/packages/app/studio/src/ui/browse/SampleDialogs.tsx
@@ -9,7 +9,12 @@ import { Errors, Files } from "@opendaw/lib-dom";
 import { SampleImporter } from "@/project/SampleImporter";
 import { FilePickerAcceptTypes } from "@/ui/FilePickerAcceptTypes";
 
-/** Dialog helpers for managing samples. */
+/**
+ * Dialog helpers for managing samples.
+ *
+ * @see SampleImporter
+ * @see SampleUtils.verify
+ */
 export namespace SampleDialogs {
   /** Open the browser's file picker for selecting sample files. */
   export const nativeFileBrowser = async (multiple: boolean = true) =>

--- a/packages/docs/docs-dev/architecture/persistence.md
+++ b/packages/docs/docs-dev/architecture/persistence.md
@@ -20,3 +20,6 @@ flowchart TD
     P -->|references| S[SampleStorage]
 ```
 
+For day‑to‑day usage tips see the
+[file management guide](../../docs-user/features/file-management.md).
+

--- a/packages/docs/docs-dev/services/stems.md
+++ b/packages/docs/docs-dev/services/stems.md
@@ -1,6 +1,8 @@
 # Stems Configurator
 
-UI component used when exporting individual track stems.
+`ExportStemsConfigurator` allows users to choose which tracks to render as
+individual stems and how each stem should be named. It is used by the export
+workflow when the *Stems* option is selected.
 
 ```mermaid
 flowchart LR
@@ -8,3 +10,6 @@ flowchart LR
   includeAudioEffectsAll --> Track
   includeSendsAll --> Track
 ```
+
+See the [exporting and sharing workflow](../../docs-user/workflows/exporting-and-sharing.md)
+for an overview of how stems fit into project delivery.

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -46,3 +46,6 @@ Import, export, and organize project files. Developers can dive deeper in the
 ## Collaborate and Share
 
 Use project bundles to collaborate. Export a bundle and send it to another user who can open it and continue working. The [Collaboration workflow](../workflows/collaboration.md) covers best practices.
+
+Detailed steps for exporting audio or bundles are available in the
+[exporting and sharing workflow](../workflows/exporting-and-sharing.md).

--- a/packages/docs/docs-user/workflows/exporting-and-sharing.md
+++ b/packages/docs/docs-user/workflows/exporting-and-sharing.md
@@ -19,3 +19,5 @@ flowchart TD
 6. **Download or share.** Save the resulting file to your computer or send the bundle to a collaborator.
 
 Use this workflow whenever you need to back up a project or deliver a finished track. For collaboration tips see the [Collaboration workflow](collaboration.md). For technical details on stem export see the [Stems Configurator](../../docs-dev/services/stems.md).
+
+Managing your local project files is covered in the [File Management feature guide](../features/file-management.md).


### PR DESCRIPTION
## Summary
- improve AudioImporter and AudioOfflineRenderer docs
- expand ExportStemsConfigurator docs and styling notes
- add persistence and workflow documentation cross-links

## Testing
- `npm test`
- `npm run lint` *(fails: command sh -c eslint "**/*.ts" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68af1fa9d8688321a4e173e0bca3a598