### PR TITLE
docs: add roadmap and references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to openDAW
 
-Thank you for your interest in contributing to openDAW! This guide outlines the preferred workflow for submitting pull requests and the coding style that keeps the project consistent.
+Thank you for your interest in contributing to openDAW! This guide outlines the preferred workflow for submitting pull requests and the coding style that keeps the project consistent. Review the [project roadmap](ROADMAP.md) to see upcoming milestones and priorities.
 
 ## Pipeline Overview
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ a strong focus on **education** and data-privacy. Please consider supporting thi
 
 ## Open-Source
 
-We are committed to transparency and community-driven development.
+We are committed to transparency and community-driven development. See the
+[project roadmap](ROADMAP.md) for upcoming milestones.
 
 The source code for openDAW is available under the [MIT License](LICENSE).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,21 @@
 # openDAW Roadmap
 
+The roadmap outlines current and future work on openDAW. For an overview of the
+project and how to get involved, see the [README](README.md) and
+[CONTRIBUTING](CONTRIBUTING.md) guides.
+
+## Milestones
+
+- **Developer documentation** – [Intro](packages/docs/docs-dev/intro.md),
+  [Architecture overview](packages/docs/docs-dev/architecture/overview.md),
+  [API coverage](packages/docs/docs-dev/api-coverage.md),
+  [Package inventory](packages/docs/docs-dev/package-inventory.md),
+  [Build and run roadmap](packages/docs/docs-dev/build-and-run/roadmap.md).
+- **User documentation** – [User guide](packages/docs/docs-user/intro.md) and
+  [Quick start](packages/docs/docs-user/quick-start.md).
+- **Learning resources** – [Learning hub](packages/docs/docs-learn/intro.md)
+  and [DAW Basics 101](packages/docs/docs-learn/daw-basics-101.md).
+
 ## Pipeline Overview
 
 Turbo coordinates workspace tasks such as builds, tests, and documentation
@@ -24,20 +40,29 @@ The repository root contains shared configuration files:
 
 ## Near term
 
-- Publish core documentation set and initial diagrams.
-- Define documentation ownership and review process.
-- Run continuous integration for tests and linting.
+- Publish core documentation set and initial diagrams – see the
+  [developer docs](packages/docs/docs-dev/intro.md).
+- Define documentation ownership and review process – see
+  [CONTRIBUTING](CONTRIBUTING.md).
+- Run continuous integration for tests and linting – follow the
+  [CI guide](packages/docs/docs-dev/build-and-run/ci.md).
 
 ## Mid term
 
-- Launch internationalization workflow for community translations.
-- Integrate accessibility tooling and audits.
-- Version documentation alongside the first stable release.
+- Launch internationalization workflow for community translations – see the
+  [Localization guide](packages/docs/docs-user/localization.md).
+- Integrate accessibility tooling and audits – reference the
+  [Accessibility guide](packages/docs/docs-user/accessibility.md).
+- Version documentation alongside the first stable release – follow the
+  [versioning policy](packages/docs/docs-dev/build-and-run/versioning.md).
 
 ## Long term
 
-- Support additional languages and downloadable offline docs.
-- Provide real-time collaborative editing for documentation.
-- Evolve roadmap based on community feedback.
+- Support additional languages and downloadable offline docs – expand the
+  [Localization guide](packages/docs/docs-user/localization.md).
+- Provide real-time collaborative editing for documentation – continue the
+  [collaboration workflow](packages/docs/docs-user/workflows/collaboration.md).
+- Evolve roadmap based on community feedback – share ideas via the
+  [community channels](README.md).
 
 Roadmap items are tentative and may change as the project evolves.

--- a/packages/docs/docs-dev/api-coverage.md
+++ b/packages/docs/docs-dev/api-coverage.md
@@ -1,6 +1,7 @@
 # API Coverage
 
-Documentation coverage measured with `typedoc-plugin-coverage`:
+Documentation coverage measured with `typedoc-plugin-coverage`.
+See the [project roadmap](../../../ROADMAP.md) for planned improvements:
 
 - [`@opendaw/lib-runtime`](./package-inventory.md#lib) – 0%
 - [`@opendaw/lib-dsp`](./package-inventory.md#lib) – 0%

--- a/packages/docs/docs-dev/architecture/overview.md
+++ b/packages/docs/docs-dev/architecture/overview.md
@@ -4,7 +4,8 @@ openDAW is composed of several packages such as
 [`@opendaw/app-studio`](../package-inventory.md#app) and
 [`@opendaw/studio-core`](../package-inventory.md#studio). The architecture is
 described using the C4 model. For a step‑by‑step look at how the
-application starts, see the [bootstrapping sequence](./bootstrap.md).
+application starts, see the [bootstrapping sequence](./bootstrap.md). Refer to
+the [project roadmap](../../../../ROADMAP.md) for milestone context.
 
 Static assets like the abstract SVG set in
 `packages/app/studio/public/viscious-speed` are bundled with the app; see that

--- a/packages/docs/docs-dev/build-and-run/roadmap.md
+++ b/packages/docs/docs-dev/build-and-run/roadmap.md
@@ -1,0 +1,9 @@
+# Build and Run Roadmap
+
+This page tracks build and runtime tasks for openDAW. See the main
+[project roadmap](../../../../ROADMAP.md) for overall milestones.
+
+## Upcoming
+
+- Automate tests and linting in continuous integration.
+- Document release steps alongside the versioning policy.

--- a/packages/docs/docs-dev/intro.md
+++ b/packages/docs/docs-dev/intro.md
@@ -4,7 +4,8 @@ The developer documentation provides guidance for contributing to openDAW's
 packages such as [`@opendaw/app-studio`](./package-inventory.md#app). Learn how
 to [build and run](./build-and-run/setup.md) the project, explore its
 [architecture](./architecture/overview.md), and ensure quality with
-[testing and QA](./testing-and-qa/index.md).
+[testing and QA](./testing-and-qa/index.md). See the
+[project roadmap](../../../ROADMAP.md) for current milestones.
 
 For writing and formatting conventions, see the [Writing Guide](./style/writing-guide.md).
 

--- a/packages/docs/docs-dev/package-inventory.md
+++ b/packages/docs/docs-dev/package-inventory.md
@@ -1,14 +1,15 @@
 # Package Inventory
 
-A high level overview of the packages in this repository.
+A high level overview of the packages in this repository. For upcoming work,
+see the [project roadmap](../../../ROADMAP.md).
 
-| Package  | Responsibility                                                        |
-| -------- | --------------------------------------------------------------------- |
-| `app`    | User-facing applications. Includes `@opendaw/app-studio` and `@opendaw/app-headless`. |
-| `config` | Shared configuration such as `@opendaw/eslint-config` and TypeScript settings. |
-| `docs`   | Documentation site and developer guides like this one.                |
+| Package  | Responsibility                                                                                                            |
+| -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `app`    | User-facing applications. Includes `@opendaw/app-studio` and `@opendaw/app-headless`.                                     |
+| `config` | Shared configuration such as `@opendaw/eslint-config` and TypeScript settings.                                            |
+| `docs`   | Documentation site and developer guides like this one.                                                                    |
 | `lib`    | Reusable libraries for DSP, DOM helpers, runtime utilities, and more, e.g. `@opendaw/lib-dsp` and `@opendaw/lib-runtime`. |
-| `studio` | Core audio engine components, adapters, and scheduling modules such as `@opendaw/studio-core`. |
+| `studio` | Core audio engine components, adapters, and scheduling modules such as `@opendaw/studio-core`.                            |
 
 Refer back to these packages when following the [build and run](./build-and-run/setup.md)
 instructions or the [extending guides](./extending/opendaw-sdk.md).

--- a/packages/docs/docs-learn/daw-basics-101.md
+++ b/packages/docs/docs-learn/daw-basics-101.md
@@ -1,6 +1,6 @@
 # DAW Basics 101
 
-A Digital Audio Workstation (DAW) is software for recording, editing, and mixing audio. It lets you capture performances, arrange clips on a timeline, and apply effects to shape the final sound.
+A Digital Audio Workstation (DAW) is software for recording, editing, and mixing audio. It lets you capture performances, arrange clips on a timeline, and apply effects to shape the final sound. For upcoming lessons, see the [project roadmap](../../../ROADMAP.md).
 
 ## Core Concepts
 
@@ -40,4 +40,3 @@ For writing guidance or to suggest edits, see the
    - [ ] Frequency
    - [ ] File size
    - [x] Time
-

--- a/packages/docs/docs-learn/intro.md
+++ b/packages/docs/docs-learn/intro.md
@@ -3,7 +3,8 @@
 The learning hub gathers tutorials and background material for openDAW.
 Start with **[DAW Basics 101](./daw-basics-101.md)** to learn core concepts
 like tracks, the mixer, and automation. Lessons build on each other, so work
-through them in order or jump to topics using the sidebar.
+through them in order or jump to topics using the sidebar. Upcoming lessons
+are outlined in the [project roadmap](../../../ROADMAP.md).
 
 Interested in contributing lessons? Check the
 [Writing Guide](../docs-dev/style/writing-guide.md) for style tips.
@@ -42,4 +43,3 @@ learning path or explore individual subjects as needed.
    - [ ] MIDI and Synthesis
    - [ ] Latency and Buffers
    - [x] Exporting and Sharing
-

--- a/packages/docs/docs-user/intro.md
+++ b/packages/docs/docs-user/intro.md
@@ -2,7 +2,8 @@
 
 This guide helps you get started with openDAW and deepen your skills. If you
 want to contribute documentation, read the
-[Writing Guide](../docs-dev/style/writing-guide.md).
+[Writing Guide](../docs-dev/style/writing-guide.md). For project milestones,
+see the [roadmap](../../../ROADMAP.md).
 
 - [Quick Start](quick-start.md) — set up the project and begin making music in minutes.
 - [UI Tour](ui-tour.md) — explore the interface and learn where everything lives.

--- a/packages/docs/docs-user/quick-start.md
+++ b/packages/docs/docs-user/quick-start.md
@@ -1,5 +1,7 @@
 # Quick Start
 
+See the [project roadmap](../../../ROADMAP.md) for planned features.
+
 1. **Open the studio.** Launch the openDAW application in your browser.
 2. **Create a project.** From the dashboard choose **New Project** to start with an empty session.
 3. **Add a track.** Click the **+** button in the track list and select an instrument or audio track.


### PR DESCRIPTION
## Summary
- expand root roadmap with linked milestones
- link roadmap from README and contributing guide
- cross-reference roadmap throughout developer, user, and learning docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af2ff0c7608321863e5407156fc16d