### PR TITLE
docs: add configuration overview and TSDoc

### DIFF
--- a/packages/app/studio/package.json
+++ b/packages/app/studio/package.json
@@ -7,6 +7,15 @@
   "description": "Web-based digital audio workstation UI for OpenDAW",
   "type": "module",
   "license": "MIT",
+  "exports": {
+    "./configs": "./src/ui/configs.ts",
+    "./features": "./src/features.ts",
+    "./FilePickerAcceptTypes": "./src/ui/FilePickerAcceptTypes.ts",
+    "./service/SessionService": "./src/service/SessionService.ts",
+    "./service/StudioService": "./src/service/StudioService.ts",
+    "./project/ProjectDialogs": "./src/project/ProjectDialogs.tsx",
+    "./ui/App": "./src/ui/App.tsx"
+  },
   "scripts": {
     "dev": "vite --clearScreen false",
     "build": "tsc && vite build",

--- a/packages/app/studio/src/features.ts
+++ b/packages/app/studio/src/features.ts
@@ -1,3 +1,6 @@
+/**
+ * Runtime feature detection utilities for the Studio application.
+ */
 import { requireProperty } from "@opendaw/lib-std";
 
 /**

--- a/packages/app/studio/src/project/ProjectDialogs.tsx
+++ b/packages/app/studio/src/project/ProjectDialogs.tsx
@@ -1,3 +1,6 @@
+/**
+ * Collection of dialogs used for common project management operations.
+ */
 import {Dialog} from "@/ui/components/Dialog"
 import {ExportStemsConfiguration, IconSymbol} from "@opendaw/studio-adapters"
 import {Surface} from "@/ui/surface/Surface"

--- a/packages/app/studio/src/service/SessionService.ts
+++ b/packages/app/studio/src/service/SessionService.ts
@@ -1,3 +1,6 @@
+/**
+ * Service handling persistence and lifecycle operations for project sessions.
+ */
 import {ProjectSession} from "@/project/ProjectSession"
 import {
     DefaultObservableValue,

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -1,3 +1,7 @@
+/**
+ * Core application service responsible for wiring together workspace, audio
+ * engine and project handling utilities.
+ */
 import {
     assert,
     DefaultObservableValue,
@@ -71,6 +75,7 @@ range.showUnitInterval(0, PPQN.fromSignature(16, 1))
 
 const snapping = new Snapping(range)
 
+/** Lightweight representation of the active project session. */
 export type Session = {
     readonly uuid: Readonly<UUID.Format>
     readonly project: Project

--- a/packages/app/studio/src/ui/App.tsx
+++ b/packages/app/studio/src/ui/App.tsx
@@ -1,3 +1,6 @@
+/**
+ * Root component that sets up routing and global UI elements for the studio.
+ */
 import { Terminator } from "@opendaw/lib-std";
 import { createElement, Frag, Router } from "@opendaw/lib-jsx";
 import { WorkspacePage } from "@/ui/workspace/WorkspacePage.tsx";
@@ -14,6 +17,10 @@ import { ErrorsPage } from "@/ui/pages/ErrorsPage.tsx";
 import { ImprintPage } from "@/ui/pages/ImprintPage.tsx";
 import { GraphPage } from "@/ui/pages/GraphPage";
 
+/**
+ * Main application component establishing the router and persistent layout
+ * chrome. It is expected to be mounted once at the root of the document.
+ */
 export const App = (service: StudioService) => {
   const terminator = new Terminator();
   return (

--- a/packages/app/studio/src/ui/FilePickerAcceptTypes.ts
+++ b/packages/app/studio/src/ui/FilePickerAcceptTypes.ts
@@ -1,10 +1,17 @@
+/**
+ * Predefined {@link FilePickerOptions} and {@link FilePickerAcceptType}
+ * configurations used throughout the studio when interacting with the
+ * File System Access API.
+ */
 export namespace FilePickerAcceptTypes {
+    /** Accept only uncompressed WAV audio files. */
     export const WavFiles: FilePickerOptions = {
         types: [{
             description: "wav-file",
             accept: {"audio/wav": [".wav"]}
         }]
     }
+    /** Accept log files produced by project synchronization (.odsl). */
     export const ProjectSyncLog: FilePickerOptions = {
         types: [{
             description: "openDAW sync-log-file",
@@ -12,16 +19,19 @@ export namespace FilePickerAcceptTypes {
         }]
     }
 
+    /** Accept a raw openDAW project file (.od). */
     export const ProjectFileType: FilePickerAcceptType = {
         description: "openDAW project",
         accept: {"application/octet-stream": [".od"]}
     }
 
+    /** Accept a bundled openDAW project archive (.odb). */
     export const ProjectBundleFileType: FilePickerAcceptType = {
         description: "openDAW project bundle",
         accept: {"application/octet-stream": [".odb"]}
     }
 
+    /** Accept a DAWProject file (.dawproject). */
     export const DawprojectFileType: FilePickerAcceptType = {
         description: "dawproject",
         accept: {"application/octet-stream": [".dawproject"]}

--- a/packages/app/studio/src/ui/configs.ts
+++ b/packages/app/studio/src/ui/configs.ts
@@ -1,6 +1,15 @@
+/**
+ * Collection of snapping presets used by timeline and meter widgets.
+ */
 import {ValueMapping} from "@opendaw/lib-std"
 
+/** Snap settings that align selections around the center. */
 export const SnapCenter = {snap: {threshold: 0.5, snapLength: 12}}
+
+/**
+ * Snap settings based on common decibel values. Useful for placing
+ * automation points at musically meaningful levels.
+ */
 export const SnapCommonDecibel = {
     snap: {
         threshold: [-12, -9, -6, -3]

--- a/packages/app/studio/tsconfig.json
+++ b/packages/app/studio/tsconfig.json
@@ -8,7 +8,14 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ]
+      ],
+      "@opendaw/app-studio/configs": ["./src/ui/configs.ts"],
+      "@opendaw/app-studio/features": ["./src/features.ts"],
+      "@opendaw/app-studio/FilePickerAcceptTypes": ["./src/ui/FilePickerAcceptTypes.ts"],
+      "@opendaw/app-studio/service/SessionService": ["./src/service/SessionService.ts"],
+      "@opendaw/app-studio/service/StudioService": ["./src/service/StudioService.ts"],
+      "@opendaw/app-studio/project/ProjectDialogs": ["./src/project/ProjectDialogs.tsx"],
+      "@opendaw/app-studio/ui/App": ["./src/ui/App.tsx"]
     },
     "allowImportingTsExtensions": true
   }

--- a/packages/docs/docs-dev/configuration/overview.md
+++ b/packages/docs/docs-dev/configuration/overview.md
@@ -1,0 +1,17 @@
+# Configuration Overview
+
+The Studio application exposes several modules that centralize runtime configuration:
+
+- `configs.ts` – snapping presets for timeline and level meters.
+- `features.ts` – feature detection ensuring required Web APIs before boot.
+- `FilePickerAcceptTypes.ts` – lists of accepted file types for the File System Access API.
+
+These modules are exported from `@opendaw/app-studio` and can be imported using path mappings defined in the package metadata:
+
+```ts
+import { SnapCenter } from "@opendaw/app-studio/configs";
+import { testFeatures } from "@opendaw/app-studio/features";
+```
+
+The package `package.json` and `tsconfig.json` reference these files so tooling and
+consumers can resolve them directly.

--- a/packages/docs/docs-user/quick-start.md
+++ b/packages/docs/docs-user/quick-start.md
@@ -13,3 +13,5 @@ For writing or editing tips, consult the
 [Writing Guide](../docs-dev/style/writing-guide.md). For a technical
 overview of how the studio boots, see the
 [bootstrapping architecture doc](../docs-dev/architecture/bootstrap.md).
+To tweak default behaviour of the application, refer to the
+[Configuration Overview](../docs-dev/configuration/overview.md).


### PR DESCRIPTION
## Summary
- document studio configuration modules and user quick start
- expose config modules via package metadata and path mappings
- add TSDoc comments for studio services and components

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/studio-enums#lint)*
- `npm run lint --workspace packages/app/studio`

------
https://chatgpt.com/codex/tasks/task_b_68af1fac13d48321bc87627c41fbcd48