### PR TITLE
docs: annotate services and add session handshake guide

### DIFF
--- a/deploy/run.ts
+++ b/deploy/run.ts
@@ -4,6 +4,10 @@
  * `packages/app/studio/dist` directory and optionally notifies a Discord
  * channel via webhook when complete. The script is currently disabled and is
  * intended to be run manually by maintainers.
+ *
+ * Security note: credentials are read from environment variables and the
+ * routine deletes remote files before uploading new ones. Double‑check the
+ * target host and paths before executing.
  */
 // NOTE: Deployment script disabled
 import SftpClient from "ssh2-sftp-client";

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "type": "git",
     "url": "https://github.com/andremichelle/opendaw"
   },
+  "engines//": "Minimum Node.js version required to work on the repo",
   "engines": {
     "node": ">=23"
   },
   "packageManager": "npm@11.4.2",
+  "workspaces//": "Monorepo packages included in the build",
   "workspaces": [
     "packages/**/*"
   ],

--- a/packages/app/headless/src/main.ts
+++ b/packages/app/headless/src/main.ts
@@ -9,7 +9,8 @@
  *
  * Security note: The demo relies on cross-origin isolation and local worker
  * bundles. Serve this page over HTTPS and avoid loading untrusted scripts to
- * prevent privilege escalation.
+ * prevent privilege escalation. The demo stores no persistent data and only
+ * fetches samples from the current origin.
  */
 import "./style.css"
 import {assert, Progress, UUID} from "@opendaw/lib-std"

--- a/packages/app/studio/src/BuildInfo.ts
+++ b/packages/app/studio/src/BuildInfo.ts
@@ -4,6 +4,9 @@
  * persisted to `public/build-info.json`. The data is fetched at
  * runtime to validate caches and expose build details to the client.
  *
+ * Security note: the information exposed here contains no user data and
+ * should not be used for authentication or authorization decisions.
+ *
  * @public
  */
 export type BuildInfo = {

--- a/packages/app/studio/src/features.ts
+++ b/packages/app/studio/src/features.ts
@@ -1,5 +1,8 @@
 /**
  * Runtime feature detection utilities for the Studio application.
+ *
+ * Security note: these tests run entirely in the browser and do not
+ * transmit any information to remote services.
  */
 import { requireProperty } from "@opendaw/lib-std";
 
@@ -10,6 +13,7 @@ import { requireProperty } from "@opendaw/lib-std";
  * API is unavailable. Keeping the logic centralized ensures that feature
  * requirements stay in sync with the documentation and user messaging.
  *
+ * @public
  * @throws {Error} When a mandatory Web API is missing from the host
  * browser.
  */

--- a/packages/app/studio/src/service/SessionService.ts
+++ b/packages/app/studio/src/service/SessionService.ts
@@ -2,6 +2,10 @@
  * Service handling persistence and lifecycle operations for project sessions.
  * Works in concert with {@link SyncLogService} for commit logging and emits
  * {@link StudioSignal} events to update the UI.
+ *
+ * Security note: all operations act on data stored within the user's
+ * browser. The service never transmits project content unless explicitly
+ * exported by the user.
  */
 import {ProjectSession} from "@/project/ProjectSession"
 import {

--- a/packages/app/studio/src/service/StudioService.ts
+++ b/packages/app/studio/src/service/StudioService.ts
@@ -1,6 +1,10 @@
 /**
  * Core application service responsible for wiring together workspace, audio
  * engine and project handling utilities.
+ *
+ * Security note: project files and samples loaded through this service are
+ * treated as untrusted input. Validation is the responsibility of callers
+ * before invoking load operations.
  */
 import {
     assert,

--- a/packages/app/studio/src/ui/configs.ts
+++ b/packages/app/studio/src/ui/configs.ts
@@ -1,4 +1,10 @@
-
+/**
+ * Preset configurations for UI snapping behaviour used throughout the
+ * Studio interface.
+ *
+ * Security note: values defined here are static constants and carry no
+ * executable code.
+ */
 import { ValueMapping } from "@opendaw/lib-std";
 
 /**

--- a/packages/docs/docs-dev/architecture/session-handshake.md
+++ b/packages/docs/docs-dev/architecture/session-handshake.md
@@ -1,0 +1,34 @@
+# Session Handshake
+
+When a project session starts the application performs a small handshake
+to synchronise the user interface, shared worker and audio worklet.  The
+sequence ensures that all components operate on the same project state
+before playback begins.
+
+## Sequence
+
+```mermaid
+sequenceDiagram
+    participant Main as Main Thread
+    participant Worker
+    participant Worklet
+    Main->>Worker: install shared worker
+    Worker-->>Main: ready
+    Main->>Worklet: construct AudioWorkletNode
+    Worklet-->>Worker: request session data
+    Worker-->>Main: confirm session
+```
+
+## Steps
+
+1. `StudioService` boots the application and invokes
+   `SessionService` to create or load a `ProjectSession`.
+2. The runtime installs worker scripts and audio worklets via
+   `WorkerAgents.install` and `Worklets.install`.
+3. Session data is transferred to the engine through a
+   [`Messenger`](../../../lib/runtime/src/messenger.ts) channel.
+4. Both the worker and worklet acknowledge the active session
+   before audio playback starts.
+
+Security note: the handshake never leaves the browser process.  No
+credentials or user data are transmitted over the network.

--- a/packages/docs/docs-user/security.md
+++ b/packages/docs/docs-user/security.md
@@ -8,5 +8,10 @@ you choose to share it.
 - Keep your browser up to date to benefit from the latest security patches.
 - When granting microphone or file permissions, ensure the request comes from
   the official openDAW application.
+- Serve the application over HTTPS to prevent man‑in‑the‑middle attacks and to
+  enable cross‑origin isolation.
+- Verify downloads before importing projects or samples from others.
+- Exported project bundles contain everything needed to recreate your work;
+  store them in a safe location.
 
 Your work remains on your device, giving you control over how it is shared.

--- a/packages/lib/runtime/src/messenger.ts
+++ b/packages/lib/runtime/src/messenger.ts
@@ -7,7 +7,8 @@ import { isDefined, Notifier, Nullable, Observable, Observer, Procedure, Subscri
  * A messenger wraps objects such as {@link Worker}, {@link MessagePort} or
  * {@link BroadcastChannel} and exposes a simple observable interface.  It can
  * also create logical sub‑channels so multiple communication streams share the
- * same underlying transport.
+ * same underlying transport. Messages are transported verbatim and are not
+ * encrypted or validated.
  */
 
 /**

--- a/packages/lib/runtime/src/network.ts
+++ b/packages/lib/runtime/src/network.ts
@@ -11,7 +11,11 @@ import { Promises } from "./promises";
  * using them.
  */
 export namespace network {
-  /** Limits the number of concurrent fetch requests. */
+  /**
+   * Limits the number of concurrent fetch requests.
+   *
+   * Raising the limit may increase load on both client and server.
+   */
   const limit = new Promises.Limit<Response>(4);
 
   /**


### PR DESCRIPTION
## Summary
- document security considerations in runtime and service modules
- add session handshake architecture doc and expand user security guide
- note engine boot and deployment script constraints

## Testing
- `npm test` *(fails: Workspace 'packages/app/studio' not found in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_68b01c509c7083219239ef60cb6e7cfa