### PR TITLE
docs: add device parameter tables

### DIFF
--- a/packages/app/studio/src/ui/components/Knob.tsx
+++ b/packages/app/studio/src/ui/components/Knob.tsx
@@ -51,7 +51,15 @@ export interface KnobProps {
     design?: Design
 }
 
-/** Circular control representing a continuous parameter value. */
+/**
+ * Circular control representing a continuous parameter value.
+ *
+ * @param lifecycle lifecycle owner for subscriptions
+ * @param value parameter controlling the knob
+ * @param anchor anchor position for the indicator
+ * @param color optional color of the knob
+ * @param design custom visual design
+ */
 export const Knob = ({lifecycle, value, anchor, color, design}: KnobProps) => {
     const {radius, trackWidth, angleOffset, indicator: [min, max], indicatorWidth} = design ?? DefaultDesign
 

--- a/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
+++ b/packages/app/studio/src/ui/devices/panel/DevicePeakMeter.tsx
@@ -15,14 +15,22 @@ import {Colors} from "@opendaw/studio-core"
 
 const className = Html.adoptStyleSheet(css, "DevicePeakMeter")
 
+/** Props for {@link DevicePeakMeter}. */
 type Construct = {
+    /** Lifecycle owner for subscriptions. */
     lifecycle: Lifecycle
+    /** Source providing live peak levels. */
     receiver: LiveStreamReceiver
+    /** Bus or channel address to observe. */
     address: Address
 }
 
 /**
  * Compact peak meter used inside the device panel to visualize output levels.
+ *
+ * @param lifecycle manages subscriptions and cleanup
+ * @param receiver provides the live peak values
+ * @param address bus or channel to monitor
  */
 export const DevicePeakMeter = ({lifecycle, receiver, address}: Construct) => {
     const element: HTMLDivElement = (<div className={className}/>)
@@ -82,3 +90,10 @@ export const DevicePeakMeter = ({lifecycle, receiver, address}: Construct) => {
     }))
     return element
 }
+
+/** Property table for {@link DevicePeakMeter}. */
+export const DevicePeakMeterPropTable = [
+    {prop: "lifecycle", type: "Lifecycle", description: "Owner used to dispose subscriptions."},
+    {prop: "receiver", type: "LiveStreamReceiver", description: "Stream supplying peak levels."},
+    {prop: "address", type: "Address", description: "Bus or channel address to monitor."}
+] as const

--- a/packages/docs/docs-dev/dsp/device-parameters.md
+++ b/packages/docs/docs-dev/dsp/device-parameters.md
@@ -1,0 +1,22 @@
+# Device parameters
+
+Processors expose their adjustable parameters through exported tables. Each table lists the parameter name, its type and a short description. The tables live next to the processor implementations and can be imported by tooling or documentation generators.
+
+```ts
+import { DelayDeviceProcessorParamTable } from '@opendaw/studio-core-processors';
+
+DelayDeviceProcessorParamTable.forEach(p => {
+  console.log(p.param, p.description);
+});
+```
+
+The following processors currently define parameter tables:
+
+- DelayDeviceProcessor
+- ReverbDeviceProcessor
+- RevampDeviceProcessor
+- StereoToolDeviceProcessor
+- NopDeviceProcessor (no parameters)
+- ArpeggioDeviceProcessor
+- PitchDeviceProcessor
+- ZeitgeistDeviceProcessor (no parameters)

--- a/packages/docs/docs-user/features/effect-parameters.md
+++ b/packages/docs/docs-user/features/effect-parameters.md
@@ -1,0 +1,14 @@
+# Effect parameters
+
+Each audio or MIDI effect exposes a set of controls that shape how the signal is processed. Parameters can be tweaked in the device panel or automated over time.
+
+Common examples include:
+
+- **Delay** – delay time, feedback, cross‑feed, filter, wet and dry mix
+- **Reverb** – decay, predelay, damping, wet and dry mix
+- **Revamp** – multi‑band EQ stages with high/low pass, shelves and bells
+- **Stereo Tool** – gain, pan, stereo width, channel invert and swap
+- **Pitch** – octave, semitone and cent adjustments
+- **Arpeggio** – mode, rate, gate, repeat, octaves and velocity
+
+Hover any control to inspect its value or double‑click to reset it. These controls correspond directly to the processor parameter tables, keeping the user interface and documentation in sync.

--- a/packages/studio/core-processors/src/devices/audio-effects/DelayDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/audio-effects/DelayDeviceProcessor.ts
@@ -163,3 +163,13 @@ export class DelayDeviceProcessor
     return `{${this.constructor.name} (${this.#id})}`;
   }
 }
+
+/** Parameter table for {@link DelayDeviceProcessor}. */
+export const DelayDeviceProcessorParamTable = [
+  { param: "delay", type: "number", description: "Delay offset selection index." },
+  { param: "feedback", type: "number", description: "Feedback amount between repeats." },
+  { param: "cross", type: "number", description: "Cross‑channel feedback level." },
+  { param: "filter", type: "number", description: "Filter balance for high/low pass." },
+  { param: "dry", type: "number", description: "Dry mix level in decibels." },
+  { param: "wet", type: "number", description: "Wet mix level in decibels." },
+] as const;

--- a/packages/studio/core-processors/src/devices/audio-effects/NopDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/audio-effects/NopDeviceProcessor.ts
@@ -92,3 +92,6 @@ export class NopDeviceProcessor
     return `{${this.constructor.name} (${this.#id})`;
   }
 }
+
+/** Parameter table for {@link NopDeviceProcessor}. */
+export const NopDeviceProcessorParamTable = [] as const;

--- a/packages/studio/core-processors/src/devices/audio-effects/RevampDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/audio-effects/RevampDeviceProcessor.ts
@@ -335,3 +335,33 @@ export class RevampDeviceProcessor
     return `{${this.constructor.name} (${this.#id})`;
   }
 }
+
+/** Parameter table for {@link RevampDeviceProcessor}. */
+export const RevampDeviceProcessorParamTable = [
+  { param: "highPass.enabled", type: "boolean", description: "Enable high‑pass filter stage." },
+  { param: "highPass.frequency", type: "number", description: "Cutoff frequency of the high‑pass filter." },
+  { param: "highPass.q", type: "number", description: "Q factor of the high‑pass filter." },
+  { param: "highPass.order", type: "int", description: "Filter order for the high‑pass stage." },
+  { param: "lowShelf.enabled", type: "boolean", description: "Enable low‑shelf stage." },
+  { param: "lowShelf.frequency", type: "number", description: "Corner frequency for the low‑shelf." },
+  { param: "lowShelf.gain", type: "number", description: "Gain applied by the low‑shelf in dB." },
+  { param: "lowBell.enabled", type: "boolean", description: "Enable low bell stage." },
+  { param: "lowBell.frequency", type: "number", description: "Center frequency of the low bell." },
+  { param: "lowBell.gain", type: "number", description: "Gain applied by the low bell in dB." },
+  { param: "lowBell.q", type: "number", description: "Q factor of the low bell." },
+  { param: "midBell.enabled", type: "boolean", description: "Enable mid bell stage." },
+  { param: "midBell.frequency", type: "number", description: "Center frequency of the mid bell." },
+  { param: "midBell.gain", type: "number", description: "Gain applied by the mid bell in dB." },
+  { param: "midBell.q", type: "number", description: "Q factor of the mid bell." },
+  { param: "highBell.enabled", type: "boolean", description: "Enable high bell stage." },
+  { param: "highBell.frequency", type: "number", description: "Center frequency of the high bell." },
+  { param: "highBell.gain", type: "number", description: "Gain applied by the high bell in dB." },
+  { param: "highBell.q", type: "number", description: "Q factor of the high bell." },
+  { param: "highShelf.enabled", type: "boolean", description: "Enable high‑shelf stage." },
+  { param: "highShelf.frequency", type: "int", description: "Corner frequency of the high‑shelf." },
+  { param: "highShelf.gain", type: "number", description: "Gain applied by the high‑shelf in dB." },
+  { param: "lowPass.enabled", type: "boolean", description: "Enable low‑pass filter stage." },
+  { param: "lowPass.frequency", type: "number", description: "Cutoff frequency for the low‑pass filter." },
+  { param: "lowPass.q", type: "number", description: "Q factor of the low‑pass filter." },
+  { param: "lowPass.order", type: "number", description: "Filter order for the low‑pass stage." },
+] as const;

--- a/packages/studio/core-processors/src/devices/audio-effects/ReverbDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/audio-effects/ReverbDeviceProcessor.ts
@@ -126,3 +126,12 @@ export class ReverbDeviceProcessor
     return `{${this.constructor.name} (${this.#id})`;
   }
 }
+
+/** Parameter table for {@link ReverbDeviceProcessor}. */
+export const ReverbDeviceProcessorParamTable = [
+  { param: "decay", type: "number", description: "Room decay time coefficient." },
+  { param: "preDelay", type: "number", description: "Predelay time before reverberation." },
+  { param: "damp", type: "number", description: "High‑frequency damping amount." },
+  { param: "wet", type: "number", description: "Wet mix level in decibels." },
+  { param: "dry", type: "number", description: "Dry mix level in decibels." },
+] as const;

--- a/packages/studio/core-processors/src/devices/audio-effects/StereoToolDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/audio-effects/StereoToolDeviceProcessor.ts
@@ -163,3 +163,13 @@ export class StereoToolDeviceProcessor
     return `{${this.constructor.name}}`;
   }
 }
+
+/** Parameter table for {@link StereoToolDeviceProcessor}. */
+export const StereoToolDeviceProcessorParamTable = [
+  { param: "volume", type: "number", description: "Output gain in decibels." },
+  { param: "panning", type: "number", description: "Balance between left and right." },
+  { param: "stereo", type: "number", description: "Stereo width amount." },
+  { param: "invertL", type: "boolean", description: "Invert left channel polarity." },
+  { param: "invertR", type: "boolean", description: "Invert right channel polarity." },
+  { param: "swap", type: "boolean", description: "Swap left and right channels." },
+] as const;

--- a/packages/studio/core-processors/src/devices/midi-effects/ArpeggioDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/midi-effects/ArpeggioDeviceProcessor.ts
@@ -220,3 +220,13 @@ export class ArpeggioDeviceProcessor
     return this.#adapter;
   }
 }
+
+/** Parameter table for {@link ArpeggioDeviceProcessor}. */
+export const ArpeggioDeviceProcessorParamTable = [
+  { param: "modeIndex", type: "int", description: "Arpeggio pattern selection." },
+  { param: "rate", type: "int", description: "Playback rate as note division." },
+  { param: "gate", type: "number", description: "Gate length of each note." },
+  { param: "repeat", type: "int", description: "Number of repeats for each note." },
+  { param: "numOctaves", type: "int", description: "Number of octave transpositions." },
+  { param: "velocity", type: "int", description: "Velocity scaling applied to notes." },
+] as const;

--- a/packages/studio/core-processors/src/devices/midi-effects/PitchDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/midi-effects/PitchDeviceProcessor.ts
@@ -139,3 +139,10 @@ export class PitchDeviceProcessor
     return this.#adapter;
   }
 }
+
+/** Parameter table for {@link PitchDeviceProcessor}. */
+export const PitchDeviceProcessorParamTable = [
+  { param: "octaves", type: "int", description: "Pitch shift in octaves." },
+  { param: "semiTones", type: "int", description: "Pitch shift in semitones." },
+  { param: "cent", type: "number", description: "Fine tuning in cents." },
+] as const;

--- a/packages/studio/core-processors/src/devices/midi-effects/ZeitgeistDeviceProcessor.ts
+++ b/packages/studio/core-processors/src/devices/midi-effects/ZeitgeistDeviceProcessor.ts
@@ -134,3 +134,6 @@ export class ZeitgeistDeviceProcessor
   handleEvent(_block: Readonly<Block>, _event: Event): void {}
   processEvents(_block: Readonly<Block>, _from: number, _to: number): void {}
 }
+
+/** Parameter table for {@link ZeitgeistDeviceProcessor}. */
+export const ZeitgeistDeviceProcessorParamTable = [] as const;


### PR DESCRIPTION
## Summary
- document processor parameters with exported tables
- document device peak meter and knob props
- add developer and user docs for effect parameters

## Testing
- `npm test`
- `npm run lint` *(fails: workspace @opendaw/lib-midi lint command exited)*

------
https://chatgpt.com/codex/tasks/task_b_68b01c538400832194e2ceb9a470378e