### PR TITLE
docs: add parameter adapter docs and TSDoc

### DIFF
--- a/packages/docs/docs-dev/extending/parameter-adapters.md
+++ b/packages/docs/docs-dev/extending/parameter-adapters.md
@@ -1,0 +1,35 @@
+# Parameter adapters
+
+Parameter adapters bridge primitive fields from boxes to the automation and
+modulation system. Each adapter wraps a field and exposes it as a parameter with
+value mapping, string formatting and control source subscriptions.
+
+## Creating parameters
+
+Adapters are collected in a `ParameterAdapterSet`. Modules and other boxes use
+this set to register their controls:
+
+```ts
+const params = new ParameterAdapterSet(ctx)
+params.createParameter(
+  box.gain,
+  ValueMapping.DefaultDecibel,
+  StringMapping.numeric({ unit: "db" }),
+  "Gain"
+)
+```
+
+The returned `AutomatableParameterFieldAdapter` handles automation playback and
+can listen for MIDI or modulation sources.
+
+## Lookup and registration
+
+Every adapter registers itself with `ParameterFieldAdapters`, allowing other
+components to look up parameters by their `Address`. This enables UI elements to
+resolve the correct parameter even when modules are dynamically created.
+
+Further reading:
+
+- [`AutomatableParameterFieldAdapter`](../../../studio/adapters/src/AutomatableParameterFieldAdapter.ts)
+- [`ParameterAdapterSet`](../../../studio/adapters/src/ParameterAdapterSet.ts)
+- [`ParameterFieldAdapters`](../../../studio/adapters/src/ParameterFieldAdapters.ts)

--- a/packages/docs/docs-dev/ui/devices/overview.md
+++ b/packages/docs/docs-dev/ui/devices/overview.md
@@ -8,4 +8,5 @@ specialised topics below.
 * [Device panel](./panel.md) – how editors are mounted and reordered.
 * [Effects](./effects.md) – implementation details for audio and midi effects.
 * [Instruments](./instruments.md) – instrument specific editors and helpers.
+* [Parameter adapters](../../extending/parameter-adapters.md) – exposing device controls to automation.
 

--- a/packages/docs/docs-user/features/devices-and-plugins.md
+++ b/packages/docs/docs-user/features/devices-and-plugins.md
@@ -23,6 +23,8 @@ OpenDAW loads plugins built with the project's SDK or other compatible Web Audio
 
 Interested in building your own plugins? Check out the [plugin guide](../../docs-dev/extending/plugin-guide.md) in the developer documentation.
 
+For how device controls are connected to automation, see the [parameter adapter guide](../../docs-dev/extending/parameter-adapters.md).
+
 ## Modular workflow
 
 Devices can be arranged as modules on a canvas and linked with wires for

--- a/packages/studio/adapters/src/AutomatableParameterFieldAdapter.ts
+++ b/packages/studio/adapters/src/AutomatableParameterFieldAdapter.ts
@@ -213,6 +213,7 @@ export class AutomatableParameterFieldAdapter<T extends PrimitiveValues = any>
   get address(): Address {
     return this.#field.address;
   }
+  /** Track that contains the field, if assigned. */
   get track(): Option<TrackBoxAdapter> {
     return this.#trackBoxAdapter;
   }

--- a/packages/studio/adapters/src/BoxAdaptersContext.ts
+++ b/packages/studio/adapters/src/BoxAdaptersContext.ts
@@ -8,6 +8,11 @@ import {ParameterFieldAdapters} from "./ParameterFieldAdapters"
 import {BoxAdapters} from "./BoxAdapters"
 import {SampleManager} from "./sample/SampleManager"
 
+/**
+ * Shared services and utilities available to all box adapters. Implementations
+ * provide access to the current graph, streaming interfaces and factories
+ * needed when constructing adapter instances.
+ */
 export interface BoxAdaptersContext extends Terminable {
     get boxGraph(): BoxGraph
     get boxAdapters(): BoxAdapters

--- a/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
+++ b/packages/studio/adapters/src/IndexedBoxAdapterCollection.ts
@@ -93,6 +93,7 @@ export class IndexedBoxAdapterCollection<A extends IndexedBoxAdapter, P extends 
 
     getAdapterById(uuid: UUID.Format): Option<A> {return this.#entries.opt(uuid).map(({adapter}) => adapter)}
 
+    /** Returns the smallest free index that can be assigned to an adapter. */
     getMinFreeIndex(): int {
         const adapters = this.adapters()
         for (let index = 0; index < adapters.length; index++) {
@@ -116,6 +117,10 @@ export class IndexedBoxAdapterCollection<A extends IndexedBoxAdapter, P extends 
         this.moveIndex(adapter.indexField.getValue(), delta)
     }
 
+    /**
+     * Moves an adapter starting at {@link startIndex} by {@link delta} steps and
+     * updates indices of affected neighbours.
+     */
     moveIndex(startIndex: int, delta: int): void {
         const adapters = this.adapters()
         const adapter = adapters[startIndex]

--- a/packages/studio/adapters/src/ParameterAdapterSet.ts
+++ b/packages/studio/adapters/src/ParameterAdapterSet.ts
@@ -4,6 +4,11 @@ import {AutomatableParameterFieldAdapter} from "./AutomatableParameterFieldAdapt
 
 import {BoxAdaptersContext} from "./BoxAdaptersContext"
 
+/**
+ * Maintains the set of {@link AutomatableParameterFieldAdapter} instances that
+ * belong to a box.  The set is keyed by the field indices of each parameter
+ * allowing fast lookups for automation and UI code.
+ */
 export class ParameterAdapterSet implements Terminable {
     readonly #context: BoxAdaptersContext
     readonly #parameters: SortedSet<FieldKeys, AutomatableParameterFieldAdapter>
@@ -13,17 +18,26 @@ export class ParameterAdapterSet implements Terminable {
         this.#parameters = new SortedSet(adapter => adapter.address.fieldKeys, NumberArrayComparator)
     }
 
+    /** Terminates and removes all registered parameter adapters. */
     terminate(): void {
         this.#parameters.forEach(parameter => parameter.terminate())
         this.#parameters.clear()
     }
 
+    /** Returns all registered parameter adapters. */
     parameters(): ReadonlyArray<AutomatableParameterFieldAdapter> {return this.#parameters.values()}
+
+    /** Looks up the adapter at the given field indices. */
     parameterAt(fieldIndices: FieldKeys): AutomatableParameterFieldAdapter {
         return this.#parameters.getOrThrow(fieldIndices,
             () => new Error(`No ParameterAdapter found at [${fieldIndices}]`))
     }
 
+    /**
+     * Creates and registers a new parameter adapter for the given field.
+     *
+     * @returns the newly created adapter
+     */
     createParameter<T extends PrimitiveValues>(
         field: PrimitiveField<T, PointerTypes>,
         valueMapping: ValueMapping<T>,
@@ -36,6 +50,7 @@ export class ParameterAdapterSet implements Terminable {
         return adapter
     }
 
+    /** Removes the parameter from the set without terminating it. */
     removeParameter<T extends PrimitiveValues>(parameter: AutomatableParameterFieldAdapter<T>): void {
         this.#parameters.removeByValue(parameter)
     }

--- a/packages/studio/adapters/src/ParameterFieldAdapters.ts
+++ b/packages/studio/adapters/src/ParameterFieldAdapters.ts
@@ -2,6 +2,11 @@ import {Option, SortedSet, Terminable} from "@opendaw/lib-std"
 import {Address} from "@opendaw/lib-box"
 import {AutomatableParameterFieldAdapter} from "./AutomatableParameterFieldAdapter"
 
+/**
+ * Indexes all {@link AutomatableParameterFieldAdapter} instances by their
+ * {@link Address}.  This allows other components to register parameters and
+ * look them up efficiently when automating or rendering user interfaces.
+ */
 export class ParameterFieldAdapters {
     readonly #set: SortedSet<Address, AutomatableParameterFieldAdapter>
 
@@ -9,11 +14,19 @@ export class ParameterFieldAdapters {
         this.#set = Address.newSet<AutomatableParameterFieldAdapter>(adapter => adapter.field.address)
     }
 
+    /**
+     * Adds an adapter to the collection.
+     *
+     * @returns handle that removes the adapter on termination
+     */
     register(adapter: AutomatableParameterFieldAdapter): Terminable {
         this.#set.add(adapter)
         return {terminate: () => this.#set.removeByValue(adapter)}
     }
 
+    /** Retrieves the adapter associated with the given address. */
     get(address: Address): AutomatableParameterFieldAdapter {return this.#set.get(address)}
+
+    /** Returns the adapter if present. */
     opt(address: Address): Option<AutomatableParameterFieldAdapter> {return this.#set.opt(address)}
 }

--- a/packages/studio/adapters/src/modular/abstract.ts
+++ b/packages/studio/adapters/src/modular/abstract.ts
@@ -8,6 +8,11 @@ import {ParameterAdapterSet} from "../ParameterAdapterSet"
 import {Direction, ModuleConnectorAdapter} from "./connector"
 import {ModularAdapter} from "./modular"
 
+/**
+ * Base implementation for concrete {@link ModuleAdapter} classes. It wires the
+ * underlying module box into the adapter context and provides common
+ * functionality such as parameter management and selection handling.
+ */
 export abstract class AbstractModuleAdapter<BOX extends Box & {
     attributes: ModuleAttributes
 }> implements ModuleAdapter {
@@ -36,11 +41,19 @@ export abstract class AbstractModuleAdapter<BOX extends Box & {
         throw new Error("Method not implemented.")
     }
 
+    /** Registers a {@link Terminable} to be disposed with this adapter. */
     own<T extends Terminable>(terminable: T): T {return this.#terminator.own(terminable)}
+
+    /** Convenience variant of {@link own} for multiple terminables. */
     ownAll<T extends Terminable>(...terminables: ReadonlyArray<T>) {this.#terminator.ownAll(...terminables)}
 
+    /** Marks the module as selected by the user. */
     onSelected(): void {this.#selected = true}
+
+    /** Marks the module as deselected. */
     onDeselected(): void {this.#selected = false}
+
+    /** Whether the module is currently selected. */
     isSelected(): boolean {return this.#selected}
 
     get box(): Box<PointerTypes, any> {return this.#box}

--- a/packages/studio/adapters/src/modular/module.ts
+++ b/packages/studio/adapters/src/modular/module.ts
@@ -20,6 +20,11 @@ import {BoxAdapters} from "../BoxAdapters"
 import {ModuleMultiplierAdapter} from "./modules/multiplier"
 import {ModularAudioInputAdapter} from "./modules/audio-input"
 
+/**
+ * Common interface implemented by adapters for all modular synth modules.
+ * Module adapters expose their parameters and connectors so the UI and routing
+ * system can interact with them in a uniform way.
+ */
 export interface ModuleAdapter extends BoxAdapter, Selectable {
     get attributes(): ModuleAttributes
     get parameters(): ParameterAdapterSet
@@ -28,7 +33,9 @@ export interface ModuleAdapter extends BoxAdapter, Selectable {
     get outputs(): ReadonlyArray<ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Output>>
 }
 
+/** Helper functions for working with {@link ModuleAdapter} instances. */
 export namespace Modules {
+    /** Determines if the given vertex belongs to a module box. */
     export const isVertexOfModule = (vertex: Vertex): boolean => vertex.box.accept<BoxVisitor<true>>({
         visitModuleGainBox: (): true => true,
         visitModuleDelayBox: (): true => true,
@@ -37,6 +44,10 @@ export namespace Modules {
         visitModularAudioOutputBox: (): true => true
     }) ?? false
 
+    /**
+     * Retrieves the adapter for the given module box from a collection of
+     * {@link BoxAdapters}.
+     */
     export const adapterFor = (adapters: BoxAdapters, box: Box): ModuleAdapter => asDefined(box.accept<BoxVisitor<ModuleAdapter>>({
         visitModuleGainBox: (box: ModuleGainBox): ModuleAdapter => adapters.adapterFor(box, ModuleGainAdapter),
         visitModuleDelayBox: (box: ModuleDelayBox): ModuleAdapter => adapters.adapterFor(box, ModuleDelayAdapter),

--- a/packages/studio/adapters/src/modular/modules/delay.ts
+++ b/packages/studio/adapters/src/modular/modules/delay.ts
@@ -7,6 +7,7 @@ import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldA
 import {Direction, ModuleConnectorAdapter} from "../connector"
 import {BoxAdaptersContext} from "../../BoxAdaptersContext"
 
+/** Adapter for the built-in delay module. */
 export class ModuleDelayAdapter extends AbstractModuleAdapter<ModuleDelayBox> implements ModuleAdapter {
     readonly #parameterTime: AutomatableParameterFieldAdapter<number>
     readonly #voltageInput: ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input>
@@ -23,8 +24,11 @@ export class ModuleDelayAdapter extends AbstractModuleAdapter<ModuleDelayBox> im
         this.#voltageOutput = ModuleConnectorAdapter.create(context.boxAdapters, box.voltageOutput, Direction.Output, "Output")
     }
 
+    /** Time parameter expressed in milliseconds. */
     get parameterTime(): AutomatableParameterFieldAdapter<number> {return this.#parameterTime}
+    /** Incoming voltage connection. */
     get voltageInput(): ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input> {return this.#voltageInput}
+    /** Outgoing voltage connection. */
     get voltageOutput(): ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Output> {return this.#voltageOutput}
 
     get inputs(): ReadonlyArray<ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input>> {

--- a/packages/studio/adapters/src/modular/modules/gain.ts
+++ b/packages/studio/adapters/src/modular/modules/gain.ts
@@ -7,6 +7,7 @@ import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldA
 import {Direction, ModuleConnectorAdapter} from "../connector"
 import {BoxAdaptersContext} from "../../BoxAdaptersContext"
 
+/** Adapter for the gain module. */
 export class ModuleGainAdapter extends AbstractModuleAdapter<ModuleGainBox> implements ModuleAdapter {
     readonly #parameterGain: AutomatableParameterFieldAdapter<number>
     readonly #voltageInput: ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input>
@@ -23,8 +24,11 @@ export class ModuleGainAdapter extends AbstractModuleAdapter<ModuleGainBox> impl
         this.#voltageOutput = ModuleConnectorAdapter.create(context.boxAdapters, box.voltageOutput, Direction.Output, "Output")
     }
 
+    /** Gain parameter measured in decibels. */
     get parameterGain(): AutomatableParameterFieldAdapter<number> {return this.#parameterGain}
+    /** Incoming voltage connection. */
     get voltageInput(): ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input> {return this.#voltageInput}
+    /** Outgoing voltage connection. */
     get voltageOutput(): ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Output> {return this.#voltageOutput}
 
     get inputs(): ReadonlyArray<ModuleConnectorAdapter<Pointers.VoltageConnection, Direction.Input>> {

--- a/packages/studio/adapters/src/modular/user-interface.ts
+++ b/packages/studio/adapters/src/modular/user-interface.ts
@@ -5,11 +5,16 @@ import {BoxAdapter} from "../BoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../AutomatableParameterFieldAdapter"
 import {BoxAdaptersContext} from "../BoxAdaptersContext"
 
+/**
+ * Adapter for elements that appear in a device's user interface. Each element
+ * knows the module it belongs to and the parameter it controls.
+ */
 export interface DeviceInterfaceElementAdapter extends BoxAdapter {
     get moduleAdapter(): ModuleAdapter
     get parameterAdapter(): AutomatableParameterFieldAdapter
 }
 
+/** Connects a {@link DeviceInterfaceKnobBox} to its module and parameter. */
 export class DeviceInterfaceKnobAdapter implements DeviceInterfaceElementAdapter {
     readonly #context: BoxAdaptersContext
     readonly #box: DeviceInterfaceKnobBox
@@ -23,10 +28,12 @@ export class DeviceInterfaceKnobAdapter implements DeviceInterfaceElementAdapter
     get uuid(): Readonly<Uint8Array> {return this.#box.address.uuid}
     get address(): Address {return this.#box.address}
 
+    /** Adapter of the module that owns this UI element. */
     get moduleAdapter(): ModuleAdapter {
         return Modules.adapterFor(this.#context.boxAdapters, this.#parameterTarget.box)
     }
 
+    /** Adapter of the parameter controlled by the UI element. */
     get parameterAdapter(): AutomatableParameterFieldAdapter {
         return this.moduleAdapter.parameters.parameterAt(this.#parameterTarget.address.fieldKeys)
     }


### PR DESCRIPTION
## Summary
- add developer guide for parameter adapters
- document adapter utilities with TSDoc
- link parameter adapter docs from device and user guides

## Testing
- `npm test` *(fails: TS6053 File '/workspace/openDAW/packages/studio/boxes/src/VaporisateurDeviceBox.ts' not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af2fe9fe888321b72babfb3333deb5