### PR TITLE
docs: document timeline selection and editors

### DIFF
--- a/packages/app/studio/src/ui/timeline/MidiImport.ts
+++ b/packages/app/studio/src/ui/timeline/MidiImport.ts
@@ -1,3 +1,7 @@
+/**
+ * Helpers for importing MIDI files and translating their events into
+ * timeline tracks and regions.
+ */
 import {
     Arrays,
     byte,
@@ -20,6 +24,11 @@ import {ColorCodes, Project} from "@opendaw/studio-core"
 import {ControlType, MidiFile} from "@opendaw/lib-midi"
 
 export namespace MidiImport {
+    /**
+     * Prompts the user for a MIDI file and converts it into note regions within
+     * the supplied project.  New tracks are created as needed and the operation
+     * runs inside an editing modification so it can be reverted on failure.
+     */
     export const toTracks = async (project: Project, audioUnitBoxAdapter: AudioUnitBoxAdapter) => {
         const fileResult = await Promises.tryCatch(Files.open().then(([file]) => file.arrayBuffer()))
         if (fileResult.status === "rejected") {

--- a/packages/app/studio/src/ui/timeline/Modifier.ts
+++ b/packages/app/studio/src/ui/timeline/Modifier.ts
@@ -1,3 +1,8 @@
+/**
+ * Contract for drag-based modifications performed on the timeline. Implementations
+ * react to pointer movement and optionally commit or revert changes through the
+ * provided editing API.
+ */
 import {Dragging} from "@opendaw/lib-dom"
 import {Editing} from "@opendaw/lib-box"
 

--- a/packages/app/studio/src/ui/timeline/SelectionRectangle.sass
+++ b/packages/app/studio/src/ui/timeline/SelectionRectangle.sass
@@ -1,3 +1,4 @@
+// Overlay rectangle drawn during drag selection on the timeline.
 component
   top: 0
   left: 0

--- a/packages/app/studio/src/ui/timeline/TimeGrid.ts
+++ b/packages/app/studio/src/ui/timeline/TimeGrid.ts
@@ -1,3 +1,7 @@
+/**
+ * Helpers for walking the musical grid of the timeline.  Provides iteration
+ * utilities that call back for each bar, beat or subdivision within a range.
+ */
 import {PPQN} from "@opendaw/lib-dsp"
 import {int, quantizeFloor} from "@opendaw/lib-std"
 import {TimelineRange} from "@/ui/timeline/TimelineRange.ts"

--- a/packages/app/studio/src/ui/timeline/TimelineHeader.sass
+++ b/packages/app/studio/src/ui/timeline/TimelineHeader.sass
@@ -1,4 +1,4 @@
-// Styles for {@link TimelineHeader} component.
+// Styles for the {@link TimelineHeader} toolbar displayed above the timeline.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/TimelineHeader.tsx
+++ b/packages/app/studio/src/ui/timeline/TimelineHeader.tsx
@@ -1,3 +1,7 @@
+/**
+ * Header toolbar displayed above the timeline.  It exposes snap settings and
+ * toggles for visibility of various timeline layers such as markers and clips.
+ */
 import css from "./TimelineHeader.sass?inline"
 import {Lifecycle} from "@opendaw/lib-std"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/timeline/TimelineNavigation.tsx
+++ b/packages/app/studio/src/ui/timeline/TimelineNavigation.tsx
@@ -1,3 +1,7 @@
+/**
+ * Navigation bar for the timeline.  It combines the loop area editor and the
+ * time axis and is typically rendered directly beneath the header.
+ */
 import css from "./TimelineNavigation.sass?inline"
 import {Lifecycle} from "@opendaw/lib-std"
 import {StudioService} from "@/service/StudioService.ts"

--- a/packages/app/studio/src/ui/timeline/TimelineRangeSlider.tsx
+++ b/packages/app/studio/src/ui/timeline/TimelineRangeSlider.tsx
@@ -1,3 +1,8 @@
+/**
+ * Slider widget that lets the user adjust the visible or playback range of
+ * the timeline.  The control exposes draggable handles for the start and end
+ * markers and supports dragging the middle section to move the entire range.
+ */
 import css from "./TimelineRangeSlider.sass?inline"
 import {int, Lifecycle, Option, Terminator, unitValue} from "@opendaw/lib-std"
 import {createElement, Frag} from "@opendaw/lib-jsx"
@@ -17,6 +22,10 @@ type Construct = {
 const COLOR_HANDLER = "rgba(255,255,255,0.25)"
 const COLOR_BACKGROUND = "rgba(255,255,255,0.125)"
 
+/**
+ * Visual slider for manipulating a {@link TimelineRange}.  Resizes according to
+ * the hosting element and updates the range in response to pointer gestures.
+ */
 export const TimelineRangeSlider = ({lifecycle, range, style, className: extraClassName}: Construct) => {
     const radius = 5
     const padding = radius * 2

--- a/packages/app/studio/src/ui/timeline/editors/EventOwnerReader.ts
+++ b/packages/app/studio/src/ui/timeline/editors/EventOwnerReader.ts
@@ -1,3 +1,8 @@
+/**
+ * Type definitions for objects that own time based events such as regions or
+ * audio files.  Readers expose a normalised API used by timeline editors to
+ * query and react to these event owners regardless of their concrete type.
+ */
 import {ppqn} from "@opendaw/lib-dsp"
 import {int, Observer, Option, Subscription} from "@opendaw/lib-std"
 import {TimelineRange} from "@/ui/timeline/TimelineRange.ts"
@@ -11,30 +16,54 @@ import {
 import {AudioFileBoxAdapter} from "@opendaw/studio-adapters"
 import {TrackBoxAdapter} from "@opendaw/studio-adapters"
 
+/** Reader specialised for regions containing audio events. */
 export interface AudioEventOwnerReader extends EventOwnerReader<never> {
+    /** Adapted audio file backing the region. */
     get file(): AudioFileBoxAdapter
+    /** Gain applied to playback of the region. */
     get gain(): number
 }
 
+/** Reader for regions containing note events. */
 export interface NoteEventOwnerReader extends EventOwnerReader<NoteEventCollectionBoxAdapter> {}
 
+/** Reader for regions containing automation or other value events. */
 export interface ValueEventOwnerReader extends EventOwnerReader<ValueEventCollectionBoxAdapter> {}
 
+/**
+ * Abstraction over an entity on the timeline that owns time based content.
+ * Provides accessors for temporal and visual properties and exposes hooks for
+ * observing changes.
+ */
 export interface EventOwnerReader<CONTENT> extends TimeAxisCursorMapper {
+    /** Start position of the owner measured in pulses. */
     get position(): ppqn
+    /** Length of the owner in pulses. */
     get duration(): ppqn
+    /** Offset of the loop inside the owner. */
     get loopOffset(): ppqn
+    /** Length of the loop region. */
     get loopDuration(): ppqn
+    /** Duration of the underlying content. */
     get contentDuration(): ppqn
     set contentDuration(value: ppqn)
+    /** Start of the region taking loop offset into account. */
     get offset(): ppqn
+    /** End position of the region. */
     get complete(): ppqn
+    /** Hue used to colorise the region. */
     get hue(): int
+    /** Whether the owner currently has content. */
     get hasContent(): boolean
+    /** True when the region references mirrored content. */
     get isMirrored(): boolean
+    /** Access to the underlying content representation. */
     get content(): CONTENT
+    /** Track containing this region if available. */
     get trackBoxAdapter(): Option<TrackBoxAdapter>
 
+    /** Subscribe to change events on the owner. */
     subscribeChange(observer: Observer<void>): Subscription
+    /** Adjust the provided range when the owner overlaps its boundaries. */
     watchOverlap(range: TimelineRange): Subscription
 }

--- a/packages/app/studio/src/ui/timeline/editors/RegionCapturingTarget.ts
+++ b/packages/app/studio/src/ui/timeline/editors/RegionCapturingTarget.ts
@@ -1,3 +1,8 @@
+/**
+ * Utility for resolving pointer positions to specific region handles.  Used by
+ * editors to determine whether a drag should move a region, resize it or adjust
+ * its loop.
+ */
 import {
     AnyLoopableRegionBoxAdapter,
     AnyRegionBoxAdapter,

--- a/packages/app/studio/src/ui/timeline/editors/RegionReader.ts
+++ b/packages/app/studio/src/ui/timeline/editors/RegionReader.ts
@@ -1,3 +1,8 @@
+/**
+ * Implementation of {@link EventOwnerReader} for region adapters.  Provides a
+ * unified way to access region properties independent of the underlying event
+ * type (audio, notes or values).
+ */
 import {ValueRegionBoxAdapter} from "@opendaw/studio-adapters"
 import {
     ValueEventCollectionBoxAdapter
@@ -21,7 +26,9 @@ import {Propagation} from "@opendaw/lib-box"
 import {AudioFileBoxAdapter} from "@opendaw/studio-adapters"
 import {TrackBoxAdapter} from "@opendaw/studio-adapters"
 
-export class RegionReader<REGION extends LoopableRegionBoxAdapter<CONTENT>, CONTENT> implements EventOwnerReader<CONTENT> {
+export class RegionReader<REGION extends LoopableRegionBoxAdapter<CONTENT>, CONTENT>
+    implements EventOwnerReader<CONTENT> {
+    /** Creates a reader for an {@link AudioRegionBoxAdapter}. */
     static forAudioRegionBoxAdapter(region: AudioRegionBoxAdapter): AudioEventOwnerReader {
         return new class extends RegionReader<AudioRegionBoxAdapter, never> implements AudioEventOwnerReader {
             constructor(region: AudioRegionBoxAdapter) {super(region)}
@@ -30,10 +37,12 @@ export class RegionReader<REGION extends LoopableRegionBoxAdapter<CONTENT>, CONT
         }(region)
     }
 
+    /** Creates a reader for a {@link NoteRegionBoxAdapter}. */
     static forNoteRegionBoxAdapter(adapter: NoteRegionBoxAdapter): NoteEventOwnerReader {
         return new RegionReader<NoteRegionBoxAdapter, NoteEventCollectionBoxAdapter>(adapter)
     }
 
+    /** Creates a reader for a {@link ValueRegionBoxAdapter}. */
     static forValueRegionBoxAdapter(adapter: ValueRegionBoxAdapter): ValueEventOwnerReader {
         return new RegionReader<ValueRegionBoxAdapter, ValueEventCollectionBoxAdapter>(adapter)
     }

--- a/packages/app/studio/src/ui/timeline/editors/Shortcuts.ts
+++ b/packages/app/studio/src/ui/timeline/editors/Shortcuts.ts
@@ -1,3 +1,7 @@
+/**
+ * Installs keyboard shortcuts for timeline editors.  Currently supports global
+ * delete and select-all actions acting on the provided selection and locator.
+ */
 import {Selection} from "@opendaw/lib-std"
 import {TimelineSelectableLocator} from "@/ui/timeline/TimelineSelectableLocator.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -5,6 +9,9 @@ import {Event} from "@opendaw/lib-dsp"
 import {Events, Keyboard} from "@opendaw/lib-dom"
 import {BoxAdapter} from "@opendaw/studio-adapters"
 
+/**
+ * Adds event listeners to handle global shortcuts on an editor element.
+ */
 export const attachShortcuts = <E extends Event & BoxAdapter>(element: Element,
                                                               editing: Editing,
                                                               selection: Selection<E>,

--- a/packages/docs/docs-dev/ui/timeline/selection.md
+++ b/packages/docs/docs-dev/ui/timeline/selection.md
@@ -1,0 +1,8 @@
+# Timeline Selection
+
+Components related to selecting items on the timeline.
+
+- **SelectionRectangle** draws the translucent box while dragging.
+- **TimelineRangeSlider** and other editors can react to the current selection.
+- Keyboard shortcuts use {@link Shortcuts.attachShortcuts} to support global
+  actions like delete or select all.

--- a/packages/docs/docs-user/features/timeline.md
+++ b/packages/docs/docs-user/features/timeline.md
@@ -16,6 +16,12 @@ Enable snapping to align edits to the musical grid.
 
 ![Timeline snapping menu](./img/timeline-snapping.svg)
 
+## Selection
+
+Drag the mouse to draw a rectangle and select multiple clips or regions.
+Use the keyboard to delete the selection or press <kbd>Ctrl</kbd>+<kbd>A</kbd>
+to select everything on the timeline.
+
 ## Example Integration
 
 ```ts


### PR DESCRIPTION
## Summary
- document timeline components like TimelineRangeSlider, MidiImport and TimeGrid
- annotate timeline editor helpers and add developer selection docs
- expand user docs with selection instructions

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/studio-enums#lint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af1fadcc18832192fd8ee8860ee162