### PR TITLE
docs: document menu system and shortcuts

### DIFF
--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -11,6 +11,10 @@ The project notepad uses markdown and can be customized. See the
 developer details. For instructions on using the feature in the Studio,
 read the [notepad user guide](../../docs/docs-user/features/notepad.md).
 
+Menu commands are built from a hierarchical `MenuItem` model. See the
+[menu overview](../../docs/docs-dev/ui/menu/overview.md) for how menus and
+keyboard shortcuts are wired into the Studio.
+
 For individual topics, browse the in-app [manuals](public/manuals/index.md).
 
 ## Component Hierarchy

--- a/packages/app/studio/src/ui/components/Menu.sass
+++ b/packages/app/studio/src/ui/components/Menu.sass
@@ -1,3 +1,5 @@
+// Floating menu widget styles.
+// @see ../../../../../docs/docs-dev/ui/menu/overview.md
 @use "@/mixins"
 @use "@/colors"
 

--- a/packages/app/studio/src/ui/components/Menu.tsx
+++ b/packages/app/studio/src/ui/components/Menu.tsx
@@ -1,3 +1,9 @@
+/**
+ * Floating menu component that renders a {@link MenuItem} tree and supports
+ * nested sub-menus, scrolling and keyboard navigation.
+ *
+ * @see ../../../../../docs/docs-dev/ui/menu/overview.md
+ */
 import css from "./Menu.sass?inline"
 import {DefaultMenuData, HeaderMenuData, MenuItem} from "@/ui/model/menu-item.ts"
 import {createElement, Frag} from "@opendaw/lib-jsx"

--- a/packages/app/studio/src/ui/components/MenuButton.sass
+++ b/packages/app/studio/src/ui/components/MenuButton.sass
@@ -1,3 +1,5 @@
+// Button styles for toggling menus.
+// @see ../../../../../docs/docs-dev/ui/menu/overview.md
 component
   --color-active: var(--color)
 

--- a/packages/app/studio/src/ui/components/MenuButton.tsx
+++ b/packages/app/studio/src/ui/components/MenuButton.tsx
@@ -1,3 +1,8 @@
+/**
+ * Trigger button spawning a {@link Menu} when activated.
+ *
+ * @see ../../../../../docs/docs-dev/ui/menu/overview.md
+ */
 import css from "./MenuButton.sass?inline"
 import {createElement, JsxValue} from "@opendaw/lib-jsx"
 import {MenuItem} from "@/ui/model/menu-item.ts"

--- a/packages/app/studio/src/ui/menu/debug.ts
+++ b/packages/app/studio/src/ui/menu/debug.ts
@@ -4,6 +4,8 @@ import { showDebugBoxDialog } from "@/ui/components/dialogs.tsx";
 
 /**
  * Menu helpers exposing development diagnostics.
+ *
+ * @see ../../../../../docs/docs-dev/ui/menu/debug.md
  */
 export namespace DebugMenus {
   /**

--- a/packages/app/studio/src/ui/model/menu-item.ts
+++ b/packages/app/studio/src/ui/model/menu-item.ts
@@ -1,3 +1,9 @@
+/**
+ * Minimal tree structure representing menu entries. Each {@link MenuItem}
+ * can lazily populate children and trigger actions when selected.
+ *
+ * @see ../../../../../docs/docs-dev/ui/menu/overview.md
+ */
 import {Arrays, Option, Procedure, Terminable} from "@opendaw/lib-std"
 
 import {IconSymbol} from "@opendaw/studio-adapters"

--- a/packages/app/studio/src/ui/pages/ManualPage.sass
+++ b/packages/app/studio/src/ui/pages/ManualPage.sass
@@ -3,6 +3,7 @@
 
 // Layout styles for the manuals page and sidebar.
 // See also: AutomationPage.sass, ComponentsPage.sass.
+// @see ../../../../../docs/docs-dev/ui/pages/manuals.md
 
 component
   flex: 1

--- a/packages/app/studio/src/ui/pages/ManualPage.tsx
+++ b/packages/app/studio/src/ui/pages/ManualPage.tsx
@@ -3,6 +3,7 @@
  *
  * @see AutomationPage for automation examples.
  * @see ComponentsPage for the component showcase.
+ * @see ../../../../../docs/docs-dev/ui/pages/manuals.md
  */
 import css from "./ManualPage.sass?inline"
 import {Await, createElement, LocalLink, PageContext, PageFactory} from "@opendaw/lib-jsx"

--- a/packages/docs/docs-dev/ui/menu/automation.md
+++ b/packages/docs/docs-dev/ui/menu/automation.md
@@ -1,3 +1,5 @@
 # Automation Menu
 
-Context menu for automatable parameters allowing creation and removal of automation tracks, MIDI learning and value reset actions.
+Context menu for automatable parameters allowing creation and removal of
+automation tracks, MIDI learning and value reset actions. Implemented via
+`attachParameterContextMenu` in `ui/menu/automation.ts`.

--- a/packages/docs/docs-dev/ui/menu/debug.md
+++ b/packages/docs/docs-dev/ui/menu/debug.md
@@ -1,3 +1,5 @@
 # Debug Menu
 
-Developer-oriented commands for inspecting internal state, validating projects and emulating failure conditions.
+Developer-oriented commands for inspecting internal state, validating projects
+and emulating failure conditions. Menu helpers live in `ui/menu/debug.ts` and
+are wired into the application menu within `service/app-menu.ts`.

--- a/packages/docs/docs-dev/ui/menu/overview.md
+++ b/packages/docs/docs-dev/ui/menu/overview.md
@@ -1,6 +1,8 @@
 # Menu Overview
 
-The menu system connects user actions to application features via a structured tree of `MenuItem` objects.
+The Studio builds menus from a tree of `MenuItem` objects. Items can lazily
+populate children, trigger actions and are rendered with the `Menu` component
+and opened by `MenuButton` controls.
 
 - [Automation](./automation.md)
 - [Debug](./debug.md)

--- a/packages/docs/docs-dev/ui/menu/shortcuts.md
+++ b/packages/docs/docs-dev/ui/menu/shortcuts.md
@@ -1,3 +1,5 @@
 # Menu Shortcuts
 
-Most menu entries expose keyboard accelerators to speed up workflows. See the [keyboard shortcuts manual](/manuals/keyboard-shortcuts) for usage.
+Most menu entries expose keyboard accelerators to speed up workflows. They are
+handled centrally by the `Shortcuts` service. See the
+[keyboard shortcuts manual](../../../docs-user/keyboard-shortcuts.md) for usage.

--- a/packages/docs/docs-user/keyboard-shortcuts.md
+++ b/packages/docs/docs-user/keyboard-shortcuts.md
@@ -2,7 +2,7 @@
 
 Replace `⌘` with `Ctrl` on Windows and Linux.
 
-For menu locations of these commands, see the [menu overview](/manuals/docs-dev/ui/menu/overview) and [menu shortcuts](/manuals/docs-dev/ui/menu/shortcuts).
+For menu locations of these commands, see the [menu overview](../docs-dev/ui/menu/overview.md) and [menu shortcuts](../docs-dev/ui/menu/shortcuts.md).
 
 ## Misc
 


### PR DESCRIPTION
## Summary
- document MenuItem model and components
- add developer docs for menus and shortcuts and update user keyboard guide
- reference menu model from Studio README

## Testing
- `npm test`
- `npm run lint` *(fails: @opendaw/lib-fusion lint script exits 1)*

------
https://chatgpt.com/codex/tasks/task_b_68af2ff0f20c8321b5dc77acc55018b7