### PR TITLE
feat: document spotlight search

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 and to **resurface the process of making music** by making **high-quality** creation tools accessible to everyone, with
 a strong focus on **education** and data-privacy. Please consider supporting this project on [Patreon](https://www.patreon.com/join/openDAW) or [ko-fi](https://ko-fi.com/opendaw).
 
+The Studio features a Spotlight command palette (<kbd>Shift</kbd>+<kbd>Enter</kbd>) for quickly running actions by name.
+
 <p align="center">
 <img src="https://raw.githubusercontent.com/andremichelle/openDAW/refs/heads/main/assets/studio-teaser.png"/>
 </p>
@@ -120,6 +122,8 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
 - [Icon Library](packages/docs/docs-dev/ui/icons/overview.md)
 - [Notepad Guide](packages/docs/docs-user/features/notepad.md)
+- [Spotlight Developer Docs](packages/docs/docs-dev/ui/spotlight/overview.md)
+- [Search Feature](packages/docs/docs-user/features/search.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -6,6 +6,8 @@ For a guided overview of the interface, see the [UI tour](../../docs/docs-user/u
 Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md). The [notepad feature](../../docs/docs-user/features/notepad.md) lets you store project notes using Markdown.
 Developer details about project storage and sessions can be found in the [projects documentation](../../docs/docs-dev/projects/overview.md).
 
+Quickly launch commands using the Spotlight search palette with <kbd>Shift</kbd>+<kbd>Enter</kbd>. Read the [user guide](../../docs/docs-user/features/search.md) or see the [developer docs](../../docs/docs-dev/ui/spotlight/overview.md).
+
 The project notepad uses markdown and can be customized. See the
 [markdown editing guide](../../docs/docs-dev/ui/markdown/editing.md) for
 developer details. For instructions on using the feature in the Studio,

--- a/packages/app/studio/src/main.ts
+++ b/packages/app/studio/src/main.ts
@@ -93,6 +93,7 @@ requestAnimationFrame(async () => {
                         } else if (event.defaultPrevented) {return}
                     }),
                     ContextMenu.install(surface.owner),
+                    // Install Spotlight command palette
                     Spotlight.install(surface, service)
                 )
             }

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -118,6 +118,7 @@ export class StudioService implements ProjectEnv {
     readonly menu = initAppMenu(this)
     readonly sessionService = new SessionService(this)
     readonly panelLayout = new PanelContents(createPanelFactory(this))
+    /** Supplies searchable actions for the Spotlight command palette. */
     readonly spotlightDataSupplier = new SpotlightDataSupplier()
     readonly samplePlayback: SamplePlayback
     // noinspection JSUnusedGlobalSymbols
@@ -215,6 +216,7 @@ export class StudioService implements ProjectEnv {
             })
         }
 
+        // Register initial spotlight actions
         this.spotlightDataSupplier.registerAction("Create Synth", EmptyExec)
         this.spotlightDataSupplier.registerAction("Create Drumcomputer", EmptyExec)
         this.spotlightDataSupplier.registerAction("Create ModularSystem", EmptyExec)

--- a/packages/app/studio/src/ui/components/SearchInput.tsx
+++ b/packages/app/studio/src/ui/components/SearchInput.tsx
@@ -1,3 +1,10 @@
+/**
+ * Reusable search input element.
+ *
+ * The component exposes its current value through a
+ * {@link MutableObservableValue} and is used by features such as the
+ * Spotlight command palette.
+ */
 import {Html} from "@opendaw/lib-dom"
 import css from "./SearchInput.sass?inline"
 import {Lifecycle, MutableObservableValue} from "@opendaw/lib-std"
@@ -5,13 +12,26 @@ import {createElement} from "@opendaw/lib-jsx"
 
 const className = Html.adoptStyleSheet(css, "SearchInput")
 
+/** Props for {@link SearchInput}. */
 type Construct = {
+    /** Lifecycle owner managing event subscriptions. */
     lifecycle: Lifecycle
+    /** Two-way bound model representing the input text. */
     model: MutableObservableValue<string>
+    /** Optional placeholder shown when the field is empty. */
     placeholder?: string
+    /** Additional inline CSS styles. */
     style?: Partial<CSSStyleDeclaration>
 }
 
+/**
+ * Renders a search box bound to a mutable observable value.
+ *
+ * @param lifecycle manages the input's subscriptions
+ * @param model holds the current search query
+ * @param placeholder optional placeholder text
+ * @param style optional inline styles
+ */
 export const SearchInput = ({lifecycle, model, placeholder, style}: Construct) => {
     const input: HTMLInputElement = (
         <input type="search"

--- a/packages/app/studio/src/ui/spotlight/Spotlight.sass
+++ b/packages/app/studio/src/ui/spotlight/Spotlight.sass
@@ -26,14 +26,14 @@ component
       height: 1.25rem
       justify-self: center
 
-    > input
+    > .SearchInput
       color: inherit
       font-size: inherit
       font-weight: inherit
       font-family: inherit
-      appearance: none
-      border: none
       background: none
+      border: none
+      box-shadow: none
       padding: 0
       outline: none
       width: 100%

--- a/packages/app/studio/src/ui/spotlight/SpotlightDataSupplier.ts
+++ b/packages/app/studio/src/ui/spotlight/SpotlightDataSupplier.ts
@@ -1,3 +1,6 @@
+/**
+ * Provides prefix-based action search for the Spotlight command palette.
+ */
 import { Arrays, assert, Exec } from "@opendaw/lib-std";
 
 import { IconSymbol } from "@opendaw/studio-adapters";

--- a/packages/docs/docs-dev/ui/spotlight/faq.md
+++ b/packages/docs/docs-dev/ui/spotlight/faq.md
@@ -1,0 +1,11 @@
+# Spotlight FAQ
+
+**How do I add new commands?**
+
+Use `StudioService.spotlightDataSupplier.registerAction(name, exec)` to
+expose a callable action. Names are matched case-insensitively by prefix.
+
+**Can I customize the search algorithm?**
+
+`SpotlightDataSupplier` is intentionally simple. Replace it with a
+custom implementation if you need fuzzy matching or additional metadata.

--- a/packages/docs/docs-dev/ui/spotlight/overview.md
+++ b/packages/docs/docs-dev/ui/spotlight/overview.md
@@ -1,0 +1,11 @@
+# Spotlight
+
+Lightweight command palette overlay that lets developers expose actions by name.
+Uses the `SearchInput` component for query entry and displays matching actions
+in a draggable flyout.
+
+## Features
+
+- Global shortcut <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>F</kbd>
+- Prefix matching via `SpotlightDataSupplier`
+- Draggable positioning on the main `Surface`

--- a/packages/docs/docs-dev/ui/spotlight/usage.md
+++ b/packages/docs/docs-dev/ui/spotlight/usage.md
@@ -1,0 +1,17 @@
+# Spotlight Usage
+
+Install the overlay and register actions during application startup:
+
+```ts
+import { Spotlight } from "@/ui/spotlight/Spotlight.tsx";
+
+// inside bootstrap
+Spotlight.install(surface, service);
+
+service.spotlightDataSupplier.registerAction("Create Synth", () => {
+  /* ... */
+});
+```
+
+`SpotlightDataSupplier` performs simple prefix matching; extend it or register
+additional providers for richer results.

--- a/packages/docs/docs-user/features/search.md
+++ b/packages/docs/docs-user/features/search.md
@@ -1,0 +1,15 @@
+# Search
+
+Use the Spotlight search to quickly find commands and items in the Studio.
+
+## Open the palette
+
+Press <kbd>Shift</kbd>+<kbd>Enter</kbd> or <kbd>Ctrl/Cmd</kbd>+<kbd>F</kbd> to
+bring up the Spotlight box.
+
+## Run a command
+
+1. Start typing to filter available actions.
+2. Press <kbd>Enter</kbd> to execute the first result.
+
+The palette can be dragged by its header to reposition it on screen.

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -145,6 +145,15 @@ module.exports = {
             "ui/files/drag-and-drop",
           ],
         },
+        {
+          type: "category",
+          label: "Spotlight",
+          items: [
+            "ui/spotlight/overview",
+            "ui/spotlight/usage",
+            "ui/spotlight/faq",
+          ],
+        },
       ],
     },
     {

--- a/packages/docs/sidebarsUser.js
+++ b/packages/docs/sidebarsUser.js
@@ -17,6 +17,7 @@ module.exports = {
         "features/file-management",
         "features/browse",
         "features/notepad",
+        "features/search",
       ],
     },
   ],


### PR DESCRIPTION
## Summary
- integrate Spotlight with reusable SearchInput component and document behavior
- describe Spotlight search in README and user docs
- add developer docs covering Spotlight overlay

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/lib-midi#lint ESLint command)*

------
https://chatgpt.com/codex/tasks/task_b_68af2fe05cc8832195d80c259c0c87c1