### PR TITLE
docs: document sample browser and OPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Huge thanks to our [ambassadors](https://opendaw.org/ambassadors), whose dedicat
 - [Canvas Utilities](packages/docs/docs-dev/ui/canvas/overview.md)
 - [Icon Library](packages/docs/docs-dev/ui/icons/overview.md)
 - [Notepad Guide](packages/docs/docs-user/features/notepad.md)
+- [File Management Guide](packages/docs/docs-user/features/file-management.md)
+- [OPFS Sample Storage](packages/docs/docs-dev/architecture/opfs-samples.md)
 
 ### Style Documentation
 

--- a/packages/app/studio/src/service/SampleApi.ts
+++ b/packages/app/studio/src/service/SampleApi.ts
@@ -24,8 +24,10 @@ const headers: RequestInit = {
 /**
  * REST API helpers for retrieving and uploading sample files.
  *
- * Uses {@link network.limitFetch} to throttle HTTP requests. See
- * [StudioService](./StudioService.ts) for how the API integrates with the app.
+ * Used by {@link SampleService} and the {@link SampleBrowser} to access the
+ * cloud library. Requests are throttled through {@link network.limitFetch} to
+ * avoid hammering the server. See {@link SampleStorage} for the local OPFS
+ * counterpart.
  *
  * ```mermaid
  * sequenceDiagram

--- a/packages/app/studio/src/ui/browse/SampleBrowser.sass
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.sass
@@ -1,4 +1,5 @@
-// Styles for browsing, filtering and previewing samples.
+// Styles for the {@link SampleBrowser} component, covering layout of the
+// location selector, sample list and preview controls.
 @use "@/colors"
 @use "@/mixins"
 

--- a/packages/app/studio/src/ui/browse/SampleBrowser.tsx
+++ b/packages/app/studio/src/ui/browse/SampleBrowser.tsx
@@ -48,7 +48,10 @@ const location = new DefaultObservableValue(SampleLocation.Cloud);
  * Browser and management UI for audio samples, allowing local or cloud
  * sources and providing preview, deletion and volume control.
  *
- * Keyboard delete removes selected local samples.
+ * Combines {@link SampleService} with {@link SampleApi} and
+ * {@link SampleLocation} to present a unified view of locally cached OPFS
+ * samples and the remote library. Keyboard delete removes selected local
+ * samples.
  */
 export const SampleBrowser = ({ lifecycle, service }: Construct) => {
   lifecycle.own({ terminate: () => service.samplePlayback.eject() });

--- a/packages/app/studio/src/ui/browse/SampleDialogs.tsx
+++ b/packages/app/studio/src/ui/browse/SampleDialogs.tsx
@@ -12,6 +12,9 @@ import { FilePickerAcceptTypes } from "@/ui/FilePickerAcceptTypes";
 /**
  * Dialog helpers for managing samples.
  *
+ * Exposed utilities are used by {@link SampleService} and
+ * {@link SampleBrowser} to locate missing files or edit metadata.
+ *
  * @see SampleImporter
  * @see SampleUtils.verify
  */

--- a/packages/app/studio/src/ui/browse/SampleLocation.sass
+++ b/packages/app/studio/src/ui/browse/SampleLocation.sass
@@ -1,0 +1,2 @@
+// Styles for {@link SampleLocation} badges indicating cloud or local source.
+

--- a/packages/app/studio/src/ui/browse/SampleLocation.tsx
+++ b/packages/app/studio/src/ui/browse/SampleLocation.tsx
@@ -1,4 +1,9 @@
-/** Indicates where a sample originates from. */
+/**
+ * Indicates where a sample originates from.
+ *
+ * Used by {@link SampleBrowser} to toggle between cloud and OPFS backed
+ * libraries.
+ */
 export const enum SampleLocation {
   /** Sample hosted on the server */
   Cloud,

--- a/packages/app/studio/src/ui/browse/SampleService.ts
+++ b/packages/app/studio/src/ui/browse/SampleService.ts
@@ -21,6 +21,10 @@ import { SampleApi } from "@/service/SampleApi";
 /**
  * Convenience wrapper around {@link StudioService} for managing samples in the
  * browser view.
+ *
+ * Ties together {@link SampleApi} for cloud access and {@link SampleStorage}
+ * for OPFS backed persistence, exposing higher level actions used by the
+ * {@link SampleBrowser} UI.
  */
 export class SampleService {
   readonly #service: StudioService;

--- a/packages/docs/docs-dev/architecture/opfs-samples.md
+++ b/packages/docs/docs-dev/architecture/opfs-samples.md
@@ -1,0 +1,34 @@
+# OPFS Sample Storage
+
+The studio caches imported and cloud hosted audio files in the browser's
+[Origin Private File System](https://developer.mozilla.org/docs/Web/API/File_System_Access_API/Origin_private_file_system).
+The `SampleStorage` service stores raw audio data under `samples/` and exposes
+utilities for lookup by UUID.
+
+## Worker Protocol
+
+File system access happens inside a dedicated web worker. The worker implements
+an `OpfsProtocol` with basic `write`, `read`, `delete` and `list` operations.
+The host registers the protocol via `OpfsWorker.init` and communicates through a
+`Messenger` channel to serialize file system operations.
+
+```mermaid
+flowchart TD
+    subgraph Worker
+        OW[OpfsWorker]
+    end
+    subgraph Main
+        SS[SampleStorage]
+    end
+    SS <--> OW
+```
+
+## Integration
+
+`SampleBrowser` and `SampleService` combine the worker backed `SampleStorage`
+with the remote `SampleApi`. Local samples live in OPFS while cloud entries are
+fetched on demand and can be imported into the local cache.
+
+For a higher level overview see the [persistence
+architecture](./persistence.md).
+

--- a/packages/docs/docs-dev/architecture/persistence.md
+++ b/packages/docs/docs-dev/architecture/persistence.md
@@ -6,7 +6,7 @@ openDAW stores project data and samples in the browser using the Origin Private 
 - `meta.json` – metadata such as title and tags
 - `image.bin` – optional cover image
 
-Sample files referenced by projects are managed via `SampleStorage` and can be packaged together with a project into a distributable bundle. Bundles are standard ZIP archives with a `uuid` marker and a `samples/` folder holding audio data.
+Sample files referenced by projects are managed via `SampleStorage` and can be packaged together with a project into a distributable bundle. Bundles are standard ZIP archives with a `uuid` marker and a `samples/` folder holding audio data. The worker based file access is described in more detail in the [OPFS sample storage](./opfs-samples.md) notes.
 
 The `Projects` utility provides functions for reading and writing these artifacts as well as creating and importing bundles.
 

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -1,6 +1,8 @@
 # File Management
 
-Import, export, and organize project files. Developers can dive deeper in the
+Import, export, and organize project files. openDAW stores data in the
+browser's Origin Private File System (OPFS) so sessions and samples persist
+offline. Developers can dive deeper in the
 [project docs](../../docs-dev/projects/overview.md) and the
 [info panel reference](../../docs-dev/ui/info-panel/overview.md).
 
@@ -9,6 +11,7 @@ Import, export, and organize project files. Developers can dive deeper in the
 - Use the **Sample Browser** to switch between cloud and local libraries.
 - Search, preview and delete samples directly from the list.
 - Adjust preview volume with the slider in the browser footer.
+- Local samples are cached in OPFS and survive page reloads.
 
 ## Save Projects
 

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -57,6 +57,8 @@ module.exports = {
         "architecture/audio-path",
         "architecture/browser-compat",
         "architecture/headless-vs-studio",
+        "architecture/persistence",
+        "architecture/opfs-samples",
       ],
     },
     {

--- a/packages/lib/fusion/src/opfs/OpfsProtocol.ts
+++ b/packages/lib/fusion/src/opfs/OpfsProtocol.ts
@@ -1,9 +1,24 @@
+/** Indicates the type of an OPFS entry. */
 export type Kind = "file" | "directory"
+
+/** Name and {@link Kind} pair returned by {@link OpfsProtocol.list}. */
 export type Entry = { name: string, kind: Kind }
 
+/**
+ * Minimal protocol used to interact with the Origin Private File System.
+ *
+ * Implementations can be used both inside a worker and on the main thread.
+ */
 export interface OpfsProtocol {
+    /** Write a file to the given path. */
     write(path: string, data: Uint8Array): Promise<void>
+
+    /** Read an entire file from the given path. */
     read(path: string): Promise<Uint8Array>
+
+    /** Remove a file or directory tree at the given path. */
     delete(path: string): Promise<void>
+
+    /** List entries below the given directory path. */
     list(path: string): Promise<ReadonlyArray<Entry>>
 }

--- a/packages/lib/fusion/src/opfs/OpfsWorker.ts
+++ b/packages/lib/fusion/src/opfs/OpfsWorker.ts
@@ -3,13 +3,30 @@ import {Communicator, Messenger, Promises} from "@opendaw/lib-runtime"
 import {Entry, OpfsProtocol} from "./OpfsProtocol"
 import "../types"
 
+/**
+ * Helper utilities for interacting with the Origin Private File System (OPFS)
+ * inside a Web Worker. All file system operations are funneled through
+ * {@link Communicator.executor} to serialize access and avoid race
+ * conditions.
+ */
 export namespace OpfsWorker {
     const DEBUG = false
     const readLimiter = new Promises.Limit<Uint8Array>(1)
     const writeLimiter = new Promises.Limit<void>(1)
 
+    /**
+     * Register the OPFS protocol handlers on the given messenger channel.
+     *
+     * @param messenger messenger used to communicate with the worker host.
+     */
     export const init = (messenger: Messenger) =>
         Communicator.executor(messenger.channel("opfs"), new class implements OpfsProtocol {
+            /**
+             * Write a file to the OPFS at the given path.
+             *
+             * @param path slash-delimited file path inside the OPFS root.
+             * @param data contents to store.
+             */
             async write(path: string, data: Uint8Array): Promise<void> {
                 if (DEBUG) {console.debug(`write ${data.length}b to ${path}`)}
                 return writeLimiter.add(() => this.#resolveFile(path, {create: true})
@@ -21,6 +38,12 @@ export namespace OpfsWorker {
                     }))
             }
 
+            /**
+             * Read a file from the OPFS.
+             *
+             * @param path slash-delimited file path inside the OPFS root.
+             * @returns file contents as a new {@link Uint8Array}.
+             */
             async read(path: string): Promise<Uint8Array> {
                 if (DEBUG) {console.debug(`read ${path}`)}
                 return readLimiter.add(() => this.#resolveFile(path)
@@ -33,12 +56,18 @@ export namespace OpfsWorker {
                     }))
             }
 
+            /**
+             * Remove a file or directory tree at the given path.
+             */
             async delete(path: string): Promise<void> {
                 const segments = pathToSegments(path)
                 return this.#resolveFolder(segments.slice(0, -1))
                     .then(folder => folder.removeEntry(asDefined(segments.at(-1)), {recursive: true}))
             }
 
+            /**
+             * List directory entries below the given path.
+             */
             async list(path: string): Promise<ReadonlyArray<Entry>> {
                 const segments = pathToSegments(path)
                 const {status, value: folder} = await Promises.tryCatch(this.#resolveFolder(segments))
@@ -50,6 +79,7 @@ export namespace OpfsWorker {
                 return result
             }
 
+            /** Resolve a file handle and open a sync access handle. */
             async #resolveFile(path: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemSyncAccessHandle> {
                 const segments = pathToSegments(path)
                 return this.#resolveFolder(segments.slice(0, -1), options)
@@ -57,6 +87,7 @@ export namespace OpfsWorker {
                         .then(handle => handle.createSyncAccessHandle()))
             }
 
+            /** Traverse the directory structure for the given path segments. */
             async #resolveFolder(segments: ReadonlyArray<string>,
                                  options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle> {
                 let folder: FileSystemDirectoryHandle = await navigator.storage.getDirectory()
@@ -65,6 +96,7 @@ export namespace OpfsWorker {
             }
         })
 
+    /** Split a slash-delimited path into individual segments. */
     const pathToSegments = (path: string): ReadonlyArray<string> => {
         const noSlashes = path.replace(/^\/+|\/+$/g, "")
         return noSlashes === "" ? [] : noSlashes.split("/")


### PR DESCRIPTION
## Summary
- document OPFS worker protocol with TSDoc
- explain SampleBrowser integration and storage options
- add developer notes on OPFS sample storage and update file management guide

## Testing
- `npm test`
- `npm run lint` *(fails: workspace @opendaw/lib-midi lint exit 1)*

------
https://chatgpt.com/codex/tasks/task_b_68af2fed4ec883219bb80db0ccc1e881