### PR TITLE
docs: add notepad guides and annotate markdown components

### DIFF
--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -6,6 +6,11 @@ For a guided overview of the interface, see the [UI tour](../../docs/docs-user/u
 Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md).
 Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
+The project notepad uses markdown and can be customized. See the
+[markdown editing guide](../../docs/docs-dev/ui/markdown/editing.md) for
+developer details. For instructions on using the feature in the Studio,
+read the [notepad user guide](../../docs/docs-user/features/notepad.md).
+
 For individual topics, browse the in-app [manuals](public/manuals/index.md).
 
 ## Component Hierarchy

--- a/packages/app/studio/src/ui/App.tsx
+++ b/packages/app/studio/src/ui/App.tsx
@@ -14,6 +14,13 @@ import { ErrorsPage } from "@/ui/pages/ErrorsPage.tsx";
 import { ImprintPage } from "@/ui/pages/ImprintPage.tsx";
 import { GraphPage } from "@/ui/pages/GraphPage";
 
+/**
+ * Root application component wiring together the global header, footer and the
+ * router that drives all workspace pages.
+ *
+ * @param service - The main studio service providing session state.
+ * @returns The root application element.
+ */
 export const App = (service: StudioService) => {
   const terminator = new Terminator();
   return (

--- a/packages/app/studio/src/ui/Dashboard.tsx
+++ b/packages/app/studio/src/ui/Dashboard.tsx
@@ -7,15 +7,25 @@ import { ProjectBrowser } from "@/project/ProjectBrowser";
 import { showProcessMonolog } from "@/ui/components/dialogs";
 import { Colors } from "@opendaw/studio-core";
 
+/** Class name used for the dashboard container. */
 const className = Html.adoptStyleSheet(css, "Dashboard");
 
 type Construct = {
+  /** Lifecycle of the containing panel. */
   lifecycle: Lifecycle;
+  /** Reference to the studio service for project operations. */
   service: StudioService;
 };
 
-/** Landing page presenting templates and recent projects. */
+/**
+ * Landing page presented when no project is open. Provides shortcuts to
+ * templates, lists recent projects and displays build metadata.
+ *
+ * @param service - Studio service used for project interaction.
+ * @returns The dashboard element.
+ */
 export const Dashboard = ({ service }: Construct) => {
+  // Calculate how long ago the application was built to show in the footer.
   const time = TimeSpan.millis(
     new Date(service.buildInfo.date).getTime() - new Date().getTime(),
   ).toUnitString();

--- a/packages/app/studio/src/ui/Markdown.sass
+++ b/packages/app/studio/src/ui/Markdown.sass
@@ -1,8 +1,11 @@
+// Styling for rendered markdown blocks.
+// Ensures that text remains selectable even when nested inside components.
 @use "@/mixins"
 
 component
   @include mixins.markdown
 
+  // Allow selection of all elements inside the markdown container.
   *
     user-select: text !important
     -webkit-user-select: text !important

--- a/packages/app/studio/src/ui/Markdown.tsx
+++ b/packages/app/studio/src/ui/Markdown.tsx
@@ -5,12 +5,35 @@ import { createElement, RouteLocation } from "@opendaw/lib-jsx";
 import markdownit from "markdown-it";
 import { markdownItTable } from "markdown-it-table";
 
+/**
+ * Shared stylesheet name used by the {@link Markdown} component and related
+ * helpers. The style sheet ensures consistent rendering of markdown content
+ * across the Studio.
+ */
 const className = Html.adoptStyleSheet(css, "Markdown");
 
+/**
+ * Construction parameters for the {@link Markdown} JSX component.
+ */
 type Construct = {
+  /** Raw markdown text to render. */
   text: string;
 };
 
+/**
+ * Converts markdown text into HTML and injects it into the supplied element.
+ *
+ * The renderer performs several quality‑of‑life enhancements:
+ *
+ * - Rewrites keyboard modifier symbols for the current platform.
+ * - Enables the markdown-it table plugin.
+ * - Forces images to be CORS friendly and fit within their container.
+ * - Routes internal links through the application's router.
+ * - Adds copy‑to‑clipboard behaviour to code blocks.
+ *
+ * @param element - Target element that will receive the rendered HTML.
+ * @param text - Markdown source to render.
+ */
 export const renderMarkdown = (element: HTMLElement, text: string) => {
   if (Browser.isWindows()) {
     Object.entries(ModfierKeys.Mac).forEach(
@@ -21,6 +44,8 @@ export const renderMarkdown = (element: HTMLElement, text: string) => {
   const md = markdownit();
   md.use(markdownItTable);
   element.innerHTML = md.render(text);
+  // Ensure images scale within the container and do not trigger CORS errors
+  // when used in canvases.
   element.querySelectorAll("img").forEach((img) => {
     img.crossOrigin = "anonymous";
     img.style.maxWidth = "100%";
@@ -28,6 +53,8 @@ export const renderMarkdown = (element: HTMLElement, text: string) => {
       img.alt = "";
     }
   });
+  // Intercept relative links and delegate navigation to the router so the
+  // entire application is not reloaded.
   element.querySelectorAll("a").forEach((a) => {
     const url = new URL(a.href);
     if (url.origin === location.origin) {
@@ -39,6 +66,7 @@ export const renderMarkdown = (element: HTMLElement, text: string) => {
       a.target = "_blank";
     }
   });
+  // Allow code blocks to be copied to the clipboard with a single click.
   element.querySelectorAll("code").forEach((code) => {
     code.title = "Click to copy to clipboard";
     code.onclick = () => {
@@ -50,6 +78,12 @@ export const renderMarkdown = (element: HTMLElement, text: string) => {
   });
 };
 
+/**
+ * JSX component rendering sanitized markdown inside a styled container.
+ *
+ * @param text - Markdown string to display.
+ * @returns The resulting DOM element.
+ */
 export const Markdown = ({ text }: Construct) => {
   if (text.startsWith("<")) {
     return "Invalid Markdown";

--- a/packages/app/studio/src/ui/NotePadPanel.sass
+++ b/packages/app/studio/src/ui/NotePadPanel.sass
@@ -1,3 +1,5 @@
+// Styles for the project notepad panel, combining general markdown rules with
+// a panel background to match the rest of the workspace.
 @use "@/colors"
 @use "@/mixins"
 
@@ -18,5 +20,6 @@ component
     padding: 1em
     max-width: 100%
 
+    // Preserve user line breaks while editing markdown.
     &[contentEditable]
       white-space: break-spaces

--- a/packages/app/studio/src/ui/NotePadPanel.tsx
+++ b/packages/app/studio/src/ui/NotePadPanel.tsx
@@ -9,19 +9,32 @@ import { Checkbox } from "@/ui/components/Checkbox";
 import { renderMarkdown } from "@/ui/Markdown";
 import { Events, Html, Keyboard } from "@opendaw/lib-dom";
 
+/** CSS module class applied to the notepad container. */
 const className = Html.adoptStyleSheet(css, "NotePadPanel");
 
+/** Construction parameters for the {@link NotePadPanel} component. */
 type Construct = {
+  /** Parent lifecycle that manages subscriptions. */
   lifecycle: Lifecycle;
+  /** Shared studio service used to persist notepad content. */
   service: StudioService;
 };
 
+/**
+ * Displays a small markdown-capable notepad. The panel allows users to toggle
+ * between editing plain text and viewing rendered markdown. Text is persisted
+ * in the current session metadata.
+ */
 export const NotePadPanel = ({ lifecycle, service }: Construct) => {
+  // Observable backing store for the markdown text.
   const markdownText = new DefaultObservableValue("");
+  // Observable toggling between edit and preview modes.
   const editMode = new DefaultObservableValue(false);
+  // Element representing the editable or rendered content.
   const notepad: HTMLElement = (
     <div className="content" role="region" aria-label="Notepad" />
   );
+  // Persist the current notepad text into the session metadata.
   const saveNotepad = () => {
     const innerText = notepad.innerText;
     if (innerText === template) {
@@ -30,6 +43,7 @@ export const NotePadPanel = ({ lifecycle, service }: Construct) => {
     markdownText.setValue(innerText);
     service.session.updateMetaData("notepad", innerText);
   };
+  // Re-render the notepad depending on edit mode state.
   const update = () => {
     Html.empty(notepad);
     const text = markdownText.getValue();

--- a/packages/app/studio/src/ui/NotePadTemplate.md
+++ b/packages/app/studio/src/ui/NotePadTemplate.md
@@ -1,3 +1,5 @@
+<!-- Default text shown when the project notepad is empty. Feel free to edit or remove. -->
+
 # Introducing the OpenDAW Project Notepad
 
 ## A Space for Your Thoughts, Lyrics, and Ideas
@@ -11,10 +13,10 @@ write down everything that matters for your project.
 
 The Project Notepad is a flexible and intuitive tool designed to support your creative process. You can use it to:
 
-* Write lyrics
-* Store musical ideas
-* Keep session notes
-* Share project details
+- Write lyrics
+- Store musical ideas
+- Keep session notes
+- Share project details
 
 ## How To?
 

--- a/packages/app/studio/src/ui/TextScroller.ts
+++ b/packages/app/studio/src/ui/TextScroller.ts
@@ -1,29 +1,47 @@
-import {clamp, Terminable, Terminator} from "@opendaw/lib-std"
-import {AnimationFrame, Events} from "@opendaw/lib-dom"
+import { clamp, Terminable, Terminator } from "@opendaw/lib-std";
+import { AnimationFrame, Events } from "@opendaw/lib-dom";
 
+/**
+ * Helpers for automatically scrolling overflowing text when the pointer hovers
+ * over an element. Useful for labels that are truncated with ellipsis.
+ */
 export namespace TextScroller {
-    export const install = (element: HTMLElement): Terminable => {
-        element.style.overflow = "hidden"
-        const scrolling = new Terminator()
-        return Terminable.many(
-            Events.subscribe(element, "pointerenter", () => {
-                element.style.textOverflow = "clip"
-                let x = 0.0
-                scrolling.own(AnimationFrame.add(() => {
-                    const smoothStep = (k: number) => k * k * (3.0 - 2.0 * k)
-                    const t = 1.0 - Math.abs(2.0 * (Math.floor(x) - x) + 1.0)
-                    const moveFunc = smoothStep(clamp((t - 0.25) / (0.75 - 0.25), 0.0, 1.0))
-                    element.scrollTop = moveFunc * (element.scrollHeight - element.clientHeight)
-                    element.scrollLeft = moveFunc * (element.scrollWidth - element.clientWidth)
-                    x += 0.5 / Math.max(element.scrollWidth, element.scrollHeight)
-                }))
-            }),
-            Events.subscribe(element, "pointerleave", () => {
-                element.style.textOverflow = "ellipsis"
-                element.scrollLeft = 0
-                scrolling.terminate()
-            }),
-            scrolling
-        )
-    }
+  /**
+   * Enables auto-scrolling behaviour on the given element. The text will scroll
+   * back and forth while the pointer remains over the element and reset when it
+   * leaves.
+   *
+   * @param element - The element whose text should scroll.
+   * @returns A {@link Terminable} that removes the installed listeners.
+   */
+  export const install = (element: HTMLElement): Terminable => {
+    element.style.overflow = "hidden";
+    const scrolling = new Terminator();
+    return Terminable.many(
+      Events.subscribe(element, "pointerenter", () => {
+        element.style.textOverflow = "clip";
+        let x = 0.0;
+        scrolling.own(
+          AnimationFrame.add(() => {
+            const smoothStep = (k: number) => k * k * (3.0 - 2.0 * k);
+            const t = 1.0 - Math.abs(2.0 * (Math.floor(x) - x) + 1.0);
+            const moveFunc = smoothStep(
+              clamp((t - 0.25) / (0.75 - 0.25), 0.0, 1.0),
+            );
+            element.scrollTop =
+              moveFunc * (element.scrollHeight - element.clientHeight);
+            element.scrollLeft =
+              moveFunc * (element.scrollWidth - element.clientWidth);
+            x += 0.5 / Math.max(element.scrollWidth, element.scrollHeight);
+          }),
+        );
+      }),
+      Events.subscribe(element, "pointerleave", () => {
+        element.style.textOverflow = "ellipsis";
+        element.scrollLeft = 0;
+        scrolling.terminate();
+      }),
+      scrolling,
+    );
+  };
 }

--- a/packages/docs/docs-dev/ui/markdown/editing.md
+++ b/packages/docs/docs-dev/ui/markdown/editing.md
@@ -1,0 +1,20 @@
+# Markdown Editing
+
+OpenDAW uses markdown to format rich text such as the project notepad. The
+`renderMarkdown` helper converts markdown to HTML and augments the output
+with platform specific tweaks.
+
+## Renderer behaviour
+
+- Rewrites modifier key symbols so shortcut references match the host OS.
+- Ensures images are CORS friendly and limited to the container width.
+- Routes internal links through the app router and opens external links in
+  a new tab.
+- Makes code blocks clickable to copy their contents to the clipboard.
+
+## Notepad integration
+
+The [notepad panel](../../../docs-user/features/notepad.md) stores its
+contents as markdown. When edit mode is active the panel exposes a plain
+text area. Leaving edit mode re-renders the text as markdown and persists it
+to the session metadata.

--- a/packages/docs/docs-dev/ui/overview.md
+++ b/packages/docs/docs-dev/ui/overview.md
@@ -4,4 +4,4 @@
 - [Menu](./menu/overview.md)
 - [Validator](./validator/overview.md)
 - [Canvas](./canvas/overview.md)
-
+- [Markdown](./markdown/editing.md)

--- a/packages/docs/docs-user/features/notepad.md
+++ b/packages/docs/docs-user/features/notepad.md
@@ -1,0 +1,19 @@
+# Notepad
+
+Capture lyrics, ideas or session notes directly within a project.
+
+## Open the notepad
+
+1. Add or focus a **Notepad** panel in the workspace.
+2. The panel displays the current project's notes or a helpful template.
+
+## Edit notes
+
+1. Click the pencil icon in the upper‑right corner of the panel to toggle edit mode.
+2. Type using plain text or markdown formatting.
+3. Leave edit mode or press <kbd>Ctrl</kbd>+<kbd>S</kbd> (<kbd>Cmd</kbd> on macOS) to save.
+
+## Tips
+
+- Notes are stored with the project and reopen automatically.
+- You can use standard markdown features like headings, lists and links.

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -165,6 +165,11 @@ module.exports = {
             "ui/modular/faq",
           ],
         },
+        {
+          type: "category",
+          label: "Markdown",
+          items: ["ui/markdown/editing"],
+        },
       ],
     },
     {

--- a/packages/docs/sidebarsUser.js
+++ b/packages/docs/sidebarsUser.js
@@ -16,6 +16,7 @@ module.exports = {
         "features/devices-and-plugins",
         "features/file-management",
         "features/browse",
+        "features/notepad",
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- document markdown renderer and notepad usage
- add TSDoc to markdown, notepad, and dashboard components
- wire new docs into sidebars and README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af1fabedfc8321ba019ff4143730ad