### PR TITLE
docs: document dawproject serialization

### DIFF
--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -6,6 +6,11 @@ For a guided overview of the interface, see the [UI tour](../../docs/docs-user/u
 Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md). The [notepad feature](../../docs/docs-user/features/notepad.md) lets you store project notes using Markdown.
 Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
+Exchange projects with other DAWs via the `.dawproject` format using the
+[DAWproject workflow](../../docs/docs-user/workflows/dawproject.md). Implementation
+details for developers live in the
+[Studio serialization guide](../../docs/docs-dev/serialization/studio-dawproject.md).
+
 The project notepad uses markdown and can be customized. See the
 [markdown editing guide](../../docs/docs-dev/ui/markdown/editing.md) for
 developer details. For instructions on using the feature in the Studio,

--- a/packages/docs/docs-dev/serialization/studio-dawproject.md
+++ b/packages/docs/docs-dev/serialization/studio-dawproject.md
@@ -1,0 +1,15 @@
+# Studio DAWproject Serialization
+
+`DawProjectImport` and `DawProjectExporter` enable the Studio to exchange sessions
+with other applications via the `.dawproject` format. The importer rebuilds the
+box graph from `project.xml` and bundled resources, while the exporter walks the
+current project and emits the corresponding `ProjectSchema`, packaging samples
+and device presets along the way.
+
+- Import: `DawProject.decode` unwraps the archive and `DawProjectImport.read`
+  recreates the project skeleton.
+- Export: `DawProjectExporter.write` gathers tracks and writes files via
+  `DeviceIO` and the provided resource packer.
+
+Return to the [serialization overview](./overview.md) or see the
+[DAWproject mapping](./dawproject.md) for schema details.

--- a/packages/docs/docs-user/workflows/dawproject.md
+++ b/packages/docs/docs-user/workflows/dawproject.md
@@ -1,0 +1,13 @@
+# DAWproject Workflow
+
+openDAW Studio can exchange projects with other digital audio workstations
+through the `.dawproject` format.
+
+1. **Export a DAWproject file.** Choose *File → Export → DAWproject* to create an
+   archive containing the current session and all referenced audio files.
+2. **Import a DAWproject file.** Use *File → Import* and select a `.dawproject`
+   bundle to start a new session from it.
+3. **Edit and re-export.** Once imported, the project behaves like any other
+   openDAW session and can be saved or exported again at any time.
+
+For technical details see the [developer serialization guide](../../docs-dev/serialization/studio-dawproject.md).

--- a/packages/lib/dawproject/README.md
+++ b/packages/lib/dawproject/README.md
@@ -18,6 +18,7 @@ data format description, and additional examples.
 
 - [DAWproject parameter mapping](../../docs/docs-dev/serialization/dawproject.md)
 - [Serialization overview](../../docs/docs-dev/serialization/overview.md)
+ - [Studio DAWproject serialization](../../docs/docs-dev/serialization/studio-dawproject.md)
 
 ## Test fixtures
 

--- a/packages/studio/core/src/dawproject/AudioUnitExportLayout.ts
+++ b/packages/studio/core/src/dawproject/AudioUnitExportLayout.ts
@@ -3,12 +3,18 @@ import {ArrayMultimap, asInstanceOf, isDefined, isInstanceOf, Nullable, Option} 
 import {AudioUnitType} from "@opendaw/studio-enums"
 import {DeviceBoxUtils} from "@opendaw/studio-adapters"
 
+/**
+ * Utilities for arranging {@link AudioUnitBox} connections into tracks for
+ * export. The resulting structure reflects how audio flows between units.
+ */
 export namespace AudioUnitExportLayout {
+    /** Recursive track representation used during export. */
     export interface Track {
         audioUnit: AudioUnitBox
         children: Array<Track>
     }
 
+    /** Build a hierarchy of tracks from the current set of audio units. */
     export const layout = (audioUnits: ReadonlyArray<AudioUnitBox>): Array<Track> => {
         const feedsInto = new ArrayMultimap<AudioUnitBox, AudioUnitBox>()
         audioUnits.forEach(unit => {
@@ -57,6 +63,9 @@ export namespace AudioUnitExportLayout {
         return {audioUnit, children}
     }
 
+    /**
+     * Debug helper that logs the computed track hierarchy to the console.
+     */
     export const printTrackStructure = (tracks: ReadonlyArray<Track>, indent = 0): void => {
         const spaces = " ".repeat(indent)
         tracks.forEach(track => {

--- a/packages/studio/core/src/dawproject/BuiltinDevices.ts
+++ b/packages/studio/core/src/dawproject/BuiltinDevices.ts
@@ -5,7 +5,13 @@ import {ifDefined, int, UUID} from "@opendaw/lib-std"
 import {Pointers} from "@opendaw/studio-enums"
 import {semitoneToHz} from "@opendaw/lib-dsp"
 
+/**
+ * Helpers for constructing built-in device boxes from DAWproject schemas.
+ */
 export namespace BuiltinDevices {
+    /**
+     * Create a Revamp equalizer device from a DAWproject {@link EqualizerSchema}.
+     */
     export const equalizer = (boxGraph: BoxGraph,
                               equalizer: EqualizerSchema,
                               field: Field<Pointers.MidiEffectHost> | Field<Pointers.AudioEffectHost>,

--- a/packages/studio/core/src/dawproject/DawProject.ts
+++ b/packages/studio/core/src/dawproject/DawProject.ts
@@ -5,14 +5,27 @@ import {FileReferenceSchema, MetaDataSchema, ProjectSchema} from "@opendaw/lib-d
 import {Project} from "../Project"
 import {DawProjectExporter} from "./DawProjectExporter"
 
+/**
+ * Helpers for reading and writing `.dawproject` zip archives used by Studio.
+ *
+ * The namespace exposes {@link decode} for turning a buffer into its XML
+ * representation and {@link encode} for writing a {@link Project} back to the
+ * DAWproject format.
+ */
 export namespace DawProject {
+    /** Metadata describing a binary resource contained in the archive. */
     export type Resource = { uuid: UUID.Format, path: string, name: string, buffer: ArrayBuffer }
 
+    /** Random access to resources stored inside the project archive. */
     export interface ResourceProvider {
         fromPath(path: string): Resource
         fromUUID(uuid: UUID.Format): Resource
     }
 
+    /**
+     * Decode a DAWproject archive into its metadata, project XML and resource
+     * lookup helpers.
+     */
     export const decode = async (buffer: ArrayBuffer | NonSharedBuffer): Promise<{
         metaData: MetaDataSchema,
         project: ProjectSchema,
@@ -43,6 +56,10 @@ export namespace DawProject {
         }
     }
 
+    /**
+     * Encode the current {@link Project} and associated metadata into a
+     * `.dawproject` zip archive.
+     */
     export const encode = (project: Project, metaData: MetaDataSchema): Promise<ArrayBuffer> => {
         const zip = new JSZip()
         const projectSchema = DawProjectExporter.write(project, {

--- a/packages/studio/core/src/dawproject/DawProjectExporter.test.ts
+++ b/packages/studio/core/src/dawproject/DawProjectExporter.test.ts
@@ -10,6 +10,8 @@ import {FileReferenceSchema} from "@opendaw/lib-dawproject"
 import {DawProjectExporter} from "./DawProjectExporter"
 import {Peaks} from "@opendaw/lib-fusion"
 
+/** Verifies that a project can be exported to DAWproject format. */
+
 describe("DawProjectExport", () => {
     it("export", async () => {
         const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/packages/studio/core/src/dawproject/DawProjectExporter.ts
+++ b/packages/studio/core/src/dawproject/DawProjectExporter.ts
@@ -51,9 +51,17 @@ import {encodeWavFloat} from "../Wav"
 import {DeviceBoxUtils} from "@opendaw/studio-adapters"
 import {DeviceIO} from "./DeviceIO"
 
+/**
+ * Serializes the Studio project graph into the DAWproject XML schema.
+ */
 export namespace DawProjectExporter {
+    /** Callback used to store binary resources such as samples or presets. */
     export interface ResourcePacker {write(path: string, buffer: ArrayBufferLike): FileReferenceSchema}
 
+    /**
+     * Convert the given {@link Project} into a {@link ProjectSchema} and emit
+     * resources via the provided {@link ResourcePacker}.
+     */
     export const write = (project: Project, resourcePacker: ResourcePacker) => {
         const ids = new AddressIdEncoder()
         const {boxGraph, timelineBox, rootBox, sampleManager} = project

--- a/packages/studio/core/src/dawproject/DawProjectImport.test.ts
+++ b/packages/studio/core/src/dawproject/DawProjectImport.test.ts
@@ -5,6 +5,8 @@ import * as fs from "node:fs"
 import {DawProject} from "./DawProject"
 import {DawProjectImport} from "./DawProjectImport"
 
+/** Basic sanity checks for the DAWproject importer. */
+
 describe("DawProjectImport", () => {
     it("import", async () => {
         const __dirname = path.dirname(fileURLToPath(import.meta.url))

--- a/packages/studio/core/src/dawproject/DawProjectImport.ts
+++ b/packages/studio/core/src/dawproject/DawProjectImport.ts
@@ -72,6 +72,12 @@ import {ColorCodes} from "../ColorCodes"
 import {DeviceIO} from "./DeviceIO"
 import {BuiltinDevices} from "./BuiltinDevices"
 
+/**
+ * Maps DAWproject XML into the Studio's box graph representation.
+ *
+ * The importer resolves audio resources, recreates device chains and returns a
+ * {@link ProjectDecoder.Skeleton} ready for further processing.
+ */
 export namespace DawProjectImport {
     type AudioBusUnit = { audioBusBox: AudioBusBox, audioUnitBox: AudioUnitBox }
     type InstrumentUnit = { instrumentBox: InstrumentBox, audioUnitBox: AudioUnitBox }
@@ -83,6 +89,10 @@ export namespace DawProjectImport {
         ifDefined(timeSignature?.denominator, value => denominator.setValue(value))
     }
 
+    /**
+     * Outcome of {@link read}. Contains the reconstructed project skeleton and
+     * identifiers of audio files that must be loaded separately.
+     */
     export type Result = {
         audioIds: ReadonlyArray<UUID.Format>,
         skeleton: ProjectDecoder.Skeleton
@@ -93,6 +103,9 @@ export namespace DawProjectImport {
         if (contentType === "notes") return Option.wrap(CaptureMidiBox.create(boxGraph, UUID.generate()))
         return Option.None
     }
+    /**
+     * Rehydrate a project from a DAWproject schema and its resource provider.
+     */
     export const read = async (schema: ProjectSchema, resources: DawProject.ResourceProvider): Promise<Result> => {
         const boxGraph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create))
         boxGraph.beginTransaction()

--- a/packages/studio/core/src/dawproject/DeviceIO.ts
+++ b/packages/studio/core/src/dawproject/DeviceIO.ts
@@ -3,7 +3,13 @@ import {assert, ByteArrayInput, ByteArrayOutput, Option, panic, UUID} from "@ope
 import {AudioFileBox, BoxIO} from "@opendaw/studio-boxes"
 import {DeviceBox, DeviceBoxUtils} from "@opendaw/studio-adapters"
 
+/**
+ * Binary import/export helpers for {@link DeviceBox} instances.
+ */
 export namespace DeviceIO {
+    /**
+     * Serialize a device box and its dependencies into a compact binary format.
+     */
     export const exportDevice = (box: Box): ArrayBufferLike => {
         const dependencies = Array.from(box.graph.dependenciesOf(box).boxes)
 
@@ -23,6 +29,9 @@ export namespace DeviceIO {
         return output.toArrayBuffer()
     }
 
+    /**
+     * Deserialize a previously exported device into the given {@link BoxGraph}.
+     */
     export const importDevice = (boxGraph: BoxGraph<BoxIO.TypeMap>, buffer: ArrayBufferLike): DeviceBox => {
         const input = new ByteArrayInput(buffer)
         const header = input.readString()

--- a/packages/studio/core/src/dawproject/todo.md
+++ b/packages/studio/core/src/dawproject/todo.md
@@ -1,5 +1,7 @@
 # TODO
 
+Internal tracker for outstanding DAWproject import/export work.
+
 ## Bugs
 
 ### Importer


### PR DESCRIPTION
## Summary
- add developer docs for studio's DAWproject serialization
- add user workflow guide for DAWproject import/export
- document DawProject helper modules with TSDoc and link docs from READMEs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af2fde6eb483218a80f9d6394f4f83