### PR TITLE
docs: annotate note and pitch editors

### DIFF
--- a/packages/app/studio/src/ui/timeline/editors/notes/Constants.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/Constants.ts
@@ -1,2 +1,11 @@
+/**
+ * Constants shared by note editor components.
+ */
+/**
+ * Size of property control nodes in pixels.
+ */
 export const PropertyNodeSize = 4
+/**
+ * Radius of drawn note events in the pitch editor.
+ */
 export const EventRadius = 8

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteContentDurationModifier.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteContentDurationModifier.ts
@@ -1,3 +1,6 @@
+/**
+ * Modifier that adjusts the loop or content duration of a note region.
+ */
 import {int, Notifier, Observer, Option, Terminable} from "@opendaw/lib-std"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -8,6 +11,9 @@ import {ppqn} from "@opendaw/lib-dsp"
 import {UINoteEvent} from "./UINoteEvent"
 import {Dragging} from "@opendaw/lib-dom"
 
+/**
+ * Construction parameters for {@link NoteContentDurationModifier}.
+ */
 type Construct = Readonly<{
     element: Element
     snapping: Snapping
@@ -15,6 +21,9 @@ type Construct = Readonly<{
     reference: NoteEventOwnerReader
 }>
 
+/**
+ * Handles drag interactions that change the note region's loop length.
+ */
 export class NoteContentDurationModifier implements NoteModifier {
     static create(construct: Construct): NoteContentDurationModifier {
         return new NoteContentDurationModifier(construct)

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteCreateModifier.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteCreateModifier.ts
@@ -1,3 +1,6 @@
+/**
+ * Modifier used while dragging to create a new note event in the editor.
+ */
 import {Generators, int, Mutable, Notifier, Observer, Option, Selection, Terminable} from "@opendaw/lib-std"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -9,6 +12,9 @@ import {NoteEventOwnerReader} from "@/ui/timeline/editors/EventOwnerReader.ts"
 import {UINoteEvent} from "@/ui/timeline/editors/notes/UINoteEvent.ts"
 import {Dragging} from "@opendaw/lib-dom"
 
+/**
+ * Construction parameters for {@link NoteCreateModifier}.
+ */
 type Construct = Readonly<{
     element: Element
     snapping: Snapping
@@ -18,6 +24,9 @@ type Construct = Readonly<{
     reference: NoteEventOwnerReader
 }>
 
+/**
+ * Handles creation of a note while the user drags in the editor.
+ */
 export class NoteCreateModifier implements NoteModifier {
     static create(construct: Construct): NoteCreateModifier {
         return new NoteCreateModifier(construct)

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteDurationModifier.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteDurationModifier.ts
@@ -1,3 +1,6 @@
+/**
+ * Modifier that adjusts the duration of selected notes.
+ */
 import {int, Notifier, Observer, Option, Selection, Terminable, unitValue} from "@opendaw/lib-std"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -31,6 +34,9 @@ class SelectedModifyStrategy implements NoteModifyStrategy {
     }
 }
 
+/**
+ * Construction parameters for {@link NoteDurationModifier}.
+ */
 type Construct = Readonly<{
     element: Element
     selection: Selection<NoteEventBoxAdapter>
@@ -39,6 +45,9 @@ type Construct = Readonly<{
     reference: NoteEventBoxAdapter
 }>
 
+/**
+ * Handles stretching or shrinking note lengths during user interaction.
+ */
 export class NoteDurationModifier implements NoteModifier {
     static create(construct: Construct): NoteDurationModifier {
         return new NoteDurationModifier(construct)

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteEditor.sass
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteEditor.sass
@@ -1,3 +1,4 @@
+// Styles for the NoteEditor component combining pitch and property panels.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteEditor.tsx
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteEditor.tsx
@@ -1,3 +1,9 @@
+/**
+ * Top level editor for note events on the timeline.
+ *
+ * Combines pitch editing, property lanes and menu integration to provide a
+ * full featured piano roll style editing environment.
+ */
 import css from "./NoteEditor.sass?inline"
 import {Events, Html, Keyboard} from "@opendaw/lib-dom"
 import {DefaultObservableValue, int, Lifecycle, Procedure} from "@opendaw/lib-std"
@@ -25,6 +31,9 @@ import {createPitchMenu} from "@/ui/timeline/editors/notes/pitch/PitchMenu.ts"
 
 const className = Html.adoptStyleSheet(css, "NoteEditor")
 
+/**
+ * Arguments required to construct a {@link NoteEditor} instance.
+ */
 type Construct = {
     lifecycle: Lifecycle
     service: StudioService
@@ -34,6 +43,9 @@ type Construct = {
     reader: NoteEventOwnerReader
 }
 
+/**
+ * Renders the note editor and wires up pitch and property sub editors.
+ */
 export const NoteEditor =
     ({lifecycle, service, menu: {editMenu, viewMenu}, range, snapping, reader}: Construct) => {
         const {project} = service

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteModifier.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteModifier.ts
@@ -1,4 +1,10 @@
+/**
+ * Base interface implemented by all note editing modifiers.
+ */
 import {NoteModifyStrategies} from "@/ui/timeline/editors/notes/NoteModifyStrategies.ts"
 import {ObservableModifier} from "@/ui/timeline/ObservableModifier.ts"
 
+/**
+ * Combines {@link NoteModifyStrategies} with observable lifecycle hooks used by the editor.
+ */
 export interface NoteModifier extends NoteModifyStrategies, ObservableModifier {}

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteModifyStrategies.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteModifyStrategies.ts
@@ -1,12 +1,20 @@
+/**
+ * Shared strategy interfaces for note editing modifiers.
+ */
 import {EventCollection, ppqn} from "@opendaw/lib-dsp"
 import {Coordinates, int, Option, unitValue} from "@opendaw/lib-std"
 
 import {NoteEventOwnerReader} from "@/ui/timeline/editors/EventOwnerReader.ts"
 import {UINoteEvent} from "@/ui/timeline/editors/notes/UINoteEvent.ts"
 
+/** Represents a point in time/value space. */
 export type Point = Coordinates<number, unitValue> // time, value
+/** Represents a line used for property overlays. */
 export type Line = [Point, Point]
 
+/**
+ * Strategy collection describing how a modifier exposes its behaviour to the UI.
+ */
 export interface NoteModifyStrategies {
     showOrigin(): boolean
     showCreation(): Option<UINoteEvent>
@@ -27,6 +35,9 @@ export namespace NoteModifyStrategies {
     })
 }
 
+/**
+ * Strategy describing how to read note attributes when a modifier is active.
+ */
 export interface NoteModifyStrategy {
     readPosition(note: UINoteEvent): ppqn
     readComplete(note: UINoteEvent): ppqn

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteMoveModifier.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteMoveModifier.ts
@@ -1,3 +1,6 @@
+/**
+ * Modifier that moves notes across time and pitch, optionally copying them.
+ */
 import {clamp, int, Notifier, Observer, Option, Selection, Terminable, unitValue} from "@opendaw/lib-std"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -27,6 +30,9 @@ class SelectedModifyStrategy implements NoteModifyStrategy {
     }
 }
 
+/**
+ * Construction parameters for {@link NoteMoveModifier}.
+ */
 type Construct = Readonly<{
     element: Element
     selection: Selection<NoteEventBoxAdapter>
@@ -37,6 +43,9 @@ type Construct = Readonly<{
     reference: NoteEventBoxAdapter
 }>
 
+/**
+ * Handles moving or copying notes during drag operations.
+ */
 export class NoteMoveModifier implements NoteModifier {
     static create(construct: Construct): NoteMoveModifier {return new NoteMoveModifier(construct)}
 

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteUtils.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteUtils.ts
@@ -1,3 +1,6 @@
+/**
+ * Utility helpers for working with note data.
+ */
 import {NoteEventCollectionBoxAdapter} from "@opendaw/studio-adapters"
 import {Promises} from "@opendaw/lib-runtime"
 import {Files} from "@opendaw/lib-dom"
@@ -5,6 +8,9 @@ import {Channel, ControlEvent, ControlType, MidiFile, MidiTrack} from "@opendaw/
 import {ArrayMultimap, int} from "@opendaw/lib-std"
 import {EventCollection, EventSpan, NoteEvent, PPQN, ppqn} from "@opendaw/lib-dsp"
 
+/**
+ * Converts a note event collection into a MIDI track.
+ */
 const fromCollection = <E extends NoteEvent>(collection: EventCollection<E>): MidiTrack => {
     const events: Array<ControlEvent> = []
     const toTicks = (position: ppqn, timeDivision: int = 96): int => Math.floor(position / PPQN.Quarter * timeDivision)
@@ -15,6 +21,9 @@ const fromCollection = <E extends NoteEvent>(collection: EventCollection<E>): Mi
     return new MidiTrack(new ArrayMultimap<Channel, ControlEvent>([[0, events]], ControlEvent.Comparator), [])
 }
 
+/**
+ * Exports a collection of notes to a downloadable MIDI file.
+ */
 export const exportNotesToMidiFile = async (collection: NoteEventCollectionBoxAdapter, suggestedName: string) => {
     const encoder = MidiFile.encoder()
     encoder.addTrack(fromCollection(collection.events))

--- a/packages/app/studio/src/ui/timeline/editors/notes/NoteViewMenu.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/NoteViewMenu.ts
@@ -1,3 +1,6 @@
+/**
+ * View menu entries for the note editor.
+ */
 import {MenuCollector, MenuItem} from "@/ui/model/menu-item.ts"
 import {Procedure} from "@opendaw/lib-std"
 import {NoteEventBoxAdapter} from "@opendaw/studio-adapters"
@@ -14,6 +17,9 @@ const NoteSizes = {
     "Large": 17
 } as const
 
+/**
+ * Installs menu options that affect note appearance and zooming.
+ */
 export const installNoteViewMenu = (range: TimelineRange,
                                     owner: NoteEventOwnerReader,
                                     pitchPositioner: PitchPositioner,

--- a/packages/app/studio/src/ui/timeline/editors/notes/UINoteEvent.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/UINoteEvent.ts
@@ -1,3 +1,6 @@
+/**
+ * Note event representation used by the UI with extra metadata.
+ */
 import {NoteEvent, ppqn} from "@opendaw/lib-dsp"
 import {int} from "@opendaw/lib-std"
 

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchContextMenu.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchContextMenu.ts
@@ -1,3 +1,6 @@
+/**
+ * Handles context menu installation for pitch editor canvases.
+ */
 import {ContextMenu} from "@/ui/ContextMenu.ts"
 import {ElementCapturing} from "@/ui/canvas/capturing.ts"
 import {Editing} from "@opendaw/lib-box"
@@ -8,6 +11,7 @@ import {createPitchMenu} from "@/ui/timeline/editors/notes/pitch/PitchMenu.ts"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {EventCollection} from "@opendaw/lib-dsp"
 
+/** Parameters for {@link installContextMenu}. */
 type Construct = {
     element: Element
     capturing: ElementCapturing<PitchCaptureTarget>
@@ -17,6 +21,9 @@ type Construct = {
     events: EventCollection<NoteEventBoxAdapter>
 }
 
+/**
+ * Subscribes a context menu to the pitch editor element.
+ */
 export const installContextMenu = ({element, capturing, snapping, editing, selection, events}: Construct) =>
     ContextMenu.subscribe(element, (collector: ContextMenu.Collector) => {
         const target = capturing.captureEvent(collector.client)

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditor.sass
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditor.sass
@@ -1,3 +1,4 @@
+// Styles for the PitchEditor canvas component.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditor.tsx
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditor.tsx
@@ -1,3 +1,6 @@
+/**
+ * Canvas based editor for visualising and manipulating note pitches.
+ */
 import css from "./PitchEditor.sass?inline"
 import {Lifecycle, Nullable, Option, panic, Selection, UUID} from "@opendaw/lib-std"
 import {createElement} from "@opendaw/lib-jsx"
@@ -37,6 +40,9 @@ const CursorMap = {
     "loop-duration": "ew-resize"
 } satisfies Record<PitchCaptureTarget["type"], CssUtils.Cursor>
 
+/**
+ * Arguments required to create a {@link PitchEditor}.
+ */
 type Construct = {
     lifecycle: Lifecycle
     graph: BoxGraph
@@ -52,6 +58,9 @@ type Construct = {
     reader: NoteEventOwnerReader
 }
 
+/**
+ * Renders the pitch editor component and installs all interaction handlers.
+ */
 export const PitchEditor =
     ({
          lifecycle,

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditorHeader.sass
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditorHeader.sass
@@ -1,3 +1,4 @@
+// Styling for the PitchEditorHeader component.
 @use "@/colors"
 
 component

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditorHeader.tsx
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEditorHeader.tsx
@@ -1,3 +1,6 @@
+/**
+ * Header component for the pitch editor containing scale selection and tools.
+ */
 import css from "./PitchEditorHeader.sass?inline"
 import {int, Lifecycle, Selection} from "@opendaw/lib-std"
 import {ScaleSelector} from "@/ui/timeline/editors/notes/pitch/ScaleSelector.tsx"
@@ -19,6 +22,9 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "PitchEditorHeader")
 
+/**
+ * Arguments accepted by {@link PitchEditorHeader}.
+ */
 type Construct = {
     lifecycle: Lifecycle
     editing: Editing
@@ -27,6 +33,9 @@ type Construct = {
     scale: ScaleConfig
 }
 
+/**
+ * Renders scale related controls and property tools above the pitch editor.
+ */
 export const PitchEditorHeader = ({lifecycle, editing, modifyContext, selection, scale}: Construct) => {
     return (
         <div className={className}>

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEventCapturing.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchEventCapturing.ts
@@ -1,3 +1,6 @@
+/**
+ * Utilities for capturing pitch editor mouse events and mapping them to notes.
+ */
 import {ElementCapturing} from "@/ui/canvas/capturing.ts"
 import {isDefined, Nullable} from "@opendaw/lib-std"
 import {PointerRadiusDistance} from "@/ui/timeline/constants.ts"
@@ -7,11 +10,17 @@ import {NoteEventBoxAdapter} from "@opendaw/studio-adapters"
 
 import {NoteEventOwnerReader} from "@/ui/timeline/editors/EventOwnerReader.ts"
 
+/**
+ * Result of mapping a pointer location to a note editing handle.
+ */
 export type PitchCaptureTarget =
     | { type: "note-end", event: NoteEventBoxAdapter }
     | { type: "note-position", event: NoteEventBoxAdapter }
     | { type: "loop-duration", reader: NoteEventOwnerReader }
 
+/**
+ * Creates an {@link ElementCapturing} instance for the pitch editor canvas.
+ */
 export const createPitchEventCapturing = (element: Element,
                                           positioner: PitchPositioner,
                                           range: TimelineRange,

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchMenu.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchMenu.ts
@@ -1,3 +1,6 @@
+/**
+ * Context menu entries for pitch editing operations.
+ */
 import {Editing} from "@opendaw/lib-box"
 import {Snapping} from "@/ui/timeline/Snapping.ts"
 import {Procedure, Selection} from "@opendaw/lib-std"
@@ -5,6 +8,9 @@ import {NoteEventBoxAdapter} from "@opendaw/studio-adapters"
 import {EventCollection} from "@opendaw/lib-dsp"
 import {MenuCollector, MenuItem} from "@/ui/model/menu-item.ts"
 
+/**
+ * Builds the menu items used by the pitch editor's edit menu.
+ */
 export const createPitchMenu = (editing: Editing,
                                 snapping: Snapping,
                                 selection: Selection<NoteEventBoxAdapter>,

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchPainter.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchPainter.ts
@@ -1,3 +1,6 @@
+/**
+ * Painter responsible for rendering pitch editor content onto a canvas.
+ */
 import {int, linear, Option, Procedure} from "@opendaw/lib-std"
 import {CanvasPainter} from "@/ui/canvas/painter.ts"
 import {PitchPositioner} from "@/ui/timeline/editors/notes/pitch/PitchPositioner.ts"
@@ -11,6 +14,9 @@ import {renderTimeGrid} from "@/ui/timeline/editors/TimeGridRenderer.ts"
 import {NoteModifier} from "@/ui/timeline/editors/notes/NoteModifier.ts"
 import {NoteEventOwnerReader} from "@/ui/timeline/editors/EventOwnerReader.ts"
 
+/**
+ * Construction parameters for {@link createNotePitchPainter}.
+ */
 type Construct = {
     canvas: HTMLCanvasElement,
     positioner: PitchPositioner,
@@ -21,6 +27,9 @@ type Construct = {
     reader: NoteEventOwnerReader
 }
 
+/**
+ * Factory for a painter that draws notes, scales and guides for the pitch editor.
+ */
 export const createNotePitchPainter =
     ({canvas, positioner, scale, range, snapping, modifyContext, reader}: Construct): Procedure<CanvasPainter> =>
         painter => {

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchPositioner.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchPositioner.ts
@@ -1,6 +1,12 @@
+/**
+ * Maintains mapping between MIDI note numbers and vertical canvas coordinates.
+ */
 import {clamp, int, Notifier, Observer, Subscription, Terminable, Terminator, ValueAxis} from "@opendaw/lib-std"
 import {ScrollModel} from "@/ui/components/ScrollModel.ts"
 
+/**
+ * Scroll-aware converter between notes and Y positions.
+ */
 export class PitchPositioner implements Terminable {
     readonly #numNotes: int = 128
     readonly #terminator: Terminator = new Terminator()

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchSelectionLocator.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/PitchSelectionLocator.ts
@@ -1,3 +1,6 @@
+/**
+ * Locates note events within the pitch editor for selection purposes.
+ */
 import {TimelineRange} from "@/ui/timeline/TimelineRange.ts"
 import {ElementCapturing} from "@/ui/canvas/capturing.ts"
 import {TimelineCoordinates, TimelineSelectableLocator} from "@/ui/timeline/TimelineSelectableLocator.ts"
@@ -7,6 +10,9 @@ import {PitchCaptureTarget} from "@/ui/timeline/editors/notes/pitch/PitchEventCa
 
 import {NoteEventOwnerReader} from "@/ui/timeline/editors/EventOwnerReader.ts"
 
+/**
+ * Factory for a selection locator that works with the pitch editor.
+ */
 export const createPitchSelectionLocator = (owner: NoteEventOwnerReader,
                                             range: TimelineRange,
                                             valueAxis: ValueAxis,

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfig.ts
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfig.ts
@@ -1,6 +1,12 @@
+/**
+ * Observable model representing the currently active musical scale.
+ */
 import {MidiKeys} from "@opendaw/lib-dsp"
 import {byte, int, JSONValue, Notifier, Observer, Subscription, Terminable} from "@opendaw/lib-std"
 
+/**
+ * Mutable scale representation with subscription support.
+ */
 export class ScaleConfig implements MidiKeys.Scale, Terminable {
     static readonly EMPTY = 0b111111111111
 

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfigurator.sass
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfigurator.sass
@@ -1,3 +1,4 @@
+// Styles for the ScaleConfigurator toggle grid.
 component
   height: 1.5em
   display: flex

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfigurator.tsx
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleConfigurator.tsx
@@ -1,3 +1,6 @@
+/**
+ * Bitmask based configuration panel for enabling notes in a scale.
+ */
 import css from "./ScaleConfigurator.sass?inline"
 import {Arrays, int, Lifecycle} from "@opendaw/lib-std"
 import {createElement} from "@opendaw/lib-jsx"
@@ -6,11 +9,15 @@ import {Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "ScaleConfigurator")
 
+/** Parameters for {@link ScaleConfigurator}. */
 type Construct = {
     lifecycle: Lifecycle
     scale: ScaleConfig
 }
 
+/**
+ * Renders a 12-tone toggle grid allowing fine grained scale definition.
+ */
 export const ScaleConfigurator = ({lifecycle, scale}: Construct) => {
     const buttons: ReadonlyArray<HTMLDivElement> = Arrays.create((index: int) => (
         <div onclick={() => scale.toggle(index)}/>

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleSelector.sass
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleSelector.sass
@@ -1,3 +1,4 @@
+// Styles for the ScaleSelector component.
 component
   display: flex
   align-items: center

--- a/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleSelector.tsx
+++ b/packages/app/studio/src/ui/timeline/editors/notes/pitch/ScaleSelector.tsx
@@ -1,3 +1,6 @@
+/**
+ * UI component for selecting the musical key/scale.
+ */
 import css from "./ScaleSelector.sass?inline"
 import {Arrays, Lifecycle} from "@opendaw/lib-std"
 import {MenuButton} from "@/ui/components/MenuButton.tsx"
@@ -10,11 +13,17 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "ScaleSelector")
 
+/**
+ * Parameters for {@link ScaleSelector}.
+ */
 type Construct = {
     lifecycle: Lifecycle
     scale: ScaleConfig
 }
 
+/**
+ * Dropdown menu allowing users to pick the root key for the scale.
+ */
 export const ScaleSelector = ({lifecycle, scale}: Construct) => {
     const labels = MidiKeys.Names.English
     const labelName = Inject.value(labels[scale.key])

--- a/packages/docs/docs-dev/ui/timeline/note-editor.md
+++ b/packages/docs/docs-dev/ui/timeline/note-editor.md
@@ -1,0 +1,18 @@
+# Note Editor
+
+Coordinates pitch and property views to edit MIDI notes.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant NoteEditor
+    participant PitchEditor
+    participant PropertyEditor
+    User->>NoteEditor: interact
+    NoteEditor->>PitchEditor: update pitch view
+    NoteEditor->>PropertyEditor: update property lanes
+```
+
+- **NoteEditor** wires pitch and property editors with selection and menus.
+- **PitchEditor** displays notes on a piano roll grid.
+- **PropertyEditor** shows velocity and other controllers.

--- a/packages/docs/docs-dev/ui/timeline/pitch-editor.md
+++ b/packages/docs/docs-dev/ui/timeline/pitch-editor.md
@@ -1,0 +1,16 @@
+# Pitch Editor
+
+Canvas driven interface for manipulating note pitch and timing.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant PitchEditor
+    participant Painter
+    User->>PitchEditor: drag note
+    PitchEditor->>Painter: request redraw
+    Painter-->>PitchEditor: render notes
+```
+
+- **PitchEditor** handles event capturing and selection.
+- **Painter** draws notes, scales and guides to the canvas.

--- a/packages/docs/docs-dev/ui/timeline/property-editor.md
+++ b/packages/docs/docs-dev/ui/timeline/property-editor.md
@@ -1,0 +1,16 @@
+# Property Editor
+
+Displays and edits per-note properties such as velocity or modulation.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant PropertyEditor
+    participant ModifyContext
+    User->>PropertyEditor: drag property node
+    PropertyEditor->>ModifyContext: apply modifier
+    ModifyContext-->>PropertyEditor: emit update
+```
+
+- **PropertyEditor** hosts draggable property nodes for the selection.
+- **ModifyContext** manages undoable changes while editing.

--- a/packages/docs/docs-user/features/piano-roll.md
+++ b/packages/docs/docs-user/features/piano-roll.md
@@ -26,5 +26,8 @@ See the [Beat Making workflow](../workflows/beat.md) for a practical example.
 More technical details are available in the developer docs:
 [Overview](../../docs-dev/ui/piano-roll/overview.md),
 [Visualizers](../../docs-dev/ui/piano-roll/visualizers.md),
-[Metronome](../../docs-dev/ui/piano-roll/metronome.md) and
-[FAQ](../../docs-dev/ui/piano-roll/faq.md).
+[Metronome](../../docs-dev/ui/piano-roll/metronome.md),
+[FAQ](../../docs-dev/ui/piano-roll/faq.md),
+[Note Editor](../../docs-dev/ui/timeline/note-editor.md),
+[Pitch Editor](../../docs-dev/ui/timeline/pitch-editor.md) and
+[Property Editor](../../docs-dev/ui/timeline/property-editor.md).


### PR DESCRIPTION
## Summary
- add TSDoc across note editor, modifiers and pitch modules
- document note, pitch and property editors with sequence diagrams
- link new editor docs from piano roll user guide

## Testing
- `npm test`
- `npm run lint` *(fails: workspace @opendaw/lib-midi lint command failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af2fd4a4e08321b4747bb85bf95038