### PR TITLE
docs: document device box adapters

### DIFF
--- a/packages/docs/docs-dev/extending/device-boxes.md
+++ b/packages/docs/docs-dev/extending/device-boxes.md
@@ -1,0 +1,15 @@
+# Device Boxes
+
+Device boxes describe the state and parameters of instruments, effects and other
+processors. Each box is wrapped by a matching adapter that maps fields to
+TypeScript APIs and audio worklet processors.
+
+## Creating a device box
+
+1. Define a box schema with fields for parameters and routing.
+2. Implement a DeviceBoxAdapter that wraps the box and exposes parameters with
+   `ParameterAdapterSet`.
+3. Register the adapter so the Studio can instantiate your device.
+
+Existing adapters in `@opendaw/studio-adapters` provide concrete examples for
+both instruments and effects.

--- a/packages/docs/docs-user/features/devices-and-plugins.md
+++ b/packages/docs/docs-user/features/devices-and-plugins.md
@@ -21,7 +21,7 @@ OpenDAW loads plugins built with the project's SDK or other compatible Web Audio
 - Traditional desktop formats like VST or Audio Unit may require additional support and are not guaranteed to work.
 - Different plugins may expose unique parameters; test them in your environment to confirm full compatibility.
 
-Interested in building your own plugins? Check out the [plugin guide](../../docs-dev/extending/plugin-guide.md) in the developer documentation.
+Interested in building your own plugins? Check out the [plugin guide](../../docs-dev/extending/plugin-guide.md) and the [device boxes guide](../../docs-dev/extending/device-boxes.md) in the developer documentation.
 
 ## Modular workflow
 

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -119,6 +119,7 @@ module.exports = {
         { type: "doc", id: "extending/plugin-guide" },
         { type: "doc", id: "extending/plugin-api" },
         { type: "doc", id: "extending/plugin-examples" },
+        { type: "doc", id: "extending/device-boxes" },
         { type: "doc", id: "extending/testing-plugins" },
         { type: "doc", id: "extending/processor-guide" },
       ],

--- a/packages/studio/adapters/README.md
+++ b/packages/studio/adapters/README.md
@@ -59,3 +59,8 @@ These patterns allow the studio to share behaviour across many different parts
 of the application while keeping the underlying data structures immutable and
 serialisable.
 
+## Device boxes
+
+Instrument, effect and groove adapters expose strongly-typed device boxes. To
+create custom devices or extend existing ones, see the [device boxes guide](../docs/docs-dev/extending/device-boxes.md) in the developer documentation.
+

--- a/packages/studio/adapters/src/devices/audio-effects/DelayDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/audio-effects/DelayDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {BoxAdaptersContext} from "../../BoxAdaptersContext"
 import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 
+/** Adapter for the built-in delay audio effect. */
 export class DelayDeviceBoxAdapter implements AudioEffectDeviceAdapter {
     static OffsetFractions = Fraction.builder()
         .add([1, 1]).add([1, 2]).add([1, 3]).add([1, 4])

--- a/packages/studio/adapters/src/devices/audio-effects/ModularDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/audio-effects/ModularDeviceBoxAdapter.ts
@@ -10,6 +10,7 @@ import {ModularAdapter} from "../../modular/modular"
 import {DeviceInterfaceKnobAdapter} from "../../modular/user-interface"
 
 
+/** Adapter that exposes a modular device chain as an audio effect. */
 export class ModularDeviceBoxAdapter implements AudioEffectDeviceAdapter {
     readonly type = "audio-effect"
     readonly accepts = "audio"

--- a/packages/studio/adapters/src/devices/audio-effects/RevampDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/audio-effects/RevampDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 
+/** Adapter for the Revamp equalizer and filter effect. */
 export class RevampDeviceBoxAdapter implements AudioEffectDeviceAdapter {
     readonly type = "audio-effect"
     readonly accepts = "audio"

--- a/packages/studio/adapters/src/devices/audio-effects/ReverbDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/audio-effects/ReverbDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 
+/** Adapter for the reverb audio effect. */
 export class ReverbDeviceBoxAdapter implements AudioEffectDeviceAdapter {
     readonly type = "audio-effect"
     readonly accepts = "audio"

--- a/packages/studio/adapters/src/devices/audio-effects/StereoToolDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/audio-effects/StereoToolDeviceBoxAdapter.ts
@@ -7,6 +7,7 @@ import {BoxAdaptersContext} from "../../BoxAdaptersContext"
 import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 
+/** Adapter for the Stereo Tool widening effect. */
 export class StereoToolDeviceBoxAdapter implements AudioEffectDeviceAdapter {
     readonly type = "audio-effect"
     readonly accepts = "audio"

--- a/packages/studio/adapters/src/devices/instruments/NanoDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/instruments/NanoDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {TrackType} from "../../timeline/TrackType"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 
+/** Adapter exposing the Nano instrument's parameters. */
 export class NanoDeviceBoxAdapter implements InstrumentDeviceBoxAdapter {
     readonly type = "instrument"
     readonly accepts = "midi"

--- a/packages/studio/adapters/src/devices/instruments/PlayfieldDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/instruments/PlayfieldDeviceBoxAdapter.ts
@@ -11,6 +11,7 @@ import {TrackType} from "../../timeline/TrackType"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 
+/** Adapter managing Playfield sample-based instruments. */
 export class PlayfieldDeviceBoxAdapter implements InstrumentDeviceBoxAdapter {
     readonly type = "instrument"
     readonly accepts = "midi"

--- a/packages/studio/adapters/src/devices/instruments/TapeDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/instruments/TapeDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 import {TrackType} from "../../timeline/TrackType"
 
+/** Adapter for the Tape instrument device. */
 export class TapeDeviceBoxAdapter implements InstrumentDeviceBoxAdapter {
     readonly type = "instrument"
     readonly accepts = "audio"

--- a/packages/studio/adapters/src/devices/instruments/VaporisateurDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/instruments/VaporisateurDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {TrackType} from "../../timeline/TrackType"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 
+/** Adapter for the Vaporisateur instrument device box. */
 export class VaporisateurDeviceBoxAdapter implements InstrumentDeviceBoxAdapter {
     readonly type = "instrument"
     readonly accepts = "midi"

--- a/packages/studio/adapters/src/devices/midi-effects/ArpeggioDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/midi-effects/ArpeggioDeviceBoxAdapter.ts
@@ -9,6 +9,7 @@ import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AutomatableParameterFieldAdapter} from "../../AutomatableParameterFieldAdapter"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 
+/** Adapter for the Arpeggio MIDI effect. */
 export class ArpeggioDeviceBoxAdapter implements MidiEffectDeviceAdapter {
     static RateFractions = Fraction.builder()
         .add([1, 1]).add([1, 2]).add([1, 3]).add([1, 4])

--- a/packages/studio/adapters/src/devices/midi-effects/PitchDeviceBoxAdapter.ts
+++ b/packages/studio/adapters/src/devices/midi-effects/PitchDeviceBoxAdapter.ts
@@ -8,6 +8,7 @@ import {ParameterAdapterSet} from "../../ParameterAdapterSet"
 import {AudioUnitBoxAdapter} from "../../audio-unit/AudioUnitBoxAdapter"
 import { AutomatableParameterFieldAdapter } from "../../AutomatableParameterFieldAdapter"
 
+/** Adapter for the Pitch MIDI effect device. */
 export class PitchDeviceBoxAdapter implements MidiEffectDeviceAdapter {
     readonly type = "midi-effect"
     readonly accepts = "midi"

--- a/packages/studio/adapters/src/grooves/GrooveShuffleBoxAdapter.ts
+++ b/packages/studio/adapters/src/grooves/GrooveShuffleBoxAdapter.ts
@@ -7,6 +7,7 @@ import {BoxAdaptersContext} from "../BoxAdaptersContext"
 import {ParameterAdapterSet} from "../ParameterAdapterSet"
 import {AutomatableParameterFieldAdapter} from "../AutomatableParameterFieldAdapter"
 
+/** Adapter that generates shuffle groove patterns. */
 export class GrooveShuffleBoxAdapter implements GrooveAdapter {
     static readonly Durations: ReadonlyArray<[int, int]> = [
         [1, 8], [1, 4], [1, 4], [1, 2], [1, 1], [2, 1], [4, 1], [8, 1], [16, 1]


### PR DESCRIPTION
## Summary
- document how device boxes are wrapped and linked from user docs
- add intro to device boxes and link it in adapters README
- add short doc comments to instrument, effect, midi and groove adapters

## Testing
- `npm test`
- `npm run lint` *(fails: workspace @opendaw/studio-enums lint error)*

------
https://chatgpt.com/codex/tasks/task_b_68af2febc014832190010612b728073b