### PR TITLE
docs: document project migration and DAWproject helpers

### DIFF
--- a/packages/docs/docs-dev/serialization/migration.md
+++ b/packages/docs/docs-dev/serialization/migration.md
@@ -1,0 +1,16 @@
+# Project Migration
+
+`ProjectMigration` upgrades legacy Studio project graphs to the current
+schema. After decoding a project or importing a `.dawproject` archive, the
+migration step inserts missing boxes and normalizes values so the rest of the
+application can operate on a consistent structure.
+
+- Runs on the skeleton produced by `DawProjectImport.read` before the project
+  is opened.
+- Creates required global helpers such as the `GrooveShuffleBox` and converts
+  outdated event representations.
+- New migration rules can be added to `ProjectMigration.migrate` as the project
+  graph evolves.
+
+Return to the [serialization overview](./overview.md).
+

--- a/packages/docs/docs-user/workflows/dawproject.md
+++ b/packages/docs/docs-user/workflows/dawproject.md
@@ -6,8 +6,10 @@ through the `.dawproject` format.
 1. **Export a DAWproject file.** Choose *File → Export → DAWproject* to create an
    archive containing the current session and all referenced audio files.
 2. **Import a DAWproject file.** Use *File → Import* and select a `.dawproject`
-   bundle to start a new session from it.
+   bundle to start a new session from it. Imported projects are automatically
+   migrated to the latest Studio schema.
 3. **Edit and re-export.** Once imported, the project behaves like any other
    openDAW session and can be saved or exported again at any time.
 
-For technical details see the [developer serialization guide](../../docs-dev/serialization/studio-dawproject.md).
+For technical details see the [developer serialization guide](../../docs-dev/serialization/studio-dawproject.md)
+and the [project migration reference](../../docs-dev/serialization/migration.md).

--- a/packages/lib/dawproject/src/defaults.ts
+++ b/packages/lib/dawproject/src/defaults.ts
@@ -1,4 +1,5 @@
 /**
+ * @packageDocumentation
  * Core schema definitions for the DAWproject XML format.
  *
  * @remarks

--- a/packages/lib/dawproject/src/utils.ts
+++ b/packages/lib/dawproject/src/utils.ts
@@ -1,4 +1,8 @@
 /* eslint-disable @typescript-eslint/no-namespace */
+/**
+ * @packageDocumentation
+ * Utility helpers for encoding and decoding parameter schemas used in DAWproject.
+ */
 import { BooleanParameterSchema, RealParameterSchema, Unit } from "./defaults";
 import { Xml } from "@opendaw/lib-xml";
 import { asDefined } from "@opendaw/lib-std";
@@ -14,7 +18,10 @@ export namespace ParameterEncoder {
   /**
    * Encodes a boolean parameter.
    *
-   * @see {@link BooleanParameterSchema}
+   * @param id - Unique parameter identifier.
+   * @param value - Boolean value to store.
+   * @param name - Optional display name.
+   * @returns Serialized {@link BooleanParameterSchema} instance.
    */
   export const bool = (id: string, value: boolean, name?: string) =>
     Xml.element(
@@ -29,7 +36,12 @@ export namespace ParameterEncoder {
   /**
    * Encodes a linear numeric parameter.
    *
-   * @see {@link RealParameterSchema}
+   * @param id - Unique parameter identifier.
+   * @param value - Linear value to encode.
+   * @param min - Optional minimum value.
+   * @param max - Optional maximum value.
+   * @param name - Optional display name.
+   * @returns Serialized {@link RealParameterSchema} instance.
    */
   export const linear = (
     id: string,
@@ -53,7 +65,12 @@ export namespace ParameterEncoder {
   /**
    * Encodes a normalized numeric parameter.
    *
-   * @see {@link RealParameterSchema}
+   * @param id - Unique parameter identifier.
+   * @param value - Normalized value within the range `[min,max]`.
+   * @param min - Minimum value of the normalized range.
+   * @param max - Maximum value of the normalized range.
+   * @param name - Optional display name.
+   * @returns Serialized {@link RealParameterSchema} instance.
    */
   export const normalized = (
     id: string,
@@ -83,6 +100,9 @@ export namespace ParameterEncoder {
 export namespace ParameterDecoder {
   /**
    * Resolves the numeric value from a {@link RealParameterSchema}.
+   *
+   * @param schema - Parameter schema to interpret.
+   * @returns Linearized numeric value.
    *
    * @remarks
    * Normalized and semitone based parameters are converted to linear values.

--- a/packages/studio/core/src/ProjectMigration.ts
+++ b/packages/studio/core/src/ProjectMigration.ts
@@ -19,6 +19,8 @@ import {Capture} from "./capture/Capture"
 export class ProjectMigration {
     /**
      * Applies all available migrations to the provided project skeleton.
+     *
+     * @param skeleton - The project graph and mandatory boxes to migrate.
      */
     static migrate({boxGraph, mandatoryBoxes}: ProjectDecoder.Skeleton): void {
         const {rootBox} = mandatoryBoxes

--- a/packages/studio/core/src/dawproject/AudioUnitExportLayout.ts
+++ b/packages/studio/core/src/dawproject/AudioUnitExportLayout.ts
@@ -14,7 +14,12 @@ export namespace AudioUnitExportLayout {
         children: Array<Track>
     }
 
-    /** Build a hierarchy of tracks from the current set of audio units. */
+    /**
+     * Build a hierarchy of tracks from the current set of audio units.
+     *
+     * @param audioUnits - All audio unit boxes to arrange.
+     * @returns Ordered track hierarchy describing the signal flow.
+     */
     export const layout = (audioUnits: ReadonlyArray<AudioUnitBox>): Array<Track> => {
         const feedsInto = new ArrayMultimap<AudioUnitBox, AudioUnitBox>()
         audioUnits.forEach(unit => {
@@ -49,6 +54,14 @@ export namespace AudioUnitExportLayout {
             .filter(isDefined)
     }
 
+    /**
+     * Recursively assemble a track tree starting at the given audio unit.
+     *
+     * @param audioUnit - The root audio unit for this branch.
+     * @param feedsInto - Mapping of downstream connections.
+     * @param visited - Set used to break cycles.
+     * @returns The assembled track node or `null` when a cycle is detected.
+     */
     const buildTrackRecursive = (audioUnit: AudioUnitBox,
                                  feedsInto: ArrayMultimap<AudioUnitBox, AudioUnitBox>,
                                  visited: Set<AudioUnitBox>): Nullable<Track> => {
@@ -65,6 +78,9 @@ export namespace AudioUnitExportLayout {
 
     /**
      * Debug helper that logs the computed track hierarchy to the console.
+     *
+     * @param tracks - The track layout produced by {@link layout}.
+     * @param indent - Current indentation level (used internally).
      */
     export const printTrackStructure = (tracks: ReadonlyArray<Track>, indent = 0): void => {
         const spaces = " ".repeat(indent)

--- a/packages/studio/core/src/dawproject/BuiltinDevices.ts
+++ b/packages/studio/core/src/dawproject/BuiltinDevices.ts
@@ -11,11 +11,18 @@ import {semitoneToHz} from "@opendaw/lib-dsp"
 export namespace BuiltinDevices {
     /**
      * Create a Revamp equalizer device from a DAWproject {@link EqualizerSchema}.
+     *
+     * @param boxGraph - Graph used to create the device and its bands.
+     * @param equalizer - Source schema describing the equalizer configuration.
+     * @param field - Host field the device will be inserted into.
+     * @param index - Position of the device within the host.
+     * @returns The constructed {@link RevampDeviceBox}.
      */
     export const equalizer = (boxGraph: BoxGraph,
                               equalizer: EqualizerSchema,
                               field: Field<Pointers.MidiEffectHost> | Field<Pointers.AudioEffectHost>,
                               index: int): RevampDeviceBox => {
+        /** Map DAWproject filter order to Revamp's order index. */
         const mapOrder = (order?: int) => {
             switch (order) {
                 case 1:
@@ -31,6 +38,7 @@ export namespace BuiltinDevices {
                     return 3
             }
         }
+        /** Populate a pass band from the DAWproject schema. */
         const readPass = (schema: BandSchema, pass: RevampPass) => {
             const {order, frequency, q, enabled} = pass
             order.setValue(mapOrder(schema.order))
@@ -38,6 +46,7 @@ export namespace BuiltinDevices {
             ifDefined(schema.Q?.value, value => q.setValue(value))
             ifDefined(schema.enabled?.value, value => enabled.setValue(value))
         }
+        /** Populate a shelf band from the DAWproject schema. */
         const readShelf = (schema: BandSchema, pass: RevampShelf) => {
             const {frequency, gain, enabled} = pass
             frequency.setValue(ParameterDecoder.readValue(schema.freq))

--- a/packages/studio/core/src/dawproject/DawProject.ts
+++ b/packages/studio/core/src/dawproject/DawProject.ts
@@ -25,6 +25,9 @@ export namespace DawProject {
     /**
      * Decode a DAWproject archive into its metadata, project XML and resource
      * lookup helpers.
+     *
+     * @param buffer - Raw bytes of the `.dawproject` zip archive.
+     * @returns Parsed metadata, project schema and resource provider.
      */
     export const decode = async (buffer: ArrayBuffer | NonSharedBuffer): Promise<{
         metaData: MetaDataSchema,
@@ -59,6 +62,10 @@ export namespace DawProject {
     /**
      * Encode the current {@link Project} and associated metadata into a
      * `.dawproject` zip archive.
+     *
+     * @param project - The project graph to serialize.
+     * @param metaData - Metadata describing the project.
+     * @returns A binary zip archive in the DAWproject format.
      */
     export const encode = (project: Project, metaData: MetaDataSchema): Promise<ArrayBuffer> => {
         const zip = new JSZip()

--- a/packages/studio/core/src/dawproject/DeviceIO.ts
+++ b/packages/studio/core/src/dawproject/DeviceIO.ts
@@ -9,6 +9,9 @@ import {DeviceBox, DeviceBoxUtils} from "@opendaw/studio-adapters"
 export namespace DeviceIO {
     /**
      * Serialize a device box and its dependencies into a compact binary format.
+     *
+     * @param box - The device box to serialize.
+     * @returns Binary representation containing the device and dependencies.
      */
     export const exportDevice = (box: Box): ArrayBufferLike => {
         const dependencies = Array.from(box.graph.dependenciesOf(box).boxes)
@@ -31,6 +34,10 @@ export namespace DeviceIO {
 
     /**
      * Deserialize a previously exported device into the given {@link BoxGraph}.
+     *
+     * @param boxGraph - Graph to which the device should be added.
+     * @param buffer - Binary data produced by {@link exportDevice}.
+     * @returns The reconstructed device box.
      */
     export const importDevice = (boxGraph: BoxGraph<BoxIO.TypeMap>, buffer: ArrayBufferLike): DeviceBox => {
         const input = new ByteArrayInput(buffer)


### PR DESCRIPTION
## Summary
- add migration guide for project serialization and link from user workflow docs
- document ProjectMigration and DAWproject import/export helpers with TSDoc
- clarify parameter utilities and schema defaults with package docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b01c5065c483219110b3463b505ade