### PR TITLE
docs: add audio routing docs and TSDoc

### DIFF
--- a/packages/docs/docs-dev/architecture/audio-devices.md
+++ b/packages/docs/docs-dev/architecture/audio-devices.md
@@ -1,0 +1,11 @@
+# Audio devices
+
+The studio interacts with audio hardware through the Web Audio API.  Microphone
+access is requested on demand and the list of available inputs is cached for
+later selection.  Streams can be opened with custom constraints to target a
+specific device or channel configuration.
+
+The `AudioDevices` helper centralizes permission handling and device
+enumeration.  It exposes convenience methods to request user approval and to
+refresh the list of inputs when hardware changes are detected.
+

--- a/packages/docs/docs-user/features/mixer.md
+++ b/packages/docs/docs-user/features/mixer.md
@@ -9,6 +9,12 @@ pan, mute and solo. Insert slots let you add effects, and send knobs make it
 easy to route the signal elsewhere. Adjusting a strip's fader changes the level
 that continues to the next stage in the mix.
 
+### Muting and soloing
+
+Use the **mute** button to silence a track without removing it from the mix.
+Toggling **solo** isolates one or more tracks while temporarily muting the rest
+so you can focus on specific parts of the arrangement.
+
 ## Sends and returns
 
 Sends on each channel allow a portion of the signal to be routed to return
@@ -48,3 +54,4 @@ graph LR
 ```
 
 For a practical example see the [Mixing workflow](../workflows/mixing.md).
+

--- a/packages/studio/core/README.md
+++ b/packages/studio/core/README.md
@@ -21,3 +21,13 @@ Further architectural details are covered in the documentation:
 - [Architecture overview](../../docs/docs-dev/architecture/overview.md)
 - [Audio path and scheduler](../../docs/docs-dev/architecture/audio-path.md)
 
+### Routing diagram
+
+```mermaid
+graph LR
+    I[Instrument] -->|audio| B[Bus]
+    B -->|audio| M[Master]
+    I -- send --> R[Return]
+    R --> M
+```
+

--- a/packages/studio/core/src/AudioDevices.ts
+++ b/packages/studio/core/src/AudioDevices.ts
@@ -2,7 +2,17 @@ import {Promises} from "@opendaw/lib-runtime"
 import {Arrays, isInstanceOf, warn} from "@opendaw/lib-std"
 import {ConstrainDOM} from "@opendaw/lib-dom"
 
+/**
+ * Utility for working with microphone hardware.
+ *
+ * The class exposes convenience methods to request user permissions,
+ * enumerate available inputs and open streams with custom constraints.
+ */
 export class AudioDevices {
+    /**
+     * Requests access to the microphone and updates the internal list of
+     * available input devices.
+     */
     static async requestPermission() {
         const {status, value: stream} =
             await Promises.tryCatch(navigator.mediaDevices.getUserMedia({audio: true}))
@@ -11,6 +21,11 @@ export class AudioDevices {
         await this.updateInputList()
     }
 
+    /**
+     * Retrieves a {@link MediaStream} that matches the provided constraints.
+     *
+     * @param constraints - Desired media track configuration.
+     */
     static async requestStream(constraints: MediaTrackConstraints): Promise<MediaStream> {
         const {status, value: stream, error} =
             await Promises.tryCatch(navigator.mediaDevices.getUserMedia({audio: constraints}))
@@ -24,6 +39,9 @@ export class AudioDevices {
         return stream
     }
 
+    /**
+     * Refreshes the cached list of available audio input devices.
+     */
     static async updateInputList() {
         this.#inputs = Arrays.empty()
         const {status, value: devices} = await Promises.tryCatch(navigator.mediaDevices.enumerateDevices())
@@ -36,5 +54,8 @@ export class AudioDevices {
 
     static #inputs: ReadonlyArray<MediaDeviceInfo> = Arrays.empty()
 
+    /**
+     * Returns the most recently enumerated list of audio inputs.
+     */
     static get inputs(): ReadonlyArray<MediaDeviceInfo> {return this.#inputs}
 }

--- a/packages/studio/core/src/AudioUnitOrdering.ts
+++ b/packages/studio/core/src/AudioUnitOrdering.ts
@@ -1,9 +1,14 @@
 import {int} from "@opendaw/lib-std"
 import {AudioUnitType} from "@opendaw/studio-enums"
 
+/**
+ * Defines the sort order for different audio unit types.
+ * Lower numbers appear earlier when channel strips are arranged.
+ */
 export const AudioUnitOrdering: Record<string, int> = {
     [AudioUnitType.Instrument]: 0,
     [AudioUnitType.Aux]: 1,
     [AudioUnitType.Bus]: 2,
     [AudioUnitType.Output]: 3
 } as const
+

--- a/packages/studio/core/src/ColorCodes.ts
+++ b/packages/studio/core/src/ColorCodes.ts
@@ -2,7 +2,13 @@ import {AudioUnitType} from "@opendaw/studio-enums"
 import {TrackType} from "@opendaw/studio-adapters"
 import {Colors} from "./Colors"
 
+/**
+ * Helpers for resolving themed colors based on domain types.
+ */
 export namespace ColorCodes {
+    /**
+     * Returns a theme color string for the given audio unit type.
+     */
     export const forAudioType = (type?: AudioUnitType): string => {
         switch (type) {
             case AudioUnitType.Output:
@@ -18,6 +24,9 @@ export namespace ColorCodes {
         }
     }
 
+    /**
+     * Returns a hue value for representing track types.
+     */
     export const forTrackType = (type?: TrackType): number => {
         switch (type) {
             case TrackType.Audio:
@@ -31,3 +40,4 @@ export namespace ColorCodes {
         }
     }
 }
+

--- a/packages/studio/core/src/Colors.ts
+++ b/packages/studio/core/src/Colors.ts
@@ -1,4 +1,8 @@
 const computedStyle = getComputedStyle(document.documentElement)
+
+/**
+ * Application color palette resolved from CSS variables.
+ */
 export const Colors = {
     blue: computedStyle.getPropertyValue("--color-blue"),
     green: computedStyle.getPropertyValue("--color-green"),
@@ -13,3 +17,4 @@ export const Colors = {
     shadow: computedStyle.getPropertyValue("--color-shadow"),
     black: computedStyle.getPropertyValue("--color-black")
 }
+

--- a/packages/studio/core/src/EffectFactories.ts
+++ b/packages/studio/core/src/EffectFactories.ts
@@ -17,7 +17,11 @@ import {
 import {IconSymbol} from "@opendaw/studio-adapters"
 import {EffectFactory} from "./EffectFactory"
 
+/**
+ * Built-in collection of effect factory definitions.
+ */
 export namespace EffectFactories {
+    /** Factory for the arpeggiator MIDI effect. */
     export const Arpeggio: EffectFactory = {
         defaultName: "Arpeggio",
         defaultIcon: IconSymbol.Stack,
@@ -31,6 +35,7 @@ export namespace EffectFactories {
         })
     }
 
+    /** Factory for simple pitch shifting of MIDI notes. */
     export const Pitch: EffectFactory = {
         defaultName: "Pitch",
         defaultIcon: IconSymbol.Note,
@@ -44,6 +49,7 @@ export namespace EffectFactories {
         })
     }
 
+    /** Factory for the Zeitgeist timing effect. */
     export const Zeitgeist: EffectFactory = {
         defaultName: "Zeitgeist",
         defaultIcon: IconSymbol.Zeitgeist,
@@ -67,6 +73,7 @@ export namespace EffectFactories {
         }
     }
 
+    /** Factory for stereo manipulation utilities. */
     export const StereoTool: EffectFactory = {
         defaultName: "Stereo Tool",
         defaultIcon: IconSymbol.Stereo,
@@ -81,6 +88,7 @@ export namespace EffectFactories {
             })
     }
 
+    /** Factory for a classic delay audio effect. */
     export const Delay: EffectFactory = {
         defaultName: "Delay",
         defaultIcon: IconSymbol.Time,
@@ -95,6 +103,7 @@ export namespace EffectFactories {
             })
     }
 
+    /** Factory for a reverb effect. */
     export const Reverb: EffectFactory = {
         defaultName: "Reverb",
         defaultIcon: IconSymbol.Cube,
@@ -110,6 +119,7 @@ export namespace EffectFactories {
             })
     }
 
+    /** Factory for the Revamp equalizer. */
     export const Revamp: EffectFactory = {
         defaultName: "Revamp",
         defaultIcon: IconSymbol.EQ,
@@ -144,6 +154,7 @@ export namespace EffectFactories {
             })
     }
 
+    /** Factory placeholder for user-created modular effects. */
     export const Modular: EffectFactory = {
         defaultName: "🔇 Create New Modular Audio Effect (inaudible yet)",
         defaultIcon: IconSymbol.Box,

--- a/packages/studio/core/src/EffectFactory.ts
+++ b/packages/studio/core/src/EffectFactory.ts
@@ -4,12 +4,29 @@ import {int} from "@opendaw/lib-std"
 import {Project} from "./Project"
 import {EffectBox} from "./EffectBox"
 
+/**
+ * Describes a factory capable of constructing an {@link EffectBox} and its
+ * associated metadata used in menus and lists.
+ */
 export interface EffectFactory {
+    /** Default human readable name. */
     get defaultName(): string
+    /** Icon symbol used in the UI. */
     get defaultIcon(): IconSymbol
+    /** Short description of the effect. */
     get description(): string
+    /** Whether a separator should precede the effect in menus. */
     get separatorBefore(): boolean
+    /** Indicates if the effect operates on audio or MIDI data. */
     get type(): "audio" | "midi"
 
+    /**
+     * Creates the effect's box and attaches it to the project.
+     *
+     * @param project - Project context for creating boxes.
+     * @param unit - Field referencing the host audio unit.
+     * @param index - Insert index within the unit's effect chain.
+     */
     create(project: Project, unit: Field<EffectPointerType>, index: int): EffectBox
 }
+

--- a/packages/studio/core/src/InstrumentOptions.ts
+++ b/packages/studio/core/src/InstrumentOptions.ts
@@ -1,4 +1,15 @@
 import {IconSymbol} from "@opendaw/studio-adapters"
 import {int} from "@opendaw/lib-std"
 
-export type InstrumentOptions = { name?: string, icon?: IconSymbol, index?: int }
+/**
+ * Optional parameters used when creating instrument instances.
+ */
+export type InstrumentOptions = {
+    /** User facing name for the instrument. */
+    name?: string,
+    /** Icon representing the instrument in the UI. */
+    icon?: IconSymbol,
+    /** Index determining the instrument's placement in lists. */
+    index?: int
+}
+

--- a/packages/studio/core/src/Mixer.ts
+++ b/packages/studio/core/src/Mixer.ts
@@ -5,7 +5,13 @@ import {AudioUnitBoxAdapter, IndexedBoxAdapterCollection} from "@opendaw/studio-
 import {DeferExec, deferNextFrame} from "@opendaw/lib-dom"
 import {Box} from "@opendaw/lib-box"
 
+/**
+ * View interface for channel strips that react to solo or mute changes.
+ */
 export interface ChannelStripView {
+    /**
+     * Toggles visual silence state of the channel strip.
+     */
     silent(value: boolean): void
 }
 
@@ -15,6 +21,9 @@ interface ChannelStripState {
     subscription: Subscription
 }
 
+/**
+ * Coordinates mute and solo state across a collection of audio units.
+ */
 export class Mixer implements Terminable {
     readonly #terminator: Terminator = new Terminator()
     readonly #states: SortedSet<UUID.Format, ChannelStripState>
@@ -61,6 +70,13 @@ export class Mixer implements Terminable {
         }))
     }
 
+    /**
+     * Registers a {@link ChannelStripView} for the given adapter.
+     *
+     * @param uuid - Adapter identifier used to attach the view.
+     * @param view - View instance to update when mixer state changes.
+     * @returns Terminable handle to remove the view.
+     */
     registerChannelStrip({uuid}: AudioUnitBoxAdapter, view: ChannelStripView): Terminable {
         this.#states.get(uuid).views.push(view)
         this.#deferUpdate.request()
@@ -70,6 +86,7 @@ export class Mixer implements Terminable {
         })
     }
 
+    /** Cleans up all resources used by the mixer. */
     terminate(): void {this.#terminator.terminate()}
 
     #updateStates(): void {

--- a/packages/studio/core/src/ProjectMigration.ts
+++ b/packages/studio/core/src/ProjectMigration.ts
@@ -13,7 +13,13 @@ import {asDefined, asInstanceOf, UUID} from "@opendaw/lib-std"
 import {AudioUnitType} from "@opendaw/studio-enums"
 import {Capture} from "./capture/Capture"
 
+/**
+ * Utility that upgrades project graphs to the current schema.
+ */
 export class ProjectMigration {
+    /**
+     * Applies all available migrations to the provided project skeleton.
+     */
     static migrate({boxGraph, mandatoryBoxes}: ProjectDecoder.Skeleton): void {
         const {rootBox} = mandatoryBoxes
         if (rootBox.groove.targetAddress.isEmpty()) {
@@ -83,3 +89,4 @@ export class ProjectMigration {
         }))
     }
 }
+


### PR DESCRIPTION
## Summary
- document device management and mixer routing
- add TSDoc across core audio utilities
- expand mixer user guide

## Testing
- `npm test`
- `npm run lint` *(fails: command sh -c eslint "**/*.ts" exited (1) in @opendaw/lib-midi)*

------
https://chatgpt.com/codex/tasks/task_b_68af2fd90360832197b41e4e5b63845a