### PR TITLE
docs: document project metadata and file management

### DIFF
--- a/packages/app/studio/src/project/ProjectBrowser.sass
+++ b/packages/app/studio/src/project/ProjectBrowser.sass
@@ -20,6 +20,7 @@ component
   div.list
     padding: 0 1em 0 0
     display: grid
+    // align rows and columns with the header layout
     grid-template-columns: subgrid
     grid-column: 1 / -1
     align-items: center

--- a/packages/app/studio/src/project/ProjectBrowser.tsx
+++ b/packages/app/studio/src/project/ProjectBrowser.tsx
@@ -11,13 +11,21 @@ import {Html} from "@opendaw/lib-dom"
 
 const className = Html.adoptStyleSheet(css, "ProjectBrowser")
 
+/**
+ * Construction options for {@link ProjectBrowser}.
+ */
 type Construct = {
+    /** Service used for project operations like deletion. */
     service: StudioService
+    /** Callback invoked when a project is selected. */
     select: Procedure<[UUID.Format, ProjectMeta]>
 }
 
 /**
  * List of saved projects allowing the user to select or delete entries.
+ *
+ * @param service - Studio service for project operations.
+ * @param select - Callback invoked when the user selects a project.
  *
  * @example
  * ```tsx

--- a/packages/app/studio/src/project/ProjectMeta.ts
+++ b/packages/app/studio/src/project/ProjectMeta.ts
@@ -25,6 +25,9 @@ export namespace ProjectMeta {
     /**
      * Create a new {@link ProjectMeta} object with sensible defaults.
      *
+     * @param name - Optional project name to use for the new metadata.
+     * @returns The initialized metadata object.
+     *
      * @example
      * ```ts
      * const meta = ProjectMeta.init("My Song")
@@ -40,6 +43,9 @@ export namespace ProjectMeta {
 
     /**
      * Create a shallow copy of the given metadata object.
+     *
+     * @param meta - Source metadata to duplicate.
+     * @returns A new metadata object containing the same fields.
      */
     export const copy = (meta: ProjectMeta): ProjectMeta => Object.assign({}, meta)
 }

--- a/packages/app/studio/src/project/Projects.ts
+++ b/packages/app/studio/src/project/Projects.ts
@@ -44,6 +44,9 @@ export namespace Projects {
     /**
      * Store the given project and its metadata.
      *
+     * @param session - Project session containing graph, metadata and cover.
+     * @returns Resolves once all files have been written.
+     *
      * @example
      * ```ts
      * await Projects.saveProject(session)
@@ -64,6 +67,7 @@ export namespace Projects {
      * Load a project's cover image from storage.
      *
      * @param uuid - Identifier of the project to fetch the cover for.
+     * @returns Option containing the cover image buffer or {@link Option.None}.
      */
     export const loadCover = async (uuid: UUID.Format): Promise<Option<ArrayBuffer>> => {
         return WorkerAgents.Opfs.read(ProjectPaths.projectCover(uuid))
@@ -75,6 +79,7 @@ export namespace Projects {
      *
      * @param service - Studio service for environment configuration.
      * @param uuid - Identifier of the project to load.
+     * @returns The decoded {@link Project} instance.
      */
     export const loadProject = async (service: StudioService, uuid: UUID.Format): Promise<Project> => {
         return WorkerAgents.Opfs.read(ProjectPaths.projectFile(uuid))
@@ -88,6 +93,8 @@ export namespace Projects {
 
     /**
      * List all stored projects with their metadata.
+     *
+     * @returns Array of project identifiers paired with metadata.
      */
     export const listProjects = async (): Promise<ReadonlyArray<{ uuid: UUID.Format, meta: ProjectMeta }>> => {
         return WorkerAgents.Opfs.list(ProjectPaths.Folder)
@@ -101,6 +108,8 @@ export namespace Projects {
 
     /**
      * Determine which samples are used by all stored projects.
+     *
+     * @returns Set of sample UUID strings referenced by projects.
      */
     export const listUsedSamples = async (): Promise<Set<string>> => {
         const uuids: Array<string> = []
@@ -121,11 +130,16 @@ export namespace Projects {
      * Delete a project and all associated files.
      *
      * @param uuid - Identifier of the project to remove.
+     * @returns Resolves when deletion has completed.
      */
     export const deleteProject = async (uuid: UUID.Format) => WorkerAgents.Opfs.delete(ProjectPaths.projectFolder(uuid))
 
     /**
      * Create a distributable bundle containing the project and samples.
+     *
+     * @param session - Project session to package.
+     * @param progress - Observable receiving progress updates between 0-1.
+     * @returns Array buffer containing the generated zip archive.
      */
     export const exportBundle = async ({uuid, project, meta, cover}: ProjectSession,
                                        progress: MutableObservableValue<unitValue>): Promise<ArrayBuffer> => {
@@ -154,6 +168,10 @@ export namespace Projects {
 
     /**
      * Import a bundle created by {@link exportBundle} and return a new session.
+     *
+     * @param service - Studio service used to configure the new project.
+     * @param arrayBuffer - Binary bundle previously produced by {@link exportBundle}.
+     * @returns Newly created {@link ProjectSession} based on the bundle contents.
      */
     export const importBundle = async (service: StudioService, arrayBuffer: ArrayBuffer): Promise<ProjectSession> => {
         const zip = await JSZip.loadAsync(arrayBuffer)

--- a/packages/app/studio/src/project/SampleImporter.ts
+++ b/packages/app/studio/src/project/SampleImporter.ts
@@ -3,6 +3,8 @@ import { Sample } from "@opendaw/studio-adapters";
 
 /**
  * Interface for importing audio samples into a project.
+ * Implementations are responsible for decoding audio data and persisting
+ * it into the project's sample storage.
  *
  * @example
  * ```ts

--- a/packages/app/studio/src/project/SampleUtils.ts
+++ b/packages/app/studio/src/project/SampleUtils.ts
@@ -22,13 +22,14 @@ export namespace SampleUtils {
    * user to replace missing ones.
    *
    * @param boxGraph Graph containing the boxes to inspect.
-   * @param importer Utility used to load replacement samples.
-   * @param audioManager Manager responsible for caching sample data.
-   *
-   * @example
-   * ```ts
-   * await SampleUtils.verify(project.boxGraph, importer, manager)
-   * ```
+  * @param importer Utility used to load replacement samples.
+  * @param audioManager Manager responsible for caching sample data.
+   * @returns Resolves once verification and any replacements are complete.
+  *
+  * @example
+  * ```ts
+  * await SampleUtils.verify(project.boxGraph, importer, manager)
+  * ```
    */
   export const verify = async (
     boxGraph: BoxGraph,

--- a/packages/app/studio/src/ui/info-panel/Cover.sass
+++ b/packages/app/studio/src/ui/info-panel/Cover.sass
@@ -2,6 +2,7 @@
 
 /**
  * Styling for the project cover image with edit overlay.
+ * Includes a small edit icon positioned in the top-right corner.
  *
  * @example
  * <div class="Cover"><img/><span class="edit-icon"/></div>

--- a/packages/app/studio/src/ui/info-panel/Cover.tsx
+++ b/packages/app/studio/src/ui/info-panel/Cover.tsx
@@ -28,6 +28,9 @@ type Construct = {
 /**
  * Displays and lets the user replace a project cover image.
  *
+ * @param lifecycle - Used to clean up DOM listeners and subscriptions.
+ * @param model - Observable value holding the current cover image data.
+ *
  * @example
  * ```tsx
  * <Cover lifecycle={lifecycle} model={coverModel}/>

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.sass
@@ -2,6 +2,7 @@
 
 /**
  * Styles for the project metadata panel.
+ * Uses mixins from {@link colors} to match the theme.
  *
  * @example
  * <div class="ProjectInfo"><div class="form">...</div></div>

--- a/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
+++ b/packages/app/studio/src/ui/info-panel/ProjectInfo.tsx
@@ -20,6 +20,9 @@ type Construct = {
 /**
  * Form component for editing project metadata and cover image.
  *
+ * @param lifecycle - Manages subscriptions and DOM listeners.
+ * @param service - Provides access to the current project session.
+ *
  * @example
  * ```tsx
  * <ProjectInfo lifecycle={lifecycle} service={service}/>

--- a/packages/docs/docs-dev/projects/metadata.md
+++ b/packages/docs/docs-dev/projects/metadata.md
@@ -1,0 +1,30 @@
+# Project Metadata
+
+Projects store descriptive information such as the title, tags and optional
+notes alongside the serialized graph. The metadata is modeled by
+[`ProjectMeta`](../../../app/studio/src/project/ProjectMeta.ts) and persisted as
+JSON in `projects/v1/<uuid>/meta.json`.
+
+## Creating Metadata
+
+Use [`ProjectMeta.init`](../../../app/studio/src/project/ProjectMeta.ts) to
+instantiate a metadata object with sensible defaults:
+
+```ts
+import { ProjectMeta } from "@/project/ProjectMeta";
+
+const meta = ProjectMeta.init("My Song");
+```
+
+## Saving and Loading
+
+The [`Projects`](../../../app/studio/src/project/Projects.ts) module handles
+writing and reading metadata files when saving or loading sessions. The
+`ProjectPaths` helpers construct the file locations.
+
+## Editing in the UI
+
+End users can edit metadata and choose a cover image through the
+`ProjectInfo` panel within the studio application. Changes are written to the
+metadata file and included when exporting project bundles.
+

--- a/packages/docs/docs-user/features/file-management.md
+++ b/packages/docs/docs-user/features/file-management.md
@@ -26,6 +26,12 @@ offline. Developers can dive deeper in the
 2. **Use autosave as a safety net.** openDAW periodically saves in the
    background, but exporting a bundle is the safest way to back up work.
 
+## Edit Project Metadata
+
+- Open the **Info Panel** to change the project name, tags, description and
+  cover image.
+- Changes are applied when an input loses focus or you press <kbd>Enter</kbd>.
+
 ## Export `.odb` Project Bundles
 
 1. **Open the export dialog.** From the main menu select _File → Export_.

--- a/packages/studio/core/src/InstrumentProduct.ts
+++ b/packages/studio/core/src/InstrumentProduct.ts
@@ -7,7 +7,10 @@ import {InstrumentBox} from "./InstrumentBox"
  * @public
  */
 export type InstrumentProduct = {
+    /** Audio unit used to process sound for the instrument. */
     audioUnitBox: AudioUnitBox
+    /** Box containing the instrument's parameters and behaviour. */
     instrumentBox: InstrumentBox
+    /** Track box hosting the instrument within the project graph. */
     trackBox: TrackBox
 }

--- a/packages/studio/core/src/Project.ts
+++ b/packages/studio/core/src/Project.ts
@@ -49,7 +49,12 @@ import { CaptureManager } from "./capture/CaptureManager";
 export class Project
   implements BoxAdaptersContext, Terminable, TerminableOwner
 {
-  /** Creates a brand new project with default boxes. */
+  /**
+   * Creates a brand new project with default boxes.
+   *
+   * @param env - Runtime environment providing services like sample loading.
+   * @returns The newly constructed project instance.
+   */
   static new(env: ProjectEnv): Project {
     const boxGraph = new BoxGraph<BoxIO.TypeMap>(Option.wrap(BoxIO.create));
     const isoString = new Date().toISOString();
@@ -101,14 +106,26 @@ export class Project
     });
   }
 
-  /** Loads a project from its serialized array buffer representation. */
+  /**
+   * Loads a project from its serialized array buffer representation.
+   *
+   * @param env - Runtime environment for the project.
+   * @param arrayBuffer - Binary data previously produced by {@link toArrayBuffer}.
+   * @returns A fully instantiated project.
+   */
   static load(env: ProjectEnv, arrayBuffer: ArrayBuffer): Project {
     const skeleton = ProjectDecoder.decode(arrayBuffer);
     ProjectMigration.migrate(skeleton);
     return new Project(env, skeleton.boxGraph, skeleton.mandatoryBoxes);
   }
 
-  /** Rehydrates a project from its decoded skeleton. */
+  /**
+   * Rehydrates a project from its decoded skeleton.
+   *
+   * @param env - Runtime environment for the project.
+   * @param skeleton - Decoded project structure.
+   * @returns A project based on the provided skeleton.
+   */
   static skeleton(env: ProjectEnv, skeleton: ProjectDecoder.Skeleton): Project {
     ProjectMigration.migrate(skeleton);
     return new Project(env, skeleton.boxGraph, skeleton.mandatoryBoxes);
@@ -235,7 +252,11 @@ export class Project
     };
   }
 
-  /** Serializes the project to an {@link ArrayBuffer}. */
+  /**
+   * Serializes the project to an {@link ArrayBuffer}.
+   *
+   * @returns Binary representation of the current project state.
+   */
   toArrayBuffer(): ArrayBufferLike {
     const output = ByteArrayOutput.create();
     output.writeInt(ProjectDecoder.MAGIC_HEADER_OPEN);
@@ -253,12 +274,18 @@ export class Project
     return output.toArrayBuffer();
   }
 
-  /** Creates a deep copy of the project. */
+  /**
+   * Creates a deep copy of the project.
+   *
+   * @returns A new {@link Project} instance containing cloned data.
+   */
   copy(): Project {
     return Project.load(this.#env, this.toArrayBuffer() as ArrayBuffer);
   }
 
-  /** Terminates all managed resources. */
+  /**
+   * Terminates all managed resources.
+   */
   terminate(): void {
     this.#terminator.terminate();
   }

--- a/packages/studio/core/src/ProjectEnv.ts
+++ b/packages/studio/core/src/ProjectEnv.ts
@@ -6,6 +6,11 @@ import {SampleManager} from "@opendaw/studio-adapters"
 /**
  * Dependencies required for constructing a {@link Project}.
  *
+ * @example
+ * ```ts
+ * const env: ProjectEnv = { sampleRate: 48000, sampleManager }
+ * const project = Project.new(env)
+ * ```
  * @public
  */
 export interface ProjectEnv {


### PR DESCRIPTION
## Summary
- add parameter and return annotations across project metadata, persistence, sample utilities, and core project classes
- document UI components for editing metadata and cover images
- add developer guide for project metadata and expand user file management docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b01c5847048321b5e328b352d58a66