### PR TITLE
docs: add mixer routing references

### DIFF
--- a/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePanel.tsx
@@ -34,11 +34,13 @@ import {Project} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "DevicePanel")
 
+/** Props for {@link DevicePanel}. */
 type Construct = {
     lifecycle: Lifecycle
     service: StudioService
 }
 
+/** Context information for the currently edited device chain. */
 type Context = { deviceHost: DeviceHost, instrument: ObservableValue<Option<AudioUnitInputAdapter>> }
 
 /**

--- a/packages/app/studio/src/ui/mixer/AudioOutputDevices.tsx
+++ b/packages/app/studio/src/ui/mixer/AudioOutputDevices.tsx
@@ -8,6 +8,7 @@ import { AudioDevices } from "@/audio/AudioDevices";
 
 const className = Html.adoptStyleSheet(css, "AudioOutputDevices");
 
+/** Props for {@link AudioOutputDevices}. */
 type Construct = {
   output: AudioOutputDevice;
   provider: Procedure<MediaDeviceInfo>;

--- a/packages/app/studio/src/ui/mixer/AuxSend.tsx
+++ b/packages/app/studio/src/ui/mixer/AuxSend.tsx
@@ -14,6 +14,7 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "AuxSend")
 
+/** Constructor options for {@link AuxSend}. */
 type Construct = {
     lifecycle: Lifecycle
     editing: Editing

--- a/packages/app/studio/src/ui/mixer/AuxSendGroup.tsx
+++ b/packages/app/studio/src/ui/mixer/AuxSendGroup.tsx
@@ -14,12 +14,14 @@ import {Colors, Project} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "AuxSendGroup")
 
+/** Internal bookkeeping for a rendered send entry. */
 type AuxSendEntry = {
     uuid: UUID.Format
     element: HTMLElement
     terminator: Terminator
 }
 
+/** Props for {@link AuxSendGroup}. */
 type Construct = {
     lifecycle: Lifecycle
     project: Project

--- a/packages/app/studio/src/ui/mixer/ChannelOutputSelector.tsx
+++ b/packages/app/studio/src/ui/mixer/ChannelOutputSelector.tsx
@@ -12,6 +12,7 @@ import {Colors, Project} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "OutputSelector")
 
+/** Props for {@link ChannelOutputSelector}. */
 type Construct = {
     lifecycle: Lifecycle
     project: Project

--- a/packages/docs/docs-dev/ui/mixer/routing.md
+++ b/packages/docs/docs-dev/ui/mixer/routing.md
@@ -1,0 +1,15 @@
+# Routing in the Mixer UI
+
+Explains how channel strips, sends and output selectors connect audio within the Studio.
+
+## Channel outputs
+
+`ChannelOutputSelector` lets users reroute a track's signal to any available bus. The component updates label and icon colors to match the chosen destination and offers quick creation of new busses.
+
+## Auxiliary sends
+
+`AuxSendGroup` manages multiple `AuxSend` controls for an audio unit. Each send exposes pan and gain knobs and can target existing or newly created effect busses.
+
+## Hardware devices
+
+`AudioOutputDevices` lists discovered browser audio outputs and allows the user to choose the playback device for the session.

--- a/packages/docs/docs-user/features/mixer.md
+++ b/packages/docs/docs-user/features/mixer.md
@@ -55,3 +55,15 @@ graph LR
 
 For a practical example see the [Mixing workflow](../workflows/mixing.md).
 
+## Changing track outputs
+
+Each channel strip provides an **Output** selector at its base. Use it to route a
+track to another bus or directly to a hardware output. The menu lists existing
+destinations and also lets you create new busses on the fly.
+
+### Output devices
+
+The master channel can target any detected audio device. Open the output menu
+and choose from the **Audio Output Devices** list to switch playback to a
+different interface such as external speakers or headphones.
+

--- a/packages/docs/sidebarsDev.js
+++ b/packages/docs/sidebarsDev.js
@@ -212,7 +212,11 @@ module.exports = {
             "ui/metering/rms-vs-peak",
           ],
         },
-        "ui/mixer",
+        {
+          type: "category",
+          label: "Mixer",
+          items: ["ui/mixer", "ui/mixer/routing"],
+        },
         {
           type: "category",
           label: "Modular",

--- a/packages/studio/core-processors/src/AuxSendProcessor.ts
+++ b/packages/studio/core-processors/src/AuxSendProcessor.ts
@@ -46,7 +46,11 @@ export class AuxSendProcessor extends AudioProcessor implements Processor, Audio
     /** Clears the output buffer. */
     reset(): void {this.#audioOutput.clear()}
 
-    /** Exposes the backing adapter for external wiring. */
+    /**
+     * Exposes the backing adapter controlling this send.
+     *
+     * @returns adapter providing access to the underlying box parameters
+     */
     get adapter(): AuxSendBoxAdapter {return this.#adapter}
 
     /**

--- a/packages/studio/core-processors/src/ChannelStripProcessor.ts
+++ b/packages/studio/core-processors/src/ChannelStripProcessor.ts
@@ -77,6 +77,11 @@ export class ChannelStripProcessor extends AudioProcessor implements Processor, 
     /** Buffer receiving the processed signal. */
     get audioOutput(): AudioBuffer {return this.#audioOutput}
 
+    /**
+     * Handles events dispatched to this processor.
+     *
+     * Currently channel strips do not react to events, so the method is a no-op.
+     */
     handleEvent(_event: Event): void {}
 
     /**

--- a/packages/studio/core/src/EffectBox.ts
+++ b/packages/studio/core/src/EffectBox.ts
@@ -15,7 +15,8 @@ import {
  * Union of all effect device boxes supported by the studio.
  *
  * Effects can be inserted or reached via sends using
- * {@link @opendaw/studio-enums#AudioSendRouting | AudioSendRouting}.
+ * {@link @opendaw/studio-enums#AudioSendRouting | AudioSendRouting}. Unknown
+ * entries ensure forward compatibility with future devices.
  *
  * @public
  */

--- a/packages/studio/core/src/EffectFactories.ts
+++ b/packages/studio/core/src/EffectFactories.ts
@@ -193,10 +193,15 @@ export namespace EffectFactories {
         }
     }
 
+    /** Mapping of MIDI effect names to their factory definitions. */
     export const MidiNamed = {Arpeggio, Pitch, Zeitgeist}
+    /** Mapping of audio effect names to their factory definitions. */
     export const AudioNamed = {StereoTool, Delay, Reverb, Revamp, Modular}
+    /** List of all built-in MIDI effect factories. */
     export const MidiList: ReadonlyArray<Readonly<EffectFactory>> = Object.values(MidiNamed)
+    /** List of all built-in audio effect factories. */
     export const AudioList: ReadonlyArray<Readonly<EffectFactory>> = Object.values(AudioNamed)
+    /** Combined lookup of MIDI and audio effect factories. */
     export const MergedNamed = {...MidiNamed, ...AudioNamed}
     export type MidiEffectKeys = keyof typeof MidiNamed
     export type AudioEffectKeys = keyof typeof AudioNamed

--- a/packages/studio/core/src/Mixer.ts
+++ b/packages/studio/core/src/Mixer.ts
@@ -31,6 +31,12 @@ export class Mixer implements Terminable {
     readonly #virtualSolo: Set<AudioUnitBoxAdapter>
     readonly #deferUpdate: DeferExec
 
+    /**
+     * Creates a new mixer instance that observes the given channel adapters and
+     * manages their mute and solo states.
+     *
+     * @param audioUnits - collection of channel strip adapters to manage
+     */
     constructor(audioUnits: IndexedBoxAdapterCollection<AudioUnitBoxAdapter, Pointers.AudioUnits>) {
         this.#states = UUID.newSet(({adapter: {uuid}}) => uuid)
         this.#solo = new Set()


### PR DESCRIPTION
## Summary
- document mixer channel routing behavior for dev and user docs
- add TSDoc around mixer routing components
- expose mixer routing docs in sidebar

## Testing
- `npm test`
- `npm run lint` (fails: npm error workspace @opendaw/lib-midi)


------
https://chatgpt.com/codex/tasks/task_b_68b01c4d6f848321a908cdead543fd4a