### PR TITLE
Fix MDX links for docs build and outline improvement plan

### DIFF
--- a/packages/docs/IMPROVEMENTS.md
+++ b/packages/docs/IMPROVEMENTS.md
@@ -1,0 +1,34 @@
+# Documentation Improvement Plan
+
+This document outlines follow-up work needed to move the openDAW documentation site toward professional quality. Items are grouped by area and can be addressed incrementally.
+
+## Broken Links and Anchors
+
+- Resolve all links reported during `npm run docs:build` such as references to `/docs/api`, `ROADMAP.md` and various developer guides.
+- Validate internal anchors (e.g. `/docs/dev/package-inventory#lib`) and update or remove outdated references.
+- Introduce automated link checking (e.g. `docusaurus-lint` or `markdown-link-check`) in CI to prevent regressions.
+
+## MDX and Content Issues
+
+- Replace remaining JSDoc style tags (`{@code ...}`) with Markdown or MDX equivalents.
+- Audit Markdown files for MDX syntax errors; add tests or linting to catch them earlier.
+- Fill placeholder content (e.g. search config, API references) and ensure all examples compile.
+
+## Site Configuration
+
+- Configure Algolia search with real `appId` and `apiKey` or remove the placeholder until ready.
+- Review Node.js engine requirement (`>=23`) and align with an available LTS version to ease local development.
+- Provide a pre-build step or workspace script so `docs:build` automatically compiles required packages like `lib-std` and `lib-dsp`.
+
+## Documentation Structure
+
+- Organize Developer, User, and Learning sections with consistent style guides and navigation.
+- Add landing pages or overview topics where currently missing.
+- Ensure API docs include cross-links from guides and vice versa for discoverability.
+
+## Testing and CI
+
+- Add a dedicated CI job to build the docs site and fail on warnings.
+- Consider snapshot tests or visual regression tools for critical documentation pages.
+
+Addressing these areas will improve the reliability and professionalism of the openDAW documentation site.

--- a/packages/docs/docs-dev/architecture/messaging.md
+++ b/packages/docs/docs-dev/architecture/messaging.md
@@ -2,8 +2,8 @@
 
 openDAW components communicate across thread and process boundaries using
 light‑weight messaging abstractions built on top of the browser's
-`postMessage` API.  The runtime's {@link packages/lib/runtime/src/messenger.ts | `Messenger`}
-wraps `MessagePort`‑like endpoints and the {@link packages/lib/runtime/src/communicator.ts | `Communicator`}
+`postMessage` API. The runtime's [`Messenger`](/api/classes/Messenger)
+wraps `MessagePort`‑like endpoints and the [`Communicator`](/api/classes/Communicator)
 layer adds a small RPC mechanism.
 
 ## Channels and Workers

--- a/packages/docs/docs-dev/ui/timeline/selection.md
+++ b/packages/docs/docs-dev/ui/timeline/selection.md
@@ -4,5 +4,5 @@ Components related to selecting items on the timeline.
 
 - **SelectionRectangle** draws the translucent box while dragging.
 - **TimelineRangeSlider** and other editors can react to the current selection.
-- Keyboard shortcuts use {@link Shortcuts.attachShortcuts} to support global
+- Keyboard shortcuts use `Shortcuts.attachShortcuts` to support global
   actions like delete or select all.


### PR DESCRIPTION
## Summary
- replace JSDoc-style `{@link}` tags in docs with MDX-friendly syntax
- add documentation improvement plan for follow-up work

## Testing
- `npm run docs:build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0276f041c8321b3e13fe95d5ebdc1