### PR TITLE
docs: standardize development instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,18 @@ and deployment samples:
 2. **Install dependencies**:
    - `npm run install:deps` to install required system tools.
    - `npm install` to fetch project packages.
-3. **Keep commits focused** and write clear commit messages that describe the change.
-4. **Format and lint** your changes:
+3. **Build the workspace**:
+   - `npm run build`
+4. **Keep commits focused** and write clear commit messages that describe the change.
+5. **Format and lint** your changes:
    - `npx prettier --write <files>`
    - `npm run lint`
-5. **Run tests** before opening a PR:
+6. **Run tests** before opening a PR:
    - `npm test`
-6. **Push your branch** and open a pull request against `main`.
-7. **Respond to review feedback** and keep the PR up to date with `main` if needed.
+7. **Generate documentation** if you changed docs:
+   - `npm run docs:build`
+8. **Push your branch** and open a pull request against `main`.
+9. **Respond to review feedback** and keep the PR up to date with `main` if needed.
 
 ## Style Guidelines
 

--- a/README.md
+++ b/README.md
@@ -184,11 +184,14 @@ Before starting, ensure you have the following installed on your system:
 
 ### Installation
 
-- `npm run cert` (only for the very first time)
-- `npm run clean` (to revert to clean slate, removes all `node_modules` and `dist` folders)
-- `npm install` (for the first time and after `npm run clean`)
-- `npm run build` (for the first time and after `npm run clean`)
-- `npm run dev:studio` | `npm run dev:headless` (start dev server)
+- `npm run cert` – generate the HTTPS certificate (first run only)
+- `npm run clean` – remove all `node_modules` and build artifacts
+- `npm run install:deps` – install required system tools
+- `npm install` – install workspace packages
+- `npm run build` – build all packages
+- `npm test` – execute the test suite
+- `npm run docs:dev` or `npm run docs:build` – generate documentation
+- `npm run dev:studio` or `npm run dev:headless` – start a development server
 - Navigate to https://localhost:8080 (port is important > cors sample api)
 
 ### Pipeline Overview

--- a/packages/app/headless/README.md
+++ b/packages/app/headless/README.md
@@ -3,11 +3,18 @@
 A minimal build of openDAW that runs entirely in the browser without any UI.
 It demonstrates booting the audio engine and playing a simple project.
 
-## Quick start
+## Development
+
+Run all commands from the repository root:
 
 ```bash
+npm run install:deps
 npm install
-npm run dev
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+npm run dev:headless
 ```
 
 Open <http://localhost:8080> in a compatible browser. Clicking the page will

--- a/packages/app/studio/README.md
+++ b/packages/app/studio/README.md
@@ -50,3 +50,17 @@ Additional information is available for
 [tracks](../../docs/docs-dev/ui/timeline/tracks.md),
 [markers](../../docs/docs-dev/ui/timeline/markers.md) and the
 [timeline footer](../../docs/docs-dev/ui/timeline/footer.md).
+
+## Development
+
+Run all commands from the repository root:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+npm run dev:studio  # launch the Studio
+```

--- a/packages/docs/docs-dev/build-and-run/monorepo.md
+++ b/packages/docs/docs-dev/build-and-run/monorepo.md
@@ -5,8 +5,11 @@ build pipeline. **Turbo** runs tasks such as builds, tests, and linting across
 packages, caching results for faster iterations. **Lerna** tracks package
 versions and can publish updates from the workspace. Typical commands include:
 
+- `npm run install:deps` – install required system tools.
+- `npm install` – install workspace packages.
 - `turbo run build` – build all packages.
 - `turbo run test` – execute tests.
+- `npm run docs:dev` or `npm run docs:build` – generate documentation.
 - `npm run publish-sdk` – invoke `lerna publish` to release packages.
 
 This structure keeps development cohesive while allowing packages to evolve

--- a/packages/docs/docs-dev/build-and-run/setup.md
+++ b/packages/docs/docs-dev/build-and-run/setup.md
@@ -47,8 +47,9 @@ Before starting, install the following tools for your platform.
    ```bash
    npm run cert
    ```
-3. Install dependencies:
+3. Install required system tools and packages:
    ```bash
+   npm run install:deps
    npm install
    ```
 4. Build the workspace:
@@ -63,6 +64,16 @@ Before starting, install the following tools for your platform.
 6. Alternatively, start the headless runtime:
    ```bash
    npm run dev:headless
+   ```
+
+7. Run the tests:
+   ```bash
+   npm test
+   ```
+8. Generate documentation:
+   ```bash
+   npm run docs:dev    # local preview
+   npm run docs:build  # static output
    ```
 
 Proceed to [running tests](./tests.md) or learn about

--- a/packages/docs/docs-dev/intro.md
+++ b/packages/docs/docs-dev/intro.md
@@ -23,3 +23,16 @@ For writing and formatting conventions, see the [Writing Guide](./style/writing-
 - [Extending](./extending/opendaw-sdk.md)
 - [Contributing](./contributing.md)
 - [Licensing](./licensing.md)
+
+## Development Commands
+
+Run the following from the repository root:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+```

--- a/packages/docs/docs-learn/intro.md
+++ b/packages/docs/docs-learn/intro.md
@@ -43,3 +43,16 @@ learning path or explore individual subjects as needed.
    - [ ] MIDI and Synthesis
    - [ ] Latency and Buffers
    - [x] Exporting and Sharing
+
+## Build from Source
+
+Run these commands from the repository root if you want to contribute lessons or code:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+```

--- a/packages/docs/docs-user/intro.md
+++ b/packages/docs/docs-user/intro.md
@@ -17,6 +17,19 @@ see the [roadmap](../../../ROADMAP.md).
   - [Beat Making](workflows/beat.md)
   - [Recording and Effects](workflows/record-and-fx.md)
   - [Automation and Modulation](workflows/automation-modulation.md)
-  - [Mixing](workflows/mixing.md)
-  - [Exporting](workflows/exporting.md)
-  - [Collaboration](workflows/collaboration.md)
+- [Mixing](workflows/mixing.md)
+- [Exporting](workflows/exporting.md)
+- [Collaboration](workflows/collaboration.md)
+
+## Build from Source
+
+Run these commands from the repository root to work on openDAW locally:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+```

--- a/packages/docs/docs-user/quick-start.md
+++ b/packages/docs/docs-user/quick-start.md
@@ -17,3 +17,16 @@ overview of how the studio boots, see the
 [bootstrapping architecture doc](../docs-dev/architecture/bootstrap.md).
 To tweak default behaviour of the application, refer to the
 [Configuration Overview](../docs-dev/configuration/overview.md).
+
+## Build from Source
+
+Run these commands from the repository root:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+```

--- a/packages/docs/docs-user/troubleshooting.md
+++ b/packages/docs/docs-user/troubleshooting.md
@@ -73,3 +73,16 @@
 
 - Consult the [project history guide](workflows/history.md) for working with
   SyncLog files.
+
+## Build from Source
+
+If you're running the project locally, use these commands from the repository root:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # local docs preview
+npm run docs:build  # static docs output
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,3 +8,15 @@ Utility scripts that help manage the development environment.
 | `clean.sh` | Remove all `node_modules`, build outputs, lock files and Turbo caches to reset the workspace. | `npm run clean` |
 | `install_dependencies.js` | Check for required system tools (Git, Node.js, mkcert, Sass, TypeScript, OpenSSL) and install any missing ones. Also runs `npm install`. | `npm run install:deps` |
 
+## Common Development Commands
+
+Execute from the repository root:
+
+```bash
+npm run install:deps
+npm install
+npm run build
+npm test
+npm run docs:dev    # preview docs
+npm run docs:build  # generate static docs
+```


### PR DESCRIPTION
## Summary
- align dependency install, build, test, and doc generation commands across readmes and docs
- document common development workflow in package and script readmes

## Testing
- `npm test`
- `npm run docs:build` *(fails: MDX compilation failed in docs)*

------
https://chatgpt.com/codex/tasks/task_b_68b01c5c26048321819d90e34c8ea753