### PR TITLE
Document color system and annotate style tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 
 ### Style Documentation
 
+The Studio relies on a central colour system described by the following
+resources:
+
 - [Style Guidelines](styles/OpenDAW/style-guidelines.md)
 - [Developer Style Guide](packages/docs/docs-dev/style-guide.md)
 - [Design Tokens](packages/docs/docs-dev/style/design-tokens.md)

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -1,6 +1,9 @@
 # OpenDAW Studio
 
 This package contains the web-based user interface for the OpenDAW project.
+It uses a central colour system defined in
+[`src/colors.sass`](src/colors.sass) and exposed through the
+[design tokens](../../docs/docs-dev/style/design-tokens.md).
 
 For a guided overview of the interface, see the [UI tour](../../docs/docs-user/ui-tour.md).
 Guidance on saving and importing projects lives in the [file management guide](../../docs/docs-user/features/file-management.md). The [notepad feature](../../docs/docs-user/features/notepad.md) lets you store project notes using Markdown.

--- a/packages/app/studio/src/colors.sass
+++ b/packages/app/studio/src/colors.sass
@@ -1,4 +1,8 @@
-// Color palette variables; see styles/OpenDAW/style-guidelines.md
+// Color palette variables shared across the Studio application.
+//
+// The tokens below are referenced by `Colors.ts` and `ColorCodes.ts` to provide
+// strongly typed access in TypeScript. See `styles/OpenDAW/style-guidelines.md`
+// for naming conventions and guidance on introducing new entries.
 \:root
   color-scheme: dark
   --color-blue: hsl(189, 100%, 65%) // Accent blue used for links and active states
@@ -41,3 +45,4 @@ $DARKENER: rgba(black, 0.04) // Overlay to slightly decrease brightness
   background-image: linear-gradient(45deg, var(--panel-background-bright) 25%, var(--panel-background) 25%, var(--panel-background) 50%, var(--panel-background-bright) 50%, var(--panel-background-bright) 75%, var(--panel-background) 75%, var(--panel-background) 100%)
   background-size: 5.66px 5.66px
   background-color: var(--panel-background-bright)
+

--- a/packages/app/studio/src/main.sass
+++ b/packages/app/studio/src/main.sass
@@ -1,7 +1,8 @@
 @use "@/colors"
 @use "@/mixins"
 
-// Global styles follow styles/OpenDAW/style-guidelines.md
+// Global styles follow styles/OpenDAW/style-guidelines.md and consume the
+// design tokens defined in `colors.sass`.
 
 html, body
   font-size: 16px

--- a/packages/app/studio/src/mixins.sass
+++ b/packages/app/studio/src/mixins.sass
@@ -1,4 +1,5 @@
-// Shared mixins follow styles/OpenDAW/style-guidelines.md
+// Shared mixins follow styles/OpenDAW/style-guidelines.md and may reference
+// variables defined in `colors.sass` for consistent theming.
 @use "@/colors"
 
 @mixin width-available

--- a/packages/app/studio/src/ui/components/Button.sass
+++ b/packages/app/studio/src/ui/components/Button.sass
@@ -1,3 +1,4 @@
+// Generic button component using design tokens from `colors.sass`.
 component
   // Base styling for generic buttons
   --color: var(--color-shadow) // Default button colour

--- a/packages/app/studio/src/ui/components/Icon.sass
+++ b/packages/app/studio/src/ui/components/Icon.sass
@@ -1,5 +1,9 @@
+// Base styles for the `Icon` component.  Sizing is kept square so that SVG
+// symbols scale predictably. See `styles/OpenDAW/style-guidelines.md` for
+// naming conventions.
 component
   width: 1em
   height: 1em
   min-width: 1em
   min-height: 1em
+

--- a/packages/app/studio/src/ui/components/Icon.tsx
+++ b/packages/app/studio/src/ui/components/Icon.tsx
@@ -4,8 +4,16 @@ import {createElement} from "@opendaw/lib-jsx"
 import {IconSymbol} from "@opendaw/studio-adapters"
 import {Html} from "@opendaw/lib-dom"
 
+// Attach the component styles and capture the generated class name.
 const defaultClassName = Html.adoptStyleSheet(css, "Icon")
 
+/**
+ * Stateless SVG icon component.
+ *
+ * The `symbol` prop references an `<svg><symbol/></svg>` definition and is
+ * rendered using the `<use>` element. Additional classes or style overrides can
+ * be supplied via `className` and `style`.
+ */
 export const Icon = ({symbol, className, style}: {
     symbol: IconSymbol,
     className?: string,
@@ -16,6 +24,10 @@ export const Icon = ({symbol, className, style}: {
     </svg>
 )
 
+/**
+ * Cartridge variant that updates the `<use>` element when the provided
+ * `ObservableValue` changes.
+ */
 export const IconCartridge = ({lifecycle, symbol, className, style}: {
     lifecycle: Lifecycle,
     symbol: ObservableValue<IconSymbol>,
@@ -23,8 +35,8 @@ export const IconCartridge = ({lifecycle, symbol, className, style}: {
     style?: Partial<CSSStyleDeclaration>
 }) => {
     const use: SVGUseElement = <use href=""/>
-    const updater = () => use.href.baseVal = `#${IconSymbol.toName(symbol.getValue())}`
+    const updater = () => (use.href.baseVal = `#${IconSymbol.toName(symbol.getValue())}`)
     updater()
     lifecycle.own(symbol.subscribe(updater))
-    return (<svg classList={Html.buildClassList(defaultClassName, className)} style={style}>{use}</svg>)
+    return <svg classList={Html.buildClassList(defaultClassName, className)} style={style}>{use}</svg>
 }

--- a/packages/docs/docs-dev/style/design-tokens.md
+++ b/packages/docs/docs-dev/style/design-tokens.md
@@ -1,6 +1,10 @@
 # Design Tokens
 
-These tokens define the visual language for the studio. Values are implemented in [`colors.sass`](../../../app/studio/src/colors.sass).
+Design tokens provide a single source of truth for colours and layout metrics
+used throughout the Studio. The CSS custom properties live in
+[`colors.sass`](../../../app/studio/src/colors.sass) and are surfaced to
+TypeScript via [`Colors.ts`](../../../studio/core/src/Colors.ts) and
+[`ColorCodes.ts`](../../../studio/core/src/ColorCodes.ts).
 
 ## Colors
 

--- a/packages/docs/docs-user/style-customization.md
+++ b/packages/docs/docs-user/style-customization.md
@@ -2,7 +2,10 @@
 
 openDAW's appearance can be adjusted by overriding the CSS variables defined in
 [`colors.sass`](../../../packages/app/studio/src/colors.sass). Variables and
-class names use kebab-case such as `--color-green` or `.help-section`.
+class names use kebab-case such as `--color-green` or `.help-section`. The
+TypeScript layer reads these values through
+[`Colors.ts`](../../studio/core/src/Colors.ts), so any changes cascade through
+all components.
 
 
 The default UI uses the **Rubik** and **Open Sans** typefaces from [`packages/app/studio/public/fonts`](../../../packages/app/studio/public/fonts). These fonts are provided under the [SIL Open Font License 1.1](https://scripts.sil.org/OFL). Replace these files or override the CSS `font-family` to customize text appearance.
@@ -11,7 +14,13 @@ To create a custom theme:
 
 1. Fork or clone the repository.
 2. Edit the desired variables in `colors.sass` or provide your own stylesheet
-   that overrides them.
+   that overrides them. For example, to adjust the primary accent colour:
+
+   ```css
+   :root {
+     --color-blue: hsl(210, 100%, 60%);
+   }
+   ```
 3. Rebuild the app to apply your changes.
 
 For more details see the [developer style guide](../docs-dev/style-guide.md) and

--- a/packages/studio/core/src/ColorCodes.ts
+++ b/packages/studio/core/src/ColorCodes.ts
@@ -2,32 +2,55 @@ import {AudioUnitType} from "@opendaw/studio-enums"
 import {TrackType} from "@opendaw/studio-adapters"
 import {Colors} from "./Colors"
 
+/**
+ * Utility helpers for resolving colour tokens based on domain specific enums.
+ *
+ * These functions keep the mapping of `AudioUnitType` and `TrackType` values to
+ * their corresponding design tokens in one place, mirroring the palette defined
+ * in `colors.sass`.
+ */
 export namespace ColorCodes {
+    /**
+     * Returns a colour token suitable for the given audio unit type.
+     */
     export const forAudioType = (type?: AudioUnitType): string => {
         switch (type) {
             case AudioUnitType.Output:
+                // Output units are highlighted with blue accents
                 return Colors.blue
             case AudioUnitType.Aux:
+                // Auxiliary units use the decorative purple accent
                 return Colors.purple
             case AudioUnitType.Bus:
+                // Busses adopt the secondary orange accent
                 return Colors.orange
             case AudioUnitType.Instrument:
+                // Instruments are shown with the green success colour
                 return Colors.green
             default:
+                // Fallback colour for unknown types
                 return Colors.dark
         }
     }
 
+    /**
+     * Numeric hue value used for track backgrounds based on track type.
+     */
     export const forTrackType = (type?: TrackType): number => {
         switch (type) {
             case TrackType.Audio:
+                // Audio tracks use a blue-ish hue
                 return 200
             case TrackType.Notes:
+                // Note tracks have a green-ish hue
                 return 45
             case TrackType.Value:
+                // Automation/value tracks default to a purple-ish hue
                 return 156
             default:
+                // No tint for unknown track types
                 return 0
         }
     }
 }
+

--- a/packages/studio/core/src/Colors.ts
+++ b/packages/studio/core/src/Colors.ts
@@ -1,15 +1,36 @@
+/**
+ * Convenience wrapper around the global CSS design tokens.
+ *
+ * Values are defined in the Studio's `colors.sass` palette and documented in
+ * `styles/OpenDAW/style-guidelines.md`. Importing this map allows components to
+ * access pre-resolved color values without repeatedly querying the DOM.
+ */
 const computedStyle = getComputedStyle(document.documentElement)
+
 export const Colors = {
+    // Accent blue used for links and active states
     blue: computedStyle.getPropertyValue("--color-blue"),
+    // Confirmation and success highlight
     green: computedStyle.getPropertyValue("--color-green"),
+    // Warning and caution tone
     yellow: computedStyle.getPropertyValue("--color-yellow"),
+    // Neutral cream for subtle surfaces
     cream: computedStyle.getPropertyValue("--color-cream"),
+    // Secondary accent orange
     orange: computedStyle.getPropertyValue("--color-orange"),
+    // Error and destructive action color
     red: computedStyle.getPropertyValue("--color-red"),
+    // Decorative purple accent
     purple: computedStyle.getPropertyValue("--color-purple"),
+    // Brightest text color
     bright: computedStyle.getPropertyValue("--color-bright"),
+    // Default interface text color
     gray: computedStyle.getPropertyValue("--color-gray"),
+    // Muted text or disabled elements
     dark: computedStyle.getPropertyValue("--color-dark"),
+    // Shadow and border color
     shadow: computedStyle.getPropertyValue("--color-shadow"),
-    black: computedStyle.getPropertyValue("--color-black")
+    // Deepest shadow tone
+    black: computedStyle.getPropertyValue("--color-black"),
 }
+

--- a/styles/OpenDAW/style-guidelines.md
+++ b/styles/OpenDAW/style-guidelines.md
@@ -10,6 +10,16 @@ This document outlines the conventions used for CSS and Sass across the project.
 - Panel backgrounds are available via `--panel-background`, `--panel-background-bright`, and `--panel-background-dark`.
 - Group related variables together and document new entries when introduced.
 
+### Color System
+
+The studio's colour palette is defined in `colors.sass` and surfaced to
+TypeScript via `Colors.ts` and `ColorCodes.ts`. When adding new colour tokens:
+
+- Use descriptive names and document their intent in `colors.sass`.
+- Update `Colors.ts` so components can access the resolved value.
+- If the colour maps to a specific domain concept (e.g. an audio unit type),
+  extend `ColorCodes.ts` accordingly.
+
 ## Naming
 
 - Class names, mixins, and variables use kebab-case (`.help-section`, `@mixin width-available`).


### PR DESCRIPTION
## Summary
- comment and document color design tokens via Colors.ts, ColorCodes.ts, and SASS sources
- expand style guidelines and docs with centralized color system references
- mention color system in repository and Studio READMEs

## Testing
- `npm test` *(fails: run failed: command exited (1))*

------
https://chatgpt.com/codex/tasks/task_b_68af2fe5133083219df406b87b1a006e