### PR TITLE
docs: add engine diagrams and API docs

### DIFF
--- a/packages/docs/docs-dev/architecture/engine.md
+++ b/packages/docs/docs-dev/architecture/engine.md
@@ -1,0 +1,38 @@
+# Engine Sequence Diagrams
+
+The studio engine coordinates audio worklets and worker agents to render and record audio. The following sequences illustrate key interactions.
+
+## Engine Startup
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Worklets
+    participant EngineWorklet
+    participant WorkerAgents
+
+    App->>Worklets: install(workletURL)
+    Worklets->>EngineWorklet: createEngine(project)
+    EngineWorklet->>WorkerAgents: initialise services
+    WorkerAgents-->>EngineWorklet: ready
+    EngineWorklet-->>App: isReady()
+```
+
+## Recording Flow
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Worklets
+    participant RecordingWorklet
+    participant SampleStorage
+
+    App->>Worklets: createRecording()
+    Worklets->>RecordingWorklet: configure ring buffer
+    RecordingWorklet->>App: stream peaks
+    App->>RecordingWorklet: finalize()
+    RecordingWorklet->>SampleStorage: store audio & peaks
+```
+
+For a broader view of the system see the [architecture overview](./overview.md).
+

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -68,8 +68,9 @@ C4Component
 - **Config** – Delivers runtime and build settings consumed by other components through
   [`@opendaw/eslint-config`](../package-inventory.md#config) and related packages.
 
-For a deeper look at timing, see the [audio path](./audio-path.md), and
-learn how to build the project in [Build and Run](../build-and-run/setup.md).
+For a deeper look at timing, see the [audio path](./audio-path.md) and the
+[engine sequence diagrams](./engine.md), and learn how to build the project in
+[Build and Run](../build-and-run/setup.md).
 
 - **App** – Provides the user interface and coordinates system interactions.
 - **Studio** – Handles audio processing, scheduling, and engine control.

--- a/packages/docs/docs-user/workflows/creating-projects.md
+++ b/packages/docs/docs-user/workflows/creating-projects.md
@@ -8,3 +8,7 @@
 
 Projects are stored locally in your browser. Make sure to export regularly if
 you plan to work across devices.
+
+For an overview of how the engine manages playback and recording, see the
+[engine sequence diagrams](../../docs-dev/architecture/engine.md).
+

--- a/packages/studio/core/src/Engine.ts
+++ b/packages/studio/core/src/Engine.ts
@@ -1,3 +1,6 @@
+/**
+ * Public interfaces for controlling the audio engine and reacting to note events.
+ */
 import {ppqn} from "@opendaw/lib-dsp"
 import {
     byte,
@@ -13,35 +16,67 @@ import {
 import {ClipNotification} from "@opendaw/studio-adapters"
 import {Project} from "./Project"
 
+/**
+ * Event describing a note-on or note-off trigger emitted by the engine.
+ */
 export type NoteTrigger =
     | { type: "note-on", uuid: UUID.Format, pitch: byte, velocity: unitValue }
     | { type: "note-off", uuid: UUID.Format, pitch: byte }
 
+/**
+ * Abstraction of the playback engine exposing transport and sequencing control.
+ */
 export interface Engine extends Terminable {
+    /** Starts playback. */
     play(): void
+    /** Stops playback. */
     stop(): void
+    /** Sets the current transport position. */
     setPosition(position: ppqn): void
+    /** Begins recording with optional count-in. */
     startRecording(countIn: boolean): void
+    /** Stops an active recording. */
     stopRecording(): void
+    /** Resolves once the engine finished initialisation. */
     isReady(): Promise<void>
+    /** Queries whether loading of resources has completed. */
     queryLoadingComplete(): Promise<boolean>
+    /** Stops playback and resets state. */
     stop(): void
+    /** Sends an all-notes-off to attached devices. */
     panic(): void
+    /** Triggers a note-on event on an instrument. */
     noteOn(uuid: UUID.Format, pitch: byte, velocity: unitValue): void
+    /** Triggers a note-off event on an instrument. */
     noteOff(uuid: UUID.Format, pitch: byte): void
+    /** Subscribes to note trigger events. */
     subscribeNotes(observer: Observer<NoteTrigger>): Subscription
+    /** Queues clips for playback. */
     scheduleClipPlay(clipIds: ReadonlyArray<UUID.Format>): void
+    /** Cancels scheduled clips for tracks. */
     scheduleClipStop(trackIds: ReadonlyArray<UUID.Format>): void
+    /** Subscribes to clip sequencing notifications. */
     subscribeClipNotification(observer: Observer<ClipNotification>): Subscription
 
+    /** Current transport position. */
     get position(): ObservableValue<ppqn>
+    /** Indicates that the engine is playing. */
     get isPlaying(): ObservableValue<boolean>
+    /** Indicates that the engine is recording. */
     get isRecording(): ObservableValue<boolean>
+    /** Indicates that the engine performs a count-in. */
     get isCountingIn(): ObservableValue<boolean>
+    /** Whether the metronome is enabled. */
     get metronomeEnabled(): ObservableValue<boolean>
+    /** Timestamp used for synchronisation. */
     get playbackTimestamp(): ObservableValue<ppqn>
+    /** Total beats to count in before recording. */
     get countInBeatsTotal(): ObservableValue<int>
+    /** Remaining count-in beats. */
     get countInBeatsRemaining(): ObservableValue<number>
+    /** Active marker state, if any. */
     get markerState(): ObservableValue<Nullable<[UUID.Format, int]>>
+    /** Project instance the engine operates on. */
     get project(): Project
 }
+

--- a/packages/studio/core/src/EngineFacade.ts
+++ b/packages/studio/core/src/EngineFacade.ts
@@ -1,3 +1,6 @@
+/**
+ * High level wrapper around {@link EngineWorklet} for application code.
+ */
 import {
     byte,
     DefaultObservableValue,

--- a/packages/studio/core/src/EngineWorklet.ts
+++ b/packages/studio/core/src/EngineWorklet.ts
@@ -1,3 +1,6 @@
+/**
+ * Engine implementation running inside an audio worklet context.
+ */
 import {
   Arrays,
   byte,

--- a/packages/studio/core/src/MeterWorklet.ts
+++ b/packages/studio/core/src/MeterWorklet.ts
@@ -1,3 +1,6 @@
+/**
+ * Worklet node forwarding peak and RMS measurements to the main thread.
+ */
 import {int, Notifier, Observer, Schema, Subscription, SyncStream, Terminable, Terminator} from "@opendaw/lib-std"
 import {AnimationFrame} from "@opendaw/lib-dom"
 import {PeakMeterProcessorOptions} from "@opendaw/studio-adapters"
@@ -56,3 +59,4 @@ export class MeterWorklet extends AudioWorkletNode implements Terminable {
     /** Terminates the worklet and releases resources. */
     terminate(): void {this.#terminator.terminate()}
 }
+

--- a/packages/studio/core/src/ProjectApi.ts
+++ b/packages/studio/core/src/ProjectApi.ts
@@ -1,3 +1,6 @@
+/**
+ * Helper functions for constructing and modifying the project box graph.
+ */
 import {
     asDefined,
     asInstanceOf,
@@ -46,11 +49,13 @@ import {ColorCodes} from "./ColorCodes"
 import {EffectBox} from "./EffectBox"
 import {AudioUnitOrdering} from "./AudioUnitOrdering"
 
+/** Options for naming and coloring created clips or regions. */
 export type ClipRegionOptions = {
     name?: string
     hue?: number
 }
 
+/** Parameters for creating a note event. */
 export type NoteEventParams = {
     owner: { events: PointerField<Pointers.NoteEventCollection> }
     position: ppqn
@@ -61,6 +66,7 @@ export type NoteEventParams = {
     chance?: int
 }
 
+/** Parameters for creating a note region on a track. */
 export type NoteRegionParams = {
     trackBox: TrackBox
     position: ppqn
@@ -75,6 +81,9 @@ export type NoteRegionParams = {
 }
 
 // noinspection JSUnusedGlobalSymbols
+/**
+ * Convenience API providing factory methods to build project structures.
+ */
 export class ProjectApi {
     readonly #project: Project
 

--- a/packages/studio/core/src/ProjectEnv.ts
+++ b/packages/studio/core/src/ProjectEnv.ts
@@ -1,3 +1,6 @@
+/**
+ * Runtime environment values needed when constructing a project.
+ */
 import {SampleManager} from "@opendaw/studio-adapters"
 
 /**
@@ -11,3 +14,4 @@ export interface ProjectEnv {
     /** Manager responsible for loading and caching samples. */
     sampleManager: SampleManager
 }
+

--- a/packages/studio/core/src/RecordingWorklet.ts
+++ b/packages/studio/core/src/RecordingWorklet.ts
@@ -1,3 +1,7 @@
+/**
+ * Audio worklet node that records incoming audio into a ring buffer while
+ * generating waveform peaks.
+ */
 import {
     Arrays,
     assert,
@@ -64,6 +68,10 @@ class PeaksWriter implements Peaks, Peaks.Stage {
     nearest(_unitsPerPixel: number): Nullable<Peaks.Stage> {return this.stages.at(0) ?? null}
 }
 
+/**
+ * Captures audio from its input and exposes recorded data along with peak
+ * information.
+ */
 export class RecordingWorklet extends AudioWorkletNode implements Terminable, SampleLoader {
     readonly uuid: UUID.Format = UUID.generate()
 
@@ -125,6 +133,10 @@ export class RecordingWorklet extends AudioWorkletNode implements Terminable, Sa
         return this.#notifier.subscribe(observer)
     }
 
+    /**
+     * Stops recording, builds the audio and peak data and stores it via
+     * {@link SampleStorage}.
+     */
     async finalize() {
         this.#reader.stop()
         this.#isRecording = false

--- a/packages/studio/core/src/RenderQuantum.ts
+++ b/packages/studio/core/src/RenderQuantum.ts
@@ -1,1 +1,7 @@
+/**
+ * Number of frames processed per Web Audio render quantum.
+ *
+ * @public
+ */
 export const RenderQuantum = 128
+

--- a/packages/studio/core/src/WorkerAgents.ts
+++ b/packages/studio/core/src/WorkerAgents.ts
@@ -1,3 +1,6 @@
+/**
+ * Interfaces to services provided by the shared worker process.
+ */
 import {FloatArray, int, Lazy, Option, Procedure} from "@opendaw/lib-std"
 import type {OpfsProtocol, SamplePeakProtocol} from "@opendaw/lib-fusion"
 import {Entry} from "@opendaw/lib-fusion"
@@ -68,3 +71,4 @@ export class WorkerAgents {
                 })
     }
 }
+

--- a/packages/studio/core/src/Worklets.ts
+++ b/packages/studio/core/src/Worklets.ts
@@ -1,3 +1,7 @@
+/**
+ * Factory responsible for installing and creating audio worklet nodes
+ * used by the studio engine.
+ */
 import {asDefined, int} from "@opendaw/lib-std"
 import {ExportStemsConfiguration, RingBuffer} from "@opendaw/studio-adapters"
 import {EngineWorklet} from "./EngineWorklet"
@@ -6,7 +10,12 @@ import {RecordingWorklet} from "./RecordingWorklet"
 import {Project} from "./Project"
 import {RenderQuantum} from "./RenderQuantum"
 
+/**
+ * Manages installation and instantiation of worklet nodes for metering,
+ * engine control and recording.
+ */
 export class Worklets {
+    /** Loads the bundled worklet processors into the given audio context. */
     static async install(context: BaseAudioContext, workletURL: string): Promise<Worklets> {
         return context.audioWorklet.addModule(workletURL).then(() => {
             const worklets = new Worklets(context)
@@ -23,14 +32,19 @@ export class Worklets {
 
     constructor(context: BaseAudioContext) {this.#context = context}
 
+    /** Creates a {@link MeterWorklet} for monitoring levels. */
     createMeter(numberOfChannels: int): MeterWorklet {
         return new MeterWorklet(this.#context, numberOfChannels)
     }
 
+    /** Creates the main {@link EngineWorklet} instance. */
     createEngine(project: Project, exportConfiguration?: ExportStemsConfiguration): EngineWorklet {
         return new EngineWorklet(this.#context, project, exportConfiguration)
     }
 
+    /**
+     * Creates a {@link RecordingWorklet} backed by a shared ring buffer.
+     */
     createRecording(numberOfChannels: int, numChunks: int, outputLatency: number): RecordingWorklet {
         const audioBytes = numberOfChannels * numChunks * RenderQuantum * Float32Array.BYTES_PER_ELEMENT
         const pointerBytes = Int32Array.BYTES_PER_ELEMENT * 2
@@ -39,3 +53,4 @@ export class Worklets {
         return new RecordingWorklet(this.#context, buffer, outputLatency)
     }
 }
+


### PR DESCRIPTION
## Summary
- document engine interfaces and worklet helpers
- add engine sequence diagrams and cross references

## Testing
- `npm run lint --workspace packages/studio/core`
- `npm test --workspace packages/studio/core` *(fails: Failed to resolve entry for package "@opendaw/lib-std" and "@opendaw/lib-xml")*


------
https://chatgpt.com/codex/tasks/task_b_68af2fdba5dc8321be82452e2873b9ca